### PR TITLE
Bump ruapc-macro and ruapc-rdma to 0.1.3

### DIFF
--- a/ruapc-macro/Cargo.toml
+++ b/ruapc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-macro"
-version = "0.1.1"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-rdma"
-version = "0.1.0"
+version = "0.1.3"
 description = "RDMA support for ruapc"
 authors.workspace = true
 edition.workspace = true

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -13,8 +13,8 @@ rdma = ["ruapc-rdma"]
 default = []
 
 [dependencies]
-ruapc-macro ={ version = "0.1.1", path = "../ruapc-macro" }
-ruapc-rdma = { version = "0.1.0", path = "../ruapc-rdma", optional = true }
+ruapc-macro ={ version = "0.1.3", path = "../ruapc-macro" }
+ruapc-rdma = { version = "0.1.3", path = "../ruapc-rdma", optional = true }
 
 bitflags.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
## Summary
- Bump ruapc-macro from 0.1.1 to 0.1.3
- Bump ruapc-rdma from 0.1.0 to 0.1.3
- Update dependency versions in ruapc/Cargo.toml

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>