### PR TITLE
Update README and comments for HTTP/2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A high-performance Rust RPC library that supports multiple transport protocols (
 
 ## Features
 
-- **Multiple Transport Protocols**: TCP, WebSocket, HTTP, RDMA (optional), and a unified protocol that supports all simultaneously
+- **Multiple Transport Protocols**: TCP, WebSocket, HTTP/1.1 and HTTP/2 (h2c), RDMA (optional), and a unified protocol that supports all simultaneously
+- **Reverse RPC**: Server can call back into client services over established HTTP/2 or WebSocket connections
 - **Multiple Serialization Formats**: JSON (default) and MessagePack support
 - **OpenAPI Integration**: Automatic OpenAPI 3.0 specification generation with JSON Schema support
 - **Built-in Documentation**: RapiDoc integration for interactive API documentation
@@ -56,7 +57,7 @@ async fn main() {
     let demo = Arc::new(DemoImpl);
     let mut router = Router::default();
     EchoService::ruapc_export(demo.clone(), &mut router);
-    let server = Server::create(router, &SocketPoolConfig::default());
+    let server = Server::create(router, &SocketPoolConfig::default()).unwrap();
 
     let server = Arc::new(server);
     let addr = SocketAddr::from_str("127.0.0.1:8000").unwrap();
@@ -76,7 +77,7 @@ use std::{net::SocketAddr, str::FromStr};
 #[tokio::main]
 async fn main() {
     let addr = SocketAddr::from_str("127.0.0.1:8000").unwrap();
-    let ctx = Context::create(&SocketPoolConfig::default()).with_addr(addr);
+    let ctx = Context::create(&SocketPoolConfig::default()).unwrap().with_addr(addr);
     let client = Client::default();
 
     let rsp = client.echo(&ctx, &Request("Rua!".into())).await;

--- a/ruapc/src/sockets/socket.rs
+++ b/ruapc/src/sockets/socket.rs
@@ -9,7 +9,7 @@ use crate::{MsgMeta, Result, State, http::HttpSocket, tcp::TcpSocket, ws::WebSoc
 /// The `Socket` enum provides a unified interface for different transport types:
 /// - TCP: Raw TCP socket
 /// - WS: WebSocket connection
-/// - HTTP: HTTP/1.1 connection
+/// - HTTP: HTTP/1.1 and HTTP/2 (h2c) connection
 /// - RDMA: RDMA connection (requires "rdma" feature)
 ///
 /// All socket types support the same `send` operation for transmitting messages.

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -23,7 +23,7 @@ use crate::{
 /// Each socket type represents a different transport protocol with its own characteristics:
 /// - **TCP**: Raw TCP sockets with custom protocol
 /// - **WS**: WebSocket over HTTP
-/// - **HTTP**: HTTP/1.1 with request/response semantics
+/// - **HTTP**: HTTP/1.1 and HTTP/2 (h2c), supports bidirectional streaming for reverse RPC
 /// - **UNIFIED**: Accepts all protocol types on the same port
 /// - **RDMA**: High-performance RDMA (requires "rdma" feature)
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy, clap::ValueEnum)]


### PR DESCRIPTION
## Summary
- Update README features to reflect HTTP/2 (h2c) support and reverse RPC capability
- Fix code examples: add missing `.unwrap()` for `Server::create()` and `Context::create()`
- Update doc comments in `socket.rs` and `socket_pool.rs` to reflect HTTP/1.1 + HTTP/2 (h2c)

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>