### PR TITLE
Support HTTP/2 h2c with reverse RPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ foldhash = "0.1"
 futures-util = "0.3"
 http-body-util = "0.1"
 humantime-serde = "1.1"
-hyper = { version = "1.6", features = ["client", "server", "http1"] }
+hyper = { version = "1.6", features = ["client", "server", "http1", "http2"] }
 hyper-tungstenite = "0.18"
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "http2", "server-auto"] }
 indexmap = "2.11"
 libc = "0.2"
 openapiv3 = "2.2"

--- a/ruapc/src/sockets/http/http_socket.rs
+++ b/ruapc/src/sockets/http/http_socket.rs
@@ -1,26 +1,18 @@
 use std::{
-    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{Context as TaskContext, Poll},
 };
 
 use bytes::{Bytes, BytesMut};
-use http_body_util::{BodyExt, Full};
 use hyper::body::Frame;
-use hyper::client::conn::http2::SendRequest;
-use hyper_util::rt::{TokioExecutor, TokioIo};
 use serde::Serialize;
-use tokio::{
-    net::TcpStream,
-    sync::{Mutex, mpsc},
-};
+use tokio::sync::mpsc;
 
 use crate::{Error, ErrorKind, Message, MsgMeta, Result, SocketTrait, State, msg::SendMsg};
 
 #[derive(Clone, Debug)]
 pub enum HttpSocket {
-    ForRequest(Arc<Connections>),
     ForResponse(u64),
     Stream(mpsc::Sender<Bytes>),
 }
@@ -55,61 +47,6 @@ impl hyper::body::Body for ChannelBody {
     }
 }
 
-impl HttpSocket {
-    async fn send_request(
-        method: &str,
-        bytes: Bytes,
-        connections: &Arc<Connections>,
-    ) -> Result<Bytes> {
-        // 1. acquire or establish HTTP/2 connection.
-        let mut sender = {
-            let mut guard = connections.sender.lock().await;
-            if let Some(sender) = guard.as_ref() {
-                sender.clone()
-            } else {
-                let stream = TcpStream::connect(connections.addr)
-                    .await
-                    .map_err(|e| Error::new(ErrorKind::TcpConnectFailed, e.to_string()))?;
-
-                let (sender, conn) = hyper::client::conn::http2::handshake(
-                    TokioExecutor::new(),
-                    TokioIo::new(stream),
-                )
-                .await
-                .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?;
-                tokio::spawn(conn);
-
-                *guard = Some(sender.clone());
-                sender
-            }
-        };
-
-        // 2. build request.
-        let req = hyper::Request::builder()
-            .uri(format!("http://{}/{}", connections.addr, method))
-            .header("Content-Type", "application/json")
-            .method(hyper::Method::POST)
-            .body(Full::new(bytes))
-            .map_err(|e| Error::new(ErrorKind::HttpBuildReqFailed, e.to_string()))?;
-
-        // 3. send request.
-        let rsp = sender
-            .send_request(req)
-            .await
-            .map_err(|e| Error::new(ErrorKind::HttpSendReqFailed, e.to_string()))?;
-
-        // 4. collect body bytes.
-        let body_bytes = rsp
-            .into_body()
-            .collect()
-            .await
-            .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?
-            .to_bytes();
-
-        Ok(body_bytes)
-    }
-}
-
 impl SocketTrait for HttpSocket {
     async fn send<P: Serialize>(
         &self,
@@ -118,37 +55,6 @@ impl SocketTrait for HttpSocket {
         state: &Arc<State>,
     ) -> Result<()> {
         match self {
-            HttpSocket::ForRequest(connections) => {
-                let mut bytes = BytesMut::new();
-                let writer = SendMsg::writer(&mut bytes);
-                let _ = serde_json::to_writer(writer, payload);
-
-                if meta.is_req() {
-                    let msgid = meta.msgid;
-                    let method = meta.method.clone();
-                    let bytes = bytes.freeze();
-                    let waiter = state.waiter.clone();
-                    let connections = connections.clone();
-                    tokio::spawn(async move {
-                        let results = Self::send_request(&method, bytes, &connections).await;
-                        let bytes = match results {
-                            Ok(bytes) => bytes,
-                            Err(err) => serde_json::to_vec(&Result::<()>::Err(err))
-                                .unwrap_or_default()
-                                .into(),
-                        };
-                        let msg = Message::new(MsgMeta::default(), bytes.into());
-                        waiter.post(msgid, msg);
-                    });
-
-                    Ok(())
-                } else {
-                    Err(Error::new(
-                        ErrorKind::InvalidArgument,
-                        format!("invalid msg type {:?}", meta),
-                    ))
-                }
-            }
             HttpSocket::ForResponse(msgid) => {
                 let mut bytes = BytesMut::new();
                 let writer = SendMsg::writer(&mut bytes);
@@ -217,10 +123,4 @@ impl SocketTrait for HttpSocket {
             }
         }
     }
-}
-
-#[derive(Debug)]
-pub struct Connections {
-    pub addr: SocketAddr,
-    pub sender: Mutex<Option<SendRequest<Full<Bytes>>>>,
 }

--- a/ruapc/src/sockets/http/http_socket.rs
+++ b/ruapc/src/sockets/http/http_socket.rs
@@ -1,11 +1,20 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context as TaskContext, Poll},
+};
 
 use bytes::{Bytes, BytesMut};
 use http_body_util::{BodyExt, Full};
+use hyper::body::Frame;
 use hyper::client::conn::http2::SendRequest;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use serde::Serialize;
-use tokio::{net::TcpStream, sync::Mutex};
+use tokio::{
+    net::TcpStream,
+    sync::{Mutex, mpsc},
+};
 
 use crate::{Error, ErrorKind, Message, MsgMeta, Result, SocketTrait, State, msg::SendMsg};
 
@@ -13,6 +22,37 @@ use crate::{Error, ErrorKind, Message, MsgMeta, Result, SocketTrait, State, msg:
 pub enum HttpSocket {
     ForRequest(Arc<Connections>),
     ForResponse(u64),
+    Stream(mpsc::Sender<Bytes>),
+}
+
+/// A streaming body backed by an mpsc channel.
+///
+/// Implements `http_body::Body` so it can be used as both
+/// request and response body for HTTP/2 bidirectional streaming.
+pub struct ChannelBody {
+    rx: mpsc::Receiver<Bytes>,
+}
+
+impl ChannelBody {
+    pub fn new(rx: mpsc::Receiver<Bytes>) -> Self {
+        Self { rx }
+    }
+}
+
+impl hyper::body::Body for ChannelBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(data)) => Poll::Ready(Some(Ok(Frame::data(data)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 impl HttpSocket {
@@ -77,12 +117,12 @@ impl SocketTrait for HttpSocket {
         payload: &P,
         state: &Arc<State>,
     ) -> Result<()> {
-        let mut bytes = BytesMut::new();
-        let writer = SendMsg::writer(&mut bytes);
-        let _ = serde_json::to_writer(writer, payload);
-
         match self {
             HttpSocket::ForRequest(connections) => {
+                let mut bytes = BytesMut::new();
+                let writer = SendMsg::writer(&mut bytes);
+                let _ = serde_json::to_writer(writer, payload);
+
                 if meta.is_req() {
                     let msgid = meta.msgid;
                     let method = meta.method.clone();
@@ -110,6 +150,10 @@ impl SocketTrait for HttpSocket {
                 }
             }
             HttpSocket::ForResponse(msgid) => {
+                let mut bytes = BytesMut::new();
+                let writer = SendMsg::writer(&mut bytes);
+                let _ = serde_json::to_writer(writer, payload);
+
                 if meta.is_rsp() {
                     let msg = Message {
                         meta: meta.clone(),
@@ -123,6 +167,53 @@ impl SocketTrait for HttpSocket {
                         format!("invalid msg type {:?}", meta),
                     ))
                 }
+            }
+            HttpSocket::Stream(sender) => {
+                // Use TCP-style framing: magic + len + meta_len + meta + payload.
+                use crate::sockets::tcp::MAGIC_NUM;
+
+                struct StreamBytes(BytesMut);
+
+                impl SendMsg for StreamBytes {
+                    fn size(&self) -> usize {
+                        self.0.size()
+                    }
+
+                    fn prepare(&mut self) -> Result<()> {
+                        self.0.extend_from_slice(&MAGIC_NUM.to_be_bytes());
+                        self.0.extend_from_slice(&0u32.to_be_bytes());
+                        self.0.prepare()
+                    }
+
+                    fn finish(&mut self, meta_offset: usize, payload_offset: usize) -> Result<()> {
+                        const S: usize = std::mem::size_of::<u32>();
+                        if meta_offset < S {
+                            return Err(Error::new(
+                                ErrorKind::SerializeFailed,
+                                format!("invalid meta offset: {meta_offset}"),
+                            ));
+                        }
+                        self.0.finish(meta_offset, payload_offset)?;
+                        let total_len = u32::try_from(self.size() - meta_offset)?;
+                        self.0[meta_offset - S..meta_offset]
+                            .copy_from_slice(&total_len.to_be_bytes());
+                        Ok(())
+                    }
+
+                    fn writer(&mut self) -> impl std::io::Write {
+                        self.0.writer()
+                    }
+                }
+
+                let mut bytes = StreamBytes(BytesMut::with_capacity(512));
+                meta.serialize_to(payload, &mut bytes)?;
+
+                sender
+                    .send(bytes.0.into())
+                    .await
+                    .map_err(|e| Error::new(ErrorKind::HttpSendReqFailed, e.to_string()))?;
+
+                Ok(())
             }
         }
     }

--- a/ruapc/src/sockets/http/http_socket.rs
+++ b/ruapc/src/sockets/http/http_socket.rs
@@ -2,8 +2,8 @@ use std::{net::SocketAddr, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use http_body_util::{BodyExt, Full};
-use hyper::client::conn::http1::SendRequest;
-use hyper_util::rt::TokioIo;
+use hyper::client::conn::http2::SendRequest;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use serde::Serialize;
 use tokio::{net::TcpStream, sync::Mutex};
 
@@ -21,23 +21,27 @@ impl HttpSocket {
         bytes: Bytes,
         connections: &Arc<Connections>,
     ) -> Result<Bytes> {
-        // 1. acquire connection.
-        let mut sender = if let Some(sender) = connections.vec.lock().await.pop() {
-            sender
-        } else {
-            // estabilish new connection.
-            let stream = TcpStream::connect(connections.addr)
+        // 1. acquire or establish HTTP/2 connection.
+        let mut sender = {
+            let mut guard = connections.sender.lock().await;
+            if let Some(sender) = guard.as_ref() {
+                sender.clone()
+            } else {
+                let stream = TcpStream::connect(connections.addr)
+                    .await
+                    .map_err(|e| Error::new(ErrorKind::TcpConnectFailed, e.to_string()))?;
+
+                let (sender, conn) = hyper::client::conn::http2::handshake(
+                    TokioExecutor::new(),
+                    TokioIo::new(stream),
+                )
                 .await
-                .map_err(|e| Error::new(ErrorKind::TcpConnectFailed, e.to_string()))?;
+                .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?;
+                tokio::spawn(conn);
 
-            let (sender, conn) = hyper::client::conn::http1::handshake::<TokioIo<_>, Full<Bytes>>(
-                TokioIo::new(stream),
-            )
-            .await
-            .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?;
-            tokio::spawn(conn);
-
-            sender
+                *guard = Some(sender.clone());
+                sender
+            }
         };
 
         // 2. build request.
@@ -61,9 +65,6 @@ impl HttpSocket {
             .await
             .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?
             .to_bytes();
-
-        // 5. restore connection.
-        connections.vec.lock().await.push(sender);
 
         Ok(body_bytes)
     }
@@ -130,5 +131,5 @@ impl SocketTrait for HttpSocket {
 #[derive(Debug)]
 pub struct Connections {
     pub addr: SocketAddr,
-    pub vec: Mutex<Vec<SendRequest<Full<Bytes>>>>,
+    pub sender: Mutex<Option<SendRequest<Full<Bytes>>>>,
 }

--- a/ruapc/src/sockets/http/http_socket_pool.rs
+++ b/ruapc/src/sockets/http/http_socket_pool.rs
@@ -1,20 +1,18 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
+use bytes::{Bytes, BytesMut};
 use foldhash::fast::RandomState;
-use http_body_util::{BodyExt, Full};
-use hyper::{
-    Request, Response,
-    body::{Bytes, Incoming},
-};
+use http_body_util::{BodyExt, Either, Full};
+use hyper::{Request, Response, body::Incoming};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::DropGuard;
 
-use super::http_socket::{Connections, HttpSocket};
+use super::http_socket::{ChannelBody, HttpSocket};
 use crate::{
     Error, ErrorKind, Message, MsgFlags, MsgMeta, RawStream, Result, Socket, SocketPoolConfig,
-    SocketPoolTrait, SocketType, State, TaskSupervisor,
+    SocketPoolTrait, SocketType, State, TaskSupervisor, sockets::tcp,
 };
 
 pub struct HttpSocketPool {
@@ -59,7 +57,7 @@ impl SocketPoolTrait for HttpSocketPool {
         &self,
         addr: &SocketAddr,
         socket_type: SocketType,
-        _state: &Arc<State>,
+        state: &Arc<State>,
     ) -> Result<Socket> {
         if socket_type != SocketType::HTTP {
             return Err(Error::new(
@@ -75,17 +73,13 @@ impl SocketPoolTrait for HttpSocketPool {
             return Ok(socket.into());
         }
 
-        // If not, create a new socket and insert it into the socket map.
+        // If not, establish an HTTP/2 streaming connection.
         let mut socket_map = self.socket_map.write().await;
         if let Some(socket) = socket_map.get(addr) {
             return Ok(socket.into());
         }
 
-        let connections = Arc::new(Connections {
-            addr: *addr,
-            sender: Mutex::default(),
-        });
-        let socket = HttpSocket::ForRequest(connections);
+        let socket = Self::connect_stream(addr, state).await?;
         socket_map.insert(*addr, socket.clone());
         Ok(socket.into())
     }
@@ -133,7 +127,7 @@ impl HttpSocketPool {
         mut req: Request<Incoming>,
         state: Arc<State>,
         addr: SocketAddr,
-    ) -> Result<Response<Full<Bytes>>> {
+    ) -> Result<Response<Either<Full<Bytes>, ChannelBody>>> {
         if hyper_tungstenite::is_upgrade_request(&req) {
             let (response, websocket) = hyper_tungstenite::upgrade(&mut req, None)
                 .map_err(|e| Error::new(ErrorKind::HttpUpgradeFailed, e.to_string()))?;
@@ -152,7 +146,12 @@ impl HttpSocketPool {
                     .await;
             });
 
-            return Ok(response);
+            return Ok(response.map(Either::Left));
+        }
+
+        // Handle /_rpc: bidirectional streaming for reverse RPC.
+        if req.method() == hyper::Method::POST && req.uri().path() == "/_rpc" {
+            return Self::handle_rpc_stream(req, state, addr).await;
         }
 
         if req.method() == hyper::Method::GET {
@@ -161,28 +160,28 @@ impl HttpSocketPool {
                     let openapi_json = serde_json::to_string_pretty(&state.router.openapi)?;
                     return Ok(Response::builder()
                         .header("Content-Type", "application/json")
-                        .body(Full::new(Bytes::from(openapi_json)))
+                        .body(Either::Left(Full::new(Bytes::from(openapi_json))))
                         .unwrap());
                 }
                 "/rapidoc/rapidoc-min.js" => {
                     return Ok(Response::builder()
                         .header("Content-Type", "application/javascript")
-                        .body(Full::new(Bytes::from(include_str!(
+                        .body(Either::Left(Full::new(Bytes::from(include_str!(
                             "rapidoc/rapidoc-min.js"
-                        ))))
+                        )))))
                         .unwrap());
                 }
                 "/rapidoc" | "/rapidoc/" | "/rapidoc/index.html" => {
                     let html = include_str!("rapidoc/index.html");
                     return Ok(Response::builder()
                         .header("Content-Type", "text/html; charset=utf-8")
-                        .body(Full::new(Bytes::from(html)))
+                        .body(Either::Left(Full::new(Bytes::from(html))))
                         .unwrap());
                 }
                 _ => {
                     return Ok(Response::builder()
                         .status(404)
-                        .body(Full::new(Bytes::from("Not Found")))
+                        .body(Either::Left(Full::new(Bytes::from("Not Found"))))
                         .unwrap());
                 }
             }
@@ -199,7 +198,9 @@ impl HttpSocketPool {
             Err(_) => {
                 return Ok(Response::builder()
                     .status(500)
-                    .body(Full::new(Bytes::from("Internal Server Error")))
+                    .body(Either::Left(Full::new(Bytes::from(
+                        "Internal Server Error",
+                    ))))
                     .unwrap());
             }
         };
@@ -215,8 +216,114 @@ impl HttpSocketPool {
 
         Ok(Response::builder()
             .header("Content-Type", "application/json")
-            .body(Full::new(msg.payload.into()))
+            .body(Either::Left(Full::new(msg.payload.into())))
             .unwrap())
+    }
+
+    /// Handle a `POST /_rpc` request for bidirectional streaming.
+    ///
+    /// Creates a pair of channels:
+    /// - Request body recv loop: reads framed messages from client → `state.handle_recv()`
+    /// - Response body send channel: server sends framed messages back to client via `ChannelBody`
+    async fn handle_rpc_stream(
+        req: Request<Incoming>,
+        state: Arc<State>,
+        addr: SocketAddr,
+    ) -> Result<Response<Either<Full<Bytes>, ChannelBody>>> {
+        // Create the send channel for server → client messages.
+        let (tx, rx) = mpsc::channel::<Bytes>(1024);
+        let socket = HttpSocket::Stream(tx);
+        let socket_for_recv = Socket::HTTP(socket);
+
+        // Spawn recv loop: read framed messages from the request body.
+        tokio::spawn({
+            let state = state.clone();
+            let socket_for_recv = socket_for_recv.clone();
+            async move {
+                if let Err(e) = Self::recv_loop(req.into_body(), &socket_for_recv, &state).await {
+                    tracing::error!("http rpc recv loop for {addr} failed: {e}");
+                }
+            }
+        });
+
+        // Return streaming response.
+        Ok(Response::builder()
+            .header("Content-Type", "application/octet-stream")
+            .body(Either::Right(ChannelBody::new(rx)))
+            .unwrap())
+    }
+
+    /// Read framed messages from an HTTP body stream.
+    ///
+    /// Uses the same wire format as TCP: `[magic][len][body]`.
+    async fn recv_loop(mut body: Incoming, socket: &Socket, state: &Arc<State>) -> Result<()> {
+        let mut buffer = BytesMut::with_capacity(1 << 20);
+        loop {
+            // Try to parse complete messages from the buffer.
+            while let Some(bytes) = tcp::parse_message(&mut buffer)? {
+                let msg = Message::parse(bytes)?;
+                state.handle_recv(socket, msg)?;
+            }
+
+            // Read more data from the body.
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    if let Some(data) = frame.data_ref() {
+                        buffer.extend_from_slice(data);
+                    }
+                }
+                Some(Err(e)) => {
+                    return Err(Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()));
+                }
+                None => return Ok(()), // Body stream ended.
+            }
+        }
+    }
+
+    /// Client-side: establish an HTTP/2 streaming connection to `/_rpc`.
+    ///
+    /// Sends a POST request with a streaming body and starts a recv loop
+    /// on the response body. Returns an `HttpSocket::Stream` for sending.
+    async fn connect_stream(addr: &SocketAddr, state: &Arc<State>) -> Result<HttpSocket> {
+        use hyper::client::conn::http2;
+
+        let stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .map_err(|e| Error::new(ErrorKind::TcpConnectFailed, e.to_string()))?;
+
+        let (mut sender, conn) = http2::handshake(TokioExecutor::new(), TokioIo::new(stream))
+            .await
+            .map_err(|e| Error::new(ErrorKind::HttpWaitRspFailed, e.to_string()))?;
+        tokio::spawn(conn);
+
+        // Create send channel for client → server messages (request body).
+        let (req_tx, req_rx) = mpsc::channel::<Bytes>(1024);
+
+        let req = Request::builder()
+            .uri(format!("http://{addr}/_rpc"))
+            .method(hyper::Method::POST)
+            .body(ChannelBody::new(req_rx))
+            .map_err(|e| Error::new(ErrorKind::HttpBuildReqFailed, e.to_string()))?;
+
+        let rsp = sender
+            .send_request(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::HttpSendReqFailed, e.to_string()))?;
+
+        // Create the socket for sending messages.
+        let socket = HttpSocket::Stream(req_tx);
+
+        // Spawn recv loop on the response body.
+        let socket_for_recv = Socket::HTTP(socket.clone());
+        let state = state.clone();
+        let addr = *addr;
+        tokio::spawn(async move {
+            if let Err(e) = Self::recv_loop(rsp.into_body(), &socket_for_recv, &state).await {
+                tracing::error!("http rpc client recv loop for {addr} failed: {e}");
+            }
+        });
+
+        Ok(socket)
     }
 }
 

--- a/ruapc/src/sockets/http/http_socket_pool.rs
+++ b/ruapc/src/sockets/http/http_socket_pool.rs
@@ -83,7 +83,7 @@ impl SocketPoolTrait for HttpSocketPool {
 
         let connections = Arc::new(Connections {
             addr: *addr,
-            vec: Mutex::default(),
+            sender: Mutex::default(),
         });
         let socket = HttpSocket::ForRequest(connections);
         socket_map.insert(*addr, socket.clone());

--- a/ruapc/src/sockets/http/http_socket_pool.rs
+++ b/ruapc/src/sockets/http/http_socket_pool.rs
@@ -5,9 +5,9 @@ use http_body_util::{BodyExt, Full};
 use hyper::{
     Request, Response,
     body::{Bytes, Incoming},
-    server::conn::http1::Builder,
 };
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder;
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::DropGuard;
 
@@ -19,14 +19,14 @@ use crate::{
 
 pub struct HttpSocketPool {
     socket_map: RwLock<HashMap<SocketAddr, HttpSocket, RandomState>>,
-    http: Builder,
+    http: Builder<TokioExecutor>,
     task_supervisor: TaskSupervisor,
 }
 
 impl SocketPoolTrait for HttpSocketPool {
     fn create(_config: &SocketPoolConfig) -> Result<Self> {
-        let mut http = Builder::new();
-        http.keep_alive(true);
+        let mut http = Builder::new(TokioExecutor::new());
+        http.http1().keep_alive(true);
         Ok(Self {
             socket_map: RwLock::default(),
             http,
@@ -106,18 +106,16 @@ impl HttpSocketPool {
         };
 
         let state = state.clone();
-        let connection = self
-            .http
-            .serve_connection(
+        let http = self.http.clone();
+
+        let task_supervisor = self.task_supervisor.start_async_task();
+        tokio::spawn(async move {
+            let connection = http.serve_connection_with_upgrades(
                 TokioIo::new(tcp_stream),
                 hyper::service::service_fn(move |req: Request<Incoming>| {
                     Self::handle_request(req, state.clone(), addr)
                 }),
-            )
-            .with_upgrades();
-
-        let task_supervisor = self.task_supervisor.start_async_task();
-        tokio::spawn(async move {
+            );
             tokio::select! {
                 () = task_supervisor.stopped() => {},
                 r = connection => {

--- a/ruapc/src/sockets/tcp/mod.rs
+++ b/ruapc/src/sockets/tcp/mod.rs
@@ -1,8 +1,45 @@
 pub(crate) const MAGIC_NUM: u32 = u32::from_be_bytes(*b"RUA!");
-const MAX_MSG_SIZE: usize = 64 << 20;
+pub(crate) const MAX_MSG_SIZE: usize = 64 << 20;
 
 mod tcp_socket;
 pub(crate) use tcp_socket::TcpSocket;
 
 mod tcp_socket_pool;
 pub(crate) use tcp_socket_pool::TcpSocketPool;
+
+use bytes::{Buf, Bytes, BytesMut};
+
+use crate::error::{Error, ErrorKind, Result};
+
+/// Parse a single framed message from the buffer.
+///
+/// Wire format: `[4B magic][4B len][len bytes body]`.
+/// Returns `Ok(None)` if the buffer doesn't contain a complete message yet.
+pub(crate) fn parse_message(buffer: &mut BytesMut) -> Result<Option<Bytes>> {
+    const S: usize = std::mem::size_of::<u64>();
+    if buffer.len() < S {
+        return Ok(None);
+    }
+    let header = u64::from_be_bytes(buffer[..S].try_into().unwrap());
+    if (header >> 32) as u32 != MAGIC_NUM {
+        return Err(Error::new(
+            ErrorKind::TcpParseMsgFailed,
+            format!("invalid header: {header:08X}"),
+        ));
+    }
+
+    let len = usize::try_from(header & u64::from(u32::MAX))?;
+    if S + len >= MAX_MSG_SIZE {
+        return Err(Error::new(
+            ErrorKind::TcpParseMsgFailed,
+            format!("msg is too long: {len}"),
+        ));
+    }
+
+    if buffer.len() < S + len {
+        Ok(None)
+    } else {
+        buffer.advance(S);
+        Ok(Some(buffer.split_to(len).into()))
+    }
+}

--- a/ruapc/src/sockets/tcp/tcp_socket_pool.rs
+++ b/ruapc/src/sockets/tcp/tcp_socket_pool.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, io::IoSlice, net::SocketAddr, sync::Arc};
 
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use foldhash::fast::RandomState;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -143,32 +143,7 @@ impl TcpSocketPool {
     }
 
     fn parse_message(buffer: &mut BytesMut) -> Result<Option<Bytes>> {
-        const S: usize = std::mem::size_of::<u64>();
-        if buffer.len() < S {
-            return Ok(None);
-        }
-        let header = u64::from_be_bytes(buffer[..S].try_into().unwrap());
-        if (header >> 32) as u32 != super::MAGIC_NUM {
-            return Err(Error::new(
-                ErrorKind::TcpParseMsgFailed,
-                format!("invalid header: {header:08X}"),
-            ));
-        }
-
-        let len = usize::try_from(header & u64::from(u32::MAX))?;
-        if S + len >= super::MAX_MSG_SIZE {
-            return Err(Error::new(
-                ErrorKind::TcpParseMsgFailed,
-                format!("msg is too long: {len}"),
-            ));
-        }
-
-        if buffer.len() < S + len {
-            Ok(None)
-        } else {
-            buffer.advance(S);
-            Ok(Some(buffer.split_to(len).into()))
-        }
+        super::parse_message(buffer)
     }
 
     async fn start_recv_loop(

--- a/ruapc/tests/test_callback.rs
+++ b/ruapc/tests/test_callback.rs
@@ -69,3 +69,34 @@ async fn test_callback() {
     server.stop();
     server.join().await;
 }
+
+#[tokio::test]
+async fn test_callback_http() {
+    let foo = Arc::new(FooServiceImpl);
+    let mut router = Router::default();
+    foo.clone().ruapc_export(&mut router);
+    let config = SocketPoolConfig {
+        socket_type: SocketType::HTTP,
+        ..Default::default()
+    };
+    let server = Server::create(router, &config).unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    let bar = Arc::new(BarServiceImpl);
+    let mut router = Router::default();
+    bar.clone().ruapc_export(&mut router);
+    let ctx = Context::create_with_router(router, &config).unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    let client = Client {
+        socket_type: Some(SocketType::HTTP),
+        ..Default::default()
+    };
+    assert_eq!(client.foo(&ctx, &FooReq(0)).await, Ok(FooRsp(1)));
+    assert_eq!(client.foo(&ctx, &FooReq(1)).await, Ok(FooRsp(3)));
+
+    server.stop();
+    server.join().await;
+}


### PR DESCRIPTION
## Summary
- Server: switch from `http1::Builder` to `hyper_util::server::conn::auto::Builder` for automatic HTTP/1.1 and h2c negotiation
- Client: switch to HTTP/2 handshake with single-connection multiplexing (replaces connection pool)
- Add bidirectional RPC over HTTP/2 streaming (`POST /_rpc` endpoint), enabling server-to-client reverse RPC
- Clean up dead code (`ForRequest`, `Connections`) and add `test_callback_http` for reverse RPC verification
- Extract `parse_message` from `TcpSocketPool` to `tcp` module for cross-module reuse

## Test plan
- [x] All existing tests pass (`cargo test --all-features`)
- [x] New `test_callback_http` verifies HTTP/2 reverse RPC (server FooService calls client BarService)
- [x] HTTP/1.1 backward compatibility (existing HTTP tests, OpenAPI, RapiDoc)
- [ ] CI pipeline validation

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>