### PR TITLE
feat: add BufferPool, Buffer, and RemoteBufferInfo

### DIFF
--- a/ruapc/src/lib.rs
+++ b/ruapc/src/lib.rs
@@ -130,7 +130,9 @@ pub use device::{Device, Devices};
 
 /// Memory management (aligned allocation, registration, keys).
 pub mod memory;
-pub use memory::{AlignedMemory, Memory, MemoryKey, MemoryRegistration};
+pub use memory::{
+    AlignedMemory, Buffer, BufferPool, Memory, MemoryKey, MemoryRegistration, RemoteBufferInfo,
+};
 
 /// Socket abstraction layer.
 mod sockets;

--- a/ruapc/src/memory/buffer.rs
+++ b/ruapc/src/memory/buffer.rs
@@ -1,0 +1,133 @@
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use crate::Result;
+use crate::device::Device;
+
+use super::buffer_pool::BufferPool;
+use super::remote_buffer_info::RemoteBufferInfo;
+
+/// A fixed-size memory buffer allocated from a [`BufferPool`].
+///
+/// Holds an `Arc<BufferPool>` to keep the pool (and the underlying
+/// registered `Memory`) alive. On drop, the buffer is returned to
+/// the pool's free list for reuse.
+///
+/// Implements `Deref<Target=[u8]>` and `DerefMut` for convenient
+/// byte-slice access.
+pub struct Buffer {
+    pool: Arc<BufferPool>,
+    ptr: NonNull<u8>,
+    len: usize,
+    memory_index: usize,
+    block_index: usize,
+}
+
+// SAFETY: The pointer is valid for the buffer's lifetime (guaranteed
+// by the Arc<BufferPool> preventing Memory from being freed), and
+// each Buffer is the sole owner of its block until returned.
+#[allow(unsafe_code)]
+unsafe impl Send for Buffer {}
+#[allow(unsafe_code)]
+unsafe impl Sync for Buffer {}
+
+#[allow(unsafe_code)]
+impl Buffer {
+    /// Creates a new buffer. Called internally by `BufferPool::allocate`.
+    pub(crate) fn new(
+        pool: Arc<BufferPool>,
+        ptr: NonNull<u8>,
+        len: usize,
+        memory_index: usize,
+        block_index: usize,
+    ) -> Self {
+        Self {
+            pool,
+            ptr,
+            len,
+            memory_index,
+            block_index,
+        }
+    }
+
+    /// Returns the size of this buffer in bytes.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Buffers always have non-zero size.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Returns a raw pointer to the buffer's memory.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns a mutable raw pointer to the buffer's memory.
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    /// Builds the [`RemoteBufferInfo`] for this buffer on the given device.
+    ///
+    /// This information can be sent to a remote peer via RPC so it can
+    /// perform Remote Read/Write operations on this buffer.
+    pub fn remote_buffer_info(&self, device: &Device) -> Result<RemoteBufferInfo> {
+        let key = self.pool.get_memory_key(self.memory_index, device)?;
+        Ok(RemoteBufferInfo {
+            key,
+            addr: self.ptr.as_ptr() as u64,
+            len: self.len as u64,
+        })
+    }
+}
+
+#[allow(unsafe_code)]
+impl Deref for Buffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // SAFETY: ptr is valid for `len` bytes.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+#[allow(unsafe_code)]
+impl DerefMut for Buffer {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for `len` bytes and we have exclusive access.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl AsRef<[u8]> for Buffer {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl AsMut<[u8]> for Buffer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self
+    }
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        self.pool.return_buffer(self.memory_index, self.block_index);
+    }
+}
+
+impl std::fmt::Debug for Buffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Buffer")
+            .field("ptr", &self.ptr)
+            .field("len", &self.len)
+            .field("memory_index", &self.memory_index)
+            .field("block_index", &self.block_index)
+            .finish()
+    }
+}

--- a/ruapc/src/memory/buffer_pool.rs
+++ b/ruapc/src/memory/buffer_pool.rs
@@ -1,0 +1,321 @@
+use std::collections::VecDeque;
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::oneshot;
+
+use crate::device::{Device, Devices};
+use crate::{Error, ErrorKind, Result};
+
+use super::buffer::Buffer;
+use super::memory_key::MemoryKey;
+use super::registered::Memory;
+
+/// A memory pool that manages large registered memory chunks and
+/// hands out fixed-size [`Buffer`]s from them.
+///
+/// Each chunk is a large `AlignedMemory` (e.g. 256 MiB) registered on
+/// all devices, then sliced into fixed-size blocks (e.g. 4 MiB).
+/// Freed buffers are returned to an internal free list for reuse.
+///
+/// When the free list is empty and the memory limit hasn't been reached,
+/// a new chunk is allocated. When the limit is hit, `allocate` returns
+/// an error; `async_allocate` waits until a buffer is returned.
+///
+/// Inspired by `ruapc-bufpool`'s design (RAII buffer return, async
+/// waiting via oneshot channels), simplified to fixed-size slab
+/// allocation since all blocks are the same size.
+pub struct BufferPool {
+    devices: Arc<Devices>,
+    inner: Mutex<PoolInner>,
+    block_size: usize,
+    chunk_size: usize,
+    max_memory: usize,
+}
+
+struct PoolInner {
+    memories: Vec<Memory>,
+    free_list: VecDeque<FreeSlot>,
+    allocated_memory: usize,
+    waiters: VecDeque<oneshot::Sender<()>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FreeSlot {
+    memory_index: usize,
+    block_index: usize,
+}
+
+impl BufferPool {
+    /// Creates a new buffer pool.
+    ///
+    /// - `devices`: the set of devices to register memory on.
+    /// - `block_size`: size of each allocated buffer (e.g. 4 MiB).
+    /// - `chunk_size`: size of each bulk allocation (e.g. 256 MiB).
+    ///   Must be a multiple of `block_size`.
+    /// - `max_memory`: upper bound on total memory from the OS.
+    ///   Use `0` for unlimited.
+    pub fn new(
+        devices: Arc<Devices>,
+        block_size: usize,
+        chunk_size: usize,
+        max_memory: usize,
+    ) -> Arc<Self> {
+        assert!(block_size > 0, "block_size must be > 0");
+        assert!(chunk_size >= block_size, "chunk_size must be >= block_size");
+        assert!(
+            chunk_size.is_multiple_of(block_size),
+            "chunk_size must be a multiple of block_size"
+        );
+        Arc::new(Self {
+            devices,
+            inner: Mutex::new(PoolInner {
+                memories: Vec::new(),
+                free_list: VecDeque::new(),
+                allocated_memory: 0,
+                waiters: VecDeque::new(),
+            }),
+            block_size,
+            chunk_size,
+            max_memory,
+        })
+    }
+
+    /// Allocates a buffer synchronously.
+    ///
+    /// If the free list is empty, tries to allocate a new chunk.
+    /// Returns an error if the memory limit is reached.
+    pub fn allocate(self: &Arc<Self>) -> Result<Buffer> {
+        let mut inner = self.inner.lock().unwrap();
+        self.allocate_inner(&mut inner)
+    }
+
+    /// Allocates a buffer, waiting asynchronously if none are available.
+    ///
+    /// If the free list is empty and the memory limit is reached,
+    /// this method waits until another buffer is returned to the pool.
+    pub async fn async_allocate(self: &Arc<Self>) -> Result<Buffer> {
+        loop {
+            let rx = {
+                let mut inner = self.inner.lock().unwrap();
+                match self.allocate_inner(&mut inner) {
+                    Ok(buf) => return Ok(buf),
+                    Err(_) => {
+                        // Memory limit reached and free list empty — wait.
+                        let (tx, rx) = oneshot::channel();
+                        inner.waiters.push_back(tx);
+                        rx
+                    }
+                }
+            };
+            // Wait outside the lock for a buffer to be returned.
+            let _ = rx.await;
+        }
+    }
+
+    fn allocate_inner(self: &Arc<Self>, inner: &mut PoolInner) -> Result<Buffer> {
+        // Try to pop from the free list.
+        if let Some(slot) = inner.free_list.pop_front() {
+            return self.make_buffer(inner, slot);
+        }
+
+        // Free list empty — try to allocate a new chunk.
+        if self.max_memory == 0 || inner.allocated_memory + self.chunk_size <= self.max_memory {
+            self.allocate_chunk(inner)?;
+            if let Some(slot) = inner.free_list.pop_front() {
+                return self.make_buffer(inner, slot);
+            }
+        }
+
+        Err(Error::new(
+            ErrorKind::InvalidArgument,
+            "buffer pool exhausted".into(),
+        ))
+    }
+
+    fn allocate_chunk(&self, inner: &mut PoolInner) -> Result<()> {
+        let mem = Memory::new(self.chunk_size, &self.devices)?;
+        let memory_index = inner.memories.len();
+        let blocks_per_chunk = self.chunk_size / self.block_size;
+
+        // Note: Memory::new rounds up to alignment boundary, so actual
+        // size may be larger. We use chunk_size for block counting.
+        for block_index in 0..blocks_per_chunk {
+            inner.free_list.push_back(FreeSlot {
+                memory_index,
+                block_index,
+            });
+        }
+
+        inner.allocated_memory += mem.aligned_memory().size();
+        inner.memories.push(mem);
+        Ok(())
+    }
+
+    #[allow(unsafe_code)]
+    fn make_buffer(self: &Arc<Self>, inner: &PoolInner, slot: FreeSlot) -> Result<Buffer> {
+        let mem = &inner.memories[slot.memory_index];
+        let base = mem.aligned_memory().as_ptr();
+        let offset = slot.block_index * self.block_size;
+        // SAFETY: offset is within the allocated memory region.
+        let ptr = unsafe { NonNull::new_unchecked(base.add(offset) as *mut u8) };
+        Ok(Buffer::new(
+            Arc::clone(self),
+            ptr,
+            self.block_size,
+            slot.memory_index,
+            slot.block_index,
+        ))
+    }
+
+    /// Returns a buffer to the free list. Called by `Buffer::drop`.
+    pub(crate) fn return_buffer(&self, memory_index: usize, block_index: usize) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.free_list.push_back(FreeSlot {
+            memory_index,
+            block_index,
+        });
+        // Wake one waiter, if any.
+        if let Some(tx) = inner.waiters.pop_front() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Returns the `MemoryKey` for a specific memory chunk on a device.
+    pub(crate) fn get_memory_key(&self, memory_index: usize, device: &Device) -> Result<MemoryKey> {
+        let inner = self.inner.lock().unwrap();
+        let mem = inner.memories.get(memory_index).ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidArgument,
+                format!("invalid memory index {memory_index}"),
+            )
+        })?;
+        mem.get_memory_key(device)
+    }
+
+    /// Returns the total memory allocated from the OS.
+    pub fn allocated_memory(&self) -> usize {
+        self.inner.lock().unwrap().allocated_memory
+    }
+
+    /// Returns the number of free buffers available.
+    pub fn free_count(&self) -> usize {
+        self.inner.lock().unwrap().free_list.len()
+    }
+
+    /// Returns the configured block size.
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Returns the configured chunk size.
+    pub fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+}
+
+impl std::fmt::Debug for BufferPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let inner = self.inner.lock().unwrap();
+        f.debug_struct("BufferPool")
+            .field("block_size", &self.block_size)
+            .field("chunk_size", &self.chunk_size)
+            .field("max_memory", &self.max_memory)
+            .field("allocated_memory", &inner.allocated_memory)
+            .field("free_count", &inner.free_list.len())
+            .field("chunks", &inner.memories.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pool(block_size: usize, chunk_size: usize, max_memory: usize) -> Arc<BufferPool> {
+        let mut devices = Devices::new();
+        devices.add_tcp_device();
+        BufferPool::new(Arc::new(devices), block_size, chunk_size, max_memory)
+    }
+
+    #[test]
+    fn test_basic_allocate_and_return() {
+        // 4 MiB blocks, 8 MiB chunks → 2 blocks per chunk.
+        let pool = make_pool(4 * 1024 * 1024, 8 * 1024 * 1024, 0);
+        assert_eq!(pool.free_count(), 0);
+
+        let buf = pool.allocate().unwrap();
+        assert_eq!(buf.len(), 4 * 1024 * 1024);
+        // After first alloc, chunk was created with 2 blocks, 1 used.
+        assert_eq!(pool.free_count(), 1);
+
+        drop(buf);
+        assert_eq!(pool.free_count(), 2);
+    }
+
+    #[test]
+    fn test_memory_limit() {
+        // chunk_size = block_size = 2MiB (minimum alignment), max_memory = 2MiB.
+        let pool = make_pool(2 * 1024 * 1024, 2 * 1024 * 1024, 2 * 1024 * 1024);
+        let buf = pool.allocate().unwrap();
+        assert_eq!(buf.len(), 2 * 1024 * 1024);
+
+        // Second allocation should fail (limit reached).
+        assert!(pool.allocate().is_err());
+
+        drop(buf);
+        // After return, should be able to allocate again.
+        assert!(pool.allocate().is_ok());
+    }
+
+    #[test]
+    fn test_buffer_read_write() {
+        let pool = make_pool(2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+        let mut buf = pool.allocate().unwrap();
+        buf[0] = 0xAB;
+        buf[1] = 0xCD;
+        assert_eq!(buf[0], 0xAB);
+        assert_eq!(buf[1], 0xCD);
+    }
+
+    #[test]
+    fn test_buffer_remote_buffer_info() {
+        let mut devices = Devices::new();
+        let d0 = devices.add_tcp_device();
+        let pool = BufferPool::new(Arc::new(devices), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+        let buf = pool.allocate().unwrap();
+        let info = buf.remote_buffer_info(&d0).unwrap();
+        assert_eq!(info.len, 2 * 1024 * 1024);
+        assert_eq!(info.addr, buf.as_ptr() as u64);
+        assert!(matches!(info.key, MemoryKey::Tcp { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_async_allocate_waits() {
+        let pool = make_pool(2 * 1024 * 1024, 2 * 1024 * 1024, 2 * 1024 * 1024);
+        let buf = pool.allocate().unwrap();
+
+        let pool2 = pool.clone();
+        let handle = tokio::spawn(async move { pool2.async_allocate().await.unwrap() });
+
+        // Give the spawned task a moment to register as a waiter.
+        tokio::task::yield_now().await;
+
+        // Return the buffer — should wake the waiter.
+        drop(buf);
+
+        let buf2 = handle.await.unwrap();
+        assert_eq!(buf2.len(), 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_multiple_chunks() {
+        // 2 MiB blocks, 2 MiB chunks, unlimited.
+        let pool = make_pool(2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+        let buf1 = pool.allocate().unwrap();
+        let buf2 = pool.allocate().unwrap();
+        // Two separate chunks should have been allocated.
+        assert_eq!(pool.allocated_memory(), 2 * 2 * 1024 * 1024);
+        assert_ne!(buf1.as_ptr(), buf2.as_ptr());
+    }
+}

--- a/ruapc/src/memory/mod.rs
+++ b/ruapc/src/memory/mod.rs
@@ -10,3 +10,13 @@ pub use memory_registration::MemoryRegistration;
 
 mod registered;
 pub use registered::Memory;
+
+mod remote_buffer_info;
+pub use remote_buffer_info::RemoteBufferInfo;
+
+#[allow(unsafe_code)]
+mod buffer;
+pub use buffer::Buffer;
+
+mod buffer_pool;
+pub use buffer_pool::BufferPool;

--- a/ruapc/src/memory/remote_buffer_info.rs
+++ b/ruapc/src/memory/remote_buffer_info.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use super::MemoryKey;
+
+/// Information needed by a remote peer to access a registered memory region.
+///
+/// Transmitted via normal RPC messages so the remote side can issue
+/// Remote Read/Write operations against the described buffer.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RemoteBufferInfo {
+    pub key: MemoryKey,
+    pub addr: u64,
+    pub len: u64,
+}


### PR DESCRIPTION
## Summary
- Add `BufferPool` for managing large registered memory chunks with fixed-size slab allocation
- Add `Buffer` with `Deref<Target=[u8]>`/`DerefMut`, RAII return to pool, and `remote_buffer_info()` for remote access
- Add `RemoteBufferInfo` (MemoryKey + addr + len) with Serialize/Deserialize
- Async allocation support via oneshot channels when pool is exhausted

Phase 2 of the Remote Read/Write design (DESIGN.md).

## Test plan
- [x] Basic allocate and return (free list management)
- [x] Memory limit enforcement
- [x] Buffer read/write via Deref/DerefMut
- [x] RemoteBufferInfo generation with correct MemoryKey
- [x] Async allocation waiting for buffer return
- [x] Multiple chunk allocation
- [x] Zero clippy warnings, all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)