### PR TITLE
Prepare release 0.1.3: add CHANGELOG, AGENTS, CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Project Overview
+
+RuaPC ("Rua! Procedure Call") is a high-performance Rust RPC library supporting multiple transport protocols with a unified API.
+
+## Architecture
+
+### Workspace Structure
+- `ruapc/` — Core library: server, client, router, socket abstractions, message format
+- `ruapc-macro/` — Proc macro `#[service]` for service definition and code generation
+- `ruapc-rdma/` — RDMA transport (optional, behind `rdma` feature flag)
+- `ruapc-demo/` — Example server/client applications
+
+### Transport Protocols
+- **TCP**: Custom binary protocol with magic number `RUA!`, length-prefixed framing
+- **WebSocket**: Over HTTP upgrade, using tokio-tungstenite
+- **HTTP**: HTTP/1.1 and HTTP/2 (h2c) via hyper, supports bidirectional streaming for reverse RPC
+- **RDMA**: High-performance RDMA via ibverbs (optional)
+- **UNIFIED**: Multiplexes all protocols on a single port (peeks first 4 bytes to detect TCP magic)
+
+### Key Abstractions
+- `SocketTrait` — Per-connection send interface
+- `SocketPoolTrait` — Connection pool management (create, acquire, handle_new_stream)
+- `Router` — Method registry mapping "ServiceName/method_name" to handler functions
+- `Waiter` — Request/response correlation via unique message IDs and oneshot channels
+- `State` — Shared state holding Router, Waiter, and SocketPool
+
+### Wire Format (TCP/HTTP/2 Stream)
+`[4B magic "RUA!"][4B total_len][4B meta_len][meta bytes][payload bytes]`
+
+### Serialization
+- JSON (default) or MessagePack (via `MsgFlags::UseMessagePack`)
+
+## Development
+
+### Build & Test
+```bash
+cargo build --all-features
+cargo test --all-features
+cargo fmt
+cargo clippy --all-features
+```
+
+### CI
+- GitHub Actions: build, test (cargo-nextest with `-j 1`), clippy, rustfmt, CodeQL, codecov
+- RDMA tests use `rxe_0` virtual device in CI (env var `RUAPC_PREFER_RXE=1`)
+
+### Conventions
+- Always run `cargo fmt` and `cargo clippy` before committing
+- PRs target `main` branch
+- All CI checks must pass before merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.3] - 2026-04-11
+
+### Added
+- HTTP/2 h2c support with automatic HTTP/1.1 and HTTP/2 protocol negotiation (#37)
+- Reverse RPC: server can call back into client services over HTTP/2 bidirectional streaming (#37)
+- OpenAPI 3.0 specification auto-generation with JSON Schema support (#17)
+- RapiDoc integration for interactive API documentation (#18)
+- Message ID (UUID) validation on server side (#28)
+- Comprehensive API documentation and doc comments (#26, #30)
+
+### Changed
+- HTTP client switched from HTTP/1.1 to HTTP/2 with single-connection multiplexing (#37)
+- Message ID allocation moved to client side (#27)
+- Socket module refactored for cleaner architecture (#34)
+
+### Fixed
+- Message ID leak in waiter (#15)
+- RDMA `ibv_reg_mr` return value check (#24)
+- HTTP socket content type (#21)
+- RDMA socket periodic health check (#16)
+- CI: prefer RXE device in RDMA unit tests for reliable CI (#36)
+
+## [0.1.2] - 2025-08-26
+
+### Added
+- RDMA transport support (optional `rdma` feature) (#13)
+- Unified socket pool: single port for TCP, WebSocket, and HTTP (#10)
+- HTTP transport (#9)
+- `MetaService::list_methods` for service discovery (#11)
+- JSON Schema support for request/response types (#7)
+- Task supervisor for graceful async task management (#6)
+- Body-less request support (#12)
+
+### Fixed
+- MessagePack deserialization failure (#4)
+
+## [0.1.1] - 2025-07-26
+
+### Added
+- Initial release
+- TCP and WebSocket transport
+- MessagePack serialization support
+- RPC callback (bidirectional RPC over TCP)
+- Proc macro `#[service]` for service definition
+
+### Fixed
+- Waiter cleanup on timeout (#1)
+- RPC callback failure (#2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to RuaPC
+
+## Getting Started
+
+1. Fork and clone the repository
+2. Install Rust nightly (required for `#![feature(return_type_notation)]`)
+3. Build: `cargo build --all-features`
+4. Test: `cargo test --all-features`
+
+## Development Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Run `cargo fmt` and `cargo clippy --all-features` — ensure zero warnings
+4. Run `cargo test --all-features` — ensure all tests pass
+5. Submit a pull request targeting `main`
+
+## Code Style
+
+- Follow standard Rust conventions
+- Run `cargo fmt` before committing
+- Run `cargo clippy --all-features` and resolve all warnings
+- Add tests for new functionality
+
+## RDMA Development
+
+RDMA features require `libibverbs-dev`. For testing without physical RDMA hardware, use the `rxe` (Soft-RoCE) kernel module:
+
+```bash
+sudo modprobe rdma_rxe
+sudo rdma link add rxe_0 type rxe netdev lo
+```
+
+## License
+
+By contributing, you agree that your contributions will be dual-licensed under MIT and Apache-2.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ authors = ["SF-Zhou <sfzhou.scut@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/SF-Zhou/ruapc"
 repository = "https://github.com/SF-Zhou/ruapc"
-description = "A Rust RPC library"
+description = "A high-performance Rust RPC library supporting TCP, WebSocket, HTTP/2, and RDMA transports"
+keywords = ["rpc", "http2", "rdma", "async"]
+categories = ["network-programming", "asynchronous"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md covering v0.1.1, v0.1.2, v0.1.3
- Add AGENTS.md with project architecture overview
- Add CONTRIBUTING.md with development workflow guide
- Update workspace description, add keywords and categories for crates.io
- Bump ruapc version to 0.1.3

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>