### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
+name: Rust
 permissions:
   contents: read
-name: Rust
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SF-Zhou/ruapc/security/code-scanning/1](https://github.com/SF-Zhou/ruapc/security/code-scanning/1)

To fix the problem, the workflow should explicitly declare its permissions so that the GitHub Actions runner restricts the available scopes for the `GITHUB_TOKEN`. Since the steps involve checking out code and uploading coverage/test reports to Codecov, but do not appear to write to the repository, contents, or issues, the minimal required permission is likely `contents: read`. The `permissions` block should be added at either the workflow root (to cover all jobs by default) or specifically for the `build` job (if other jobs require differing permissions). In this specific snippet, adding the block at the workflow root (under `name: Rust`) is most effective and future-proof.

No special imports/methods are required; just insert the `permissions: contents: read` section after the workflow `name` but before the `on:` trigger, i.e., at line 2.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
