### PR TITLE
feat: add Remote Read/Write API with TCP implementation

### DIFF
--- a/ruapc/src/context.rs
+++ b/ruapc/src/context.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use tokio_util::sync::DropGuard;
 
 use crate::{
-    Error, Result, Router, Socket, SocketPoolConfig, SocketTrait, State,
+    Devices, Error, Result, Router, Socket, SocketPoolConfig, SocketTrait, State,
     msg::{MsgFlags, MsgMeta},
 };
 
@@ -97,7 +97,19 @@ impl Context {
     /// let ctx = Context::create_with_router(router, &SocketPoolConfig::default()).unwrap();
     /// ```
     pub fn create_with_router(router: Router, config: &SocketPoolConfig) -> Result<Self> {
-        let (state, drop_guard) = State::create(router, config)?;
+        Self::create_with_router_and_devices(router, config, None)
+    }
+
+    /// Creates a new context with a custom router, configuration, and devices.
+    ///
+    /// When `devices` is provided, a `MemoryService` is automatically
+    /// registered to handle incoming Remote Read/Write requests from peers.
+    pub fn create_with_router_and_devices(
+        router: Router,
+        config: &SocketPoolConfig,
+        devices: Option<Arc<Devices>>,
+    ) -> Result<Self> {
+        let (state, drop_guard) = State::create(router, config, devices)?;
         Ok(Self {
             state,
             endpoint: SocketEndpoint::Invalid,
@@ -205,5 +217,72 @@ impl Context {
     /// * `err` - The error to send back
     pub async fn send_err_rsp(&mut self, err: Error) {
         self.send_rsp::<(), Error>(Err(err)).await;
+    }
+
+    /// Reads data from a remote peer's registered memory via reverse RPC.
+    ///
+    /// Sends a `MemoryService/read` request to the peer, which validates
+    /// the access and returns the data. The returned data is copied into
+    /// `local_buf` starting at offset 0.
+    ///
+    /// # Arguments
+    ///
+    /// * `remote` - Remote buffer info (key, addr, len) obtained from the peer
+    /// * `local_buf` - Local buffer to write the received data into
+    pub async fn remote_read(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &mut crate::Buffer,
+    ) -> Result<()> {
+        use crate::services::{MemoryReadReq, MemoryService};
+
+        let req = MemoryReadReq {
+            key: remote.key,
+            addr: remote.addr,
+            len: remote.len,
+        };
+        let client = crate::Client::default();
+        let data: Vec<u8> = client.read(self, &req).await?;
+        if data.len() > local_buf.len() {
+            return Err(Error::new(
+                crate::ErrorKind::InvalidArgument,
+                format!(
+                    "remote read returned {} bytes but local buffer is {} bytes",
+                    data.len(),
+                    local_buf.len()
+                ),
+            ));
+        }
+        local_buf[..data.len()].copy_from_slice(&data);
+        Ok(())
+    }
+
+    /// Writes data from a local buffer to a remote peer's registered memory
+    /// via reverse RPC.
+    ///
+    /// Sends a `MemoryService/write` request to the peer with the data,
+    /// which validates the access and writes the data.
+    ///
+    /// # Arguments
+    ///
+    /// * `remote` - Remote buffer info (key, addr, len) obtained from the peer
+    /// * `local_buf` - Local buffer containing the data to write
+    /// * `len` - Number of bytes to write from `local_buf`
+    pub async fn remote_write(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &crate::Buffer,
+        len: usize,
+    ) -> Result<()> {
+        use crate::services::{MemoryService, MemoryWriteReq};
+
+        let req = MemoryWriteReq {
+            key: remote.key,
+            addr: remote.addr,
+            data: local_buf[..len].to_vec(),
+        };
+        let client = crate::Client::default();
+        client.write(self, &req).await?;
+        Ok(())
     }
 }

--- a/ruapc/src/device/mod.rs
+++ b/ruapc/src/device/mod.rs
@@ -8,6 +8,8 @@ pub use rdma_device::RdmaDevice;
 
 use std::sync::Arc;
 
+use crate::Result;
+
 /// A network device abstraction using enum dispatch.
 ///
 /// Can be a real RDMA NIC or a virtual TCP device. Memory must be
@@ -27,6 +29,30 @@ impl Device {
             Device::Tcp(d) => d.index(),
             #[cfg(feature = "rdma")]
             Device::Rdma(d) => d.index(),
+        }
+    }
+
+    /// Reads data from a registered memory region using absolute address.
+    pub fn read_memory(&self, id: u32, addr: u64, len: u64) -> Result<Vec<u8>> {
+        match self {
+            Device::Tcp(d) => d.read_memory(id, addr, len),
+            #[cfg(feature = "rdma")]
+            Device::Rdma(_) => Err(crate::Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "read_memory not supported on RDMA device".into(),
+            )),
+        }
+    }
+
+    /// Writes data into a registered memory region using absolute address.
+    pub fn write_memory(&self, id: u32, addr: u64, data: &[u8]) -> Result<()> {
+        match self {
+            Device::Tcp(d) => d.write_memory(id, addr, data),
+            #[cfg(feature = "rdma")]
+            Device::Rdma(_) => Err(crate::Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "write_memory not supported on RDMA device".into(),
+            )),
         }
     }
 }

--- a/ruapc/src/device/tcp_device.rs
+++ b/ruapc/src/device/tcp_device.rs
@@ -100,9 +100,9 @@ impl TcpDevice {
 
         let region_start = region.addr as u64;
         let region_end = region_start + region.len as u64;
-        let access_end = addr.checked_add(len).ok_or_else(|| {
-            Error::new(ErrorKind::InvalidArgument, "addr + len overflow".into())
-        })?;
+        let access_end = addr
+            .checked_add(len)
+            .ok_or_else(|| Error::new(ErrorKind::InvalidArgument, "addr + len overflow".into()))?;
 
         if addr < region_start || access_end > region_end {
             return Err(Error::new(

--- a/ruapc/src/device/tcp_device.rs
+++ b/ruapc/src/device/tcp_device.rs
@@ -50,6 +50,72 @@ impl TcpDevice {
         registry.remove(&id);
     }
 
+    /// Reads data from a registered memory region using absolute address.
+    ///
+    /// Validates that the range `[addr, addr+len)` is within the region
+    /// registered under `id`, then copies data out.
+    ///
+    /// # Safety justification
+    ///
+    /// The memory was registered by the owning `Memory` struct which holds
+    /// both the `AlignedMemory` allocation and the `Arc<Device>` keeping
+    /// this `TcpDevice` alive. As long as the registration exists in the
+    /// registry, the underlying memory is guaranteed to be valid.
+    #[allow(unsafe_code)]
+    pub fn read_memory(&self, id: u32, addr: u64, len: u64) -> Result<Vec<u8>> {
+        self.validate_absolute_access(id, addr, len)?;
+        // SAFETY: validate_absolute_access confirmed the region is registered
+        // and the range [addr, addr+len) is within bounds.
+        let data = unsafe { std::slice::from_raw_parts(addr as *const u8, len as usize) };
+        Ok(data.to_vec())
+    }
+
+    /// Writes data into a registered memory region using absolute address.
+    ///
+    /// Validates that the range `[addr, addr+len)` is within the region
+    /// registered under `id`, then copies data in.
+    ///
+    /// # Safety justification
+    ///
+    /// Same as `read_memory` — the registration guarantees the memory is valid.
+    #[allow(unsafe_code)]
+    pub fn write_memory(&self, id: u32, addr: u64, data: &[u8]) -> Result<()> {
+        self.validate_absolute_access(id, addr, data.len() as u64)?;
+        // SAFETY: validate_absolute_access confirmed the region is registered
+        // and the range [addr, addr+len) is within bounds.
+        let dest = unsafe { std::slice::from_raw_parts_mut(addr as *mut u8, data.len()) };
+        dest.copy_from_slice(data);
+        Ok(())
+    }
+
+    /// Validates that an absolute address range is within a registered region.
+    fn validate_absolute_access(&self, id: u32, addr: u64, len: u64) -> Result<()> {
+        let registry = self.registry.lock().unwrap();
+        let region = registry.get(&id).ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidArgument,
+                format!("memory region ID {id} not registered"),
+            )
+        })?;
+
+        let region_start = region.addr as u64;
+        let region_end = region_start + region.len as u64;
+        let access_end = addr.checked_add(len).ok_or_else(|| {
+            Error::new(ErrorKind::InvalidArgument, "addr + len overflow".into())
+        })?;
+
+        if addr < region_start || access_end > region_end {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "access out of bounds: addr={addr:#x} len={len} outside region [{region_start:#x}, {region_end:#x})"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Validates that an access (id, offset, len) is within a registered region.
     pub fn validate_access(&self, id: u32, offset: u64, len: u64) -> Result<usize> {
         let registry = self.registry.lock().unwrap();

--- a/ruapc/src/lib.rs
+++ b/ruapc/src/lib.rs
@@ -142,7 +142,7 @@ pub use sockets::*;
 mod state;
 pub use state::State;
 
-/// Built-in services (MetaService, RdmaService).
+/// Built-in services (MetaService, MemoryService, RdmaService).
 pub mod services;
 
 /// RPC context carrying request metadata and connection information.

--- a/ruapc/src/memory/memory_key.rs
+++ b/ruapc/src/memory/memory_key.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// A device-specific key for remote memory access.
@@ -5,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// After memory is registered on a device, a `MemoryKey` is produced.
 /// This key is sent to the remote peer (via normal RPC messages) so
 /// it can perform Remote Read/Write operations against the registered memory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum MemoryKey {
     /// TCP: a software-assigned registration ID.
     Tcp { id: u32 },

--- a/ruapc/src/memory/remote_buffer_info.rs
+++ b/ruapc/src/memory/remote_buffer_info.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::MemoryKey;
@@ -6,7 +7,7 @@ use super::MemoryKey;
 ///
 /// Transmitted via normal RPC messages so the remote side can issue
 /// Remote Read/Write operations against the described buffer.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub struct RemoteBufferInfo {
     pub key: MemoryKey,
     pub addr: u64,

--- a/ruapc/src/server.rs
+++ b/ruapc/src/server.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 use tokio_util::sync::DropGuard;
 
-use crate::{Listener, Result, Router, SocketPoolConfig, SocketPoolTrait, State};
+use crate::{Devices, Listener, Result, Router, SocketPoolConfig, SocketPoolTrait, State};
 
 /// RPC server that listens for and handles incoming requests.
 ///
@@ -53,7 +53,19 @@ impl Server {
     /// let server = Server::create(router, &SocketPoolConfig::default()).unwrap();
     /// ```
     pub fn create(router: Router, config: &SocketPoolConfig) -> Result<Self> {
-        let (state, drop_guard) = State::create(router, config)?;
+        Self::create_with_devices(router, config, None)
+    }
+
+    /// Creates a new RPC server with device support for Remote Read/Write.
+    ///
+    /// When `devices` is provided, a `MemoryService` is automatically
+    /// registered to handle incoming Remote Read/Write requests.
+    pub fn create_with_devices(
+        router: Router,
+        config: &SocketPoolConfig,
+        devices: Option<Arc<Devices>>,
+    ) -> Result<Self> {
+        let (state, drop_guard) = State::create(router, config, devices)?;
 
         Ok(Self {
             state,

--- a/ruapc/src/services/memory_service.rs
+++ b/ruapc/src/services/memory_service.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::device::Devices;
+use crate::memory::MemoryKey;
+use crate::{Context, Result};
+
+/// Request to read from a remote memory region.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct MemoryReadReq {
+    pub key: MemoryKey,
+    pub addr: u64,
+    pub len: u64,
+}
+
+/// Request to write to a remote memory region.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct MemoryWriteReq {
+    pub key: MemoryKey,
+    pub addr: u64,
+    pub data: Vec<u8>,
+}
+
+/// Built-in service for Remote Read/Write operations over TCP.
+///
+/// When a peer wants to read from or write to registered memory on this
+/// side, it sends a reverse RPC to this service. The service validates
+/// the access against the device's registry and performs the operation.
+#[ruapc_macro::service]
+pub trait MemoryService {
+    /// Reads data from a registered memory region.
+    async fn read(&self, ctx: &Context, req: &MemoryReadReq) -> Result<Vec<u8>>;
+
+    /// Writes data to a registered memory region.
+    async fn write(&self, ctx: &Context, req: &MemoryWriteReq) -> Result<()>;
+}
+
+/// Implementation of MemoryService backed by a Devices collection.
+pub struct MemoryServiceImpl {
+    pub devices: Arc<Devices>,
+}
+
+impl MemoryService for MemoryServiceImpl {
+    async fn read(&self, _ctx: &Context, req: &MemoryReadReq) -> Result<Vec<u8>> {
+        let device = self.device_for_key(&req.key)?;
+        device.read_memory(self.tcp_id(&req.key)?, req.addr, req.len)
+    }
+
+    async fn write(&self, _ctx: &Context, req: &MemoryWriteReq) -> Result<()> {
+        let device = self.device_for_key(&req.key)?;
+        device.write_memory(self.tcp_id(&req.key)?, req.addr, &req.data)
+    }
+}
+
+impl MemoryServiceImpl {
+    fn device_for_key(&self, key: &MemoryKey) -> Result<&Arc<crate::device::Device>> {
+        match key {
+            MemoryKey::Tcp { .. } => {
+                // Find the first TCP device.
+                for dev in self.devices.iter() {
+                    if matches!(dev.as_ref(), crate::device::Device::Tcp(_)) {
+                        return Ok(dev);
+                    }
+                }
+                Err(crate::Error::new(
+                    crate::ErrorKind::InvalidArgument,
+                    "no TCP device available".into(),
+                ))
+            }
+            #[cfg(feature = "rdma")]
+            MemoryKey::Rdma { .. } => Err(crate::Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "RDMA remote read/write via MemoryService not supported".into(),
+            )),
+        }
+    }
+
+    fn tcp_id(&self, key: &MemoryKey) -> Result<u32> {
+        match key {
+            MemoryKey::Tcp { id } => Ok(*id),
+            #[cfg(feature = "rdma")]
+            _ => Err(crate::Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "expected TCP memory key".into(),
+            )),
+        }
+    }
+}

--- a/ruapc/src/services/mod.rs
+++ b/ruapc/src/services/mod.rs
@@ -3,6 +3,10 @@
 //! This module provides built-in services that are automatically
 //! registered with every RuaPC server, including:
 //! - MetaService: Introspection and metadata service
+//! - MemoryService: Remote Read/Write operations over TCP
 
 mod meta_service;
 pub use meta_service::{MetaService, Metadata};
+
+mod memory_service;
+pub use memory_service::{MemoryReadReq, MemoryService, MemoryServiceImpl, MemoryWriteReq};

--- a/ruapc/src/state.rs
+++ b/ruapc/src/state.rs
@@ -3,8 +3,9 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio_util::sync::DropGuard;
 
 use crate::{
-    Context, Message, RawStream, Result, Router, Socket, SocketPool, SocketPoolConfig,
+    Context, Devices, Message, RawStream, Result, Router, Socket, SocketPool, SocketPoolConfig,
     SocketPoolTrait, Waiter,
+    services::{MemoryService, MemoryServiceImpl},
 };
 
 /// Shared state for the RPC system.
@@ -23,6 +24,8 @@ pub struct State {
     pub(crate) waiter: Arc<Waiter>,
     /// Socket pool for managing connections.
     pub(crate) socket_pool: SocketPool,
+    /// Device collection for memory registration and Remote Read/Write.
+    pub devices: Option<Arc<Devices>>,
 }
 
 impl State {
@@ -39,6 +42,12 @@ impl State {
     /// * `config` - Socket pool configuration
     ///
     /// # Returns
+    /// Creates a new state with the given router and configuration.
+    ///
+    /// When `devices` is provided, a `MemoryService` is automatically
+    /// registered in the router to handle Remote Read/Write requests.
+    ///
+    /// # Returns
     ///
     /// Returns an Arc-wrapped state and a drop guard for lifecycle management.
     ///
@@ -48,12 +57,20 @@ impl State {
     pub(crate) fn create(
         mut router: Router,
         config: &SocketPoolConfig,
+        devices: Option<Arc<Devices>>,
     ) -> Result<(Arc<Self>, DropGuard)> {
+        if let Some(ref devs) = devices {
+            let mem_svc = Arc::new(MemoryServiceImpl {
+                devices: devs.clone(),
+            });
+            mem_svc.ruapc_export(&mut router);
+        }
         router.build_open_api()?;
         let state = Self {
             router,
             waiter: Arc::default(),
             socket_pool: SocketPool::create(config)?,
+            devices,
         };
         let state = Arc::new(state);
         let drop_guard = state.drop_guard();

--- a/ruapc/tests/test_remote_rw.rs
+++ b/ruapc/tests/test_remote_rw.rs
@@ -100,8 +100,7 @@ async fn test_tcp_remote_read() {
     let client_device = client_devices.add_tcp_device();
     let client_devices = Arc::new(client_devices);
 
-    let client_pool =
-        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+    let client_pool = BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
 
     // Allocate client buffer and fill with test data.
     let mut client_buf = client_pool.allocate().unwrap();
@@ -164,8 +163,7 @@ async fn test_tcp_remote_write() {
     let client_device = client_devices.add_tcp_device();
     let client_devices = Arc::new(client_devices);
 
-    let client_pool =
-        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+    let client_pool = BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
 
     // Allocate client buffer (initially zeroed by the allocator).
     let client_buf = client_pool.allocate().unwrap();
@@ -236,8 +234,7 @@ async fn test_tcp_remote_read_bounds_check() {
     let client_device = client_devices.add_tcp_device();
     let client_devices = Arc::new(client_devices);
 
-    let client_pool =
-        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+    let client_pool = BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
     let client_buf = client_pool.allocate().unwrap();
     let rbi = client_buf.remote_buffer_info(&client_device).unwrap();
 

--- a/ruapc/tests/test_remote_rw.rs
+++ b/ruapc/tests/test_remote_rw.rs
@@ -1,0 +1,269 @@
+#![feature(return_type_notation)]
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ruapc::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Client sends its RemoteBufferInfo to the server.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct RemoteReadReq {
+    info: RemoteBufferInfo,
+}
+
+/// Server returns the data it read from the client's buffer.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+struct RemoteReadRsp {
+    data: Vec<u8>,
+}
+
+#[service]
+trait ReadTestService {
+    async fn read_remote(&self, ctx: &Context, req: &RemoteReadReq) -> Result<RemoteReadRsp>;
+}
+
+struct ReadTestImpl;
+
+impl ReadTestService for ReadTestImpl {
+    async fn read_remote(&self, ctx: &Context, req: &RemoteReadReq) -> Result<RemoteReadRsp> {
+        // Allocate a local buffer on the server side to receive data.
+        let devices = ctx.state.devices.as_ref().unwrap();
+        let pool = BufferPool::new(devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+        let mut local_buf = pool.allocate().unwrap();
+
+        // Remote read: pull data from the client's registered memory.
+        ctx.remote_read(&req.info, &mut local_buf).await?;
+
+        // Return the data we read.
+        let len = req.info.len as usize;
+        Ok(RemoteReadRsp {
+            data: local_buf[..len].to_vec(),
+        })
+    }
+}
+
+/// Client sends RemoteBufferInfo + data for the server to write.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct RemoteWriteReq {
+    info: RemoteBufferInfo,
+    data: Vec<u8>,
+}
+
+#[service]
+trait WriteTestService {
+    async fn write_remote(&self, ctx: &Context, req: &RemoteWriteReq) -> Result<()>;
+}
+
+struct WriteTestImpl;
+
+impl WriteTestService for WriteTestImpl {
+    async fn write_remote(&self, ctx: &Context, req: &RemoteWriteReq) -> Result<()> {
+        // Allocate a local buffer on the server side, fill with data.
+        let devices = ctx.state.devices.as_ref().unwrap();
+        let pool = BufferPool::new(devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+        let mut local_buf = pool.allocate().unwrap();
+        local_buf[..req.data.len()].copy_from_slice(&req.data);
+
+        // Remote write: push data to the client's registered memory.
+        ctx.remote_write(&req.info, &local_buf, req.data.len())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_tcp_remote_read() {
+    // Set up devices shared by server.
+    let mut server_devices = Devices::new();
+    let _server_device = server_devices.add_tcp_device();
+    let server_devices = Arc::new(server_devices);
+
+    // Set up server with ReadTestService.
+    let read_svc = Arc::new(ReadTestImpl);
+    let mut router = Router::default();
+    read_svc.ruapc_export(&mut router);
+    let server = Server::create_with_devices(
+        router,
+        &SocketPoolConfig::default(),
+        Some(server_devices.clone()),
+    )
+    .unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    // Set up client with devices and MemoryService.
+    let mut client_devices = Devices::new();
+    let client_device = client_devices.add_tcp_device();
+    let client_devices = Arc::new(client_devices);
+
+    let client_pool =
+        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+
+    // Allocate client buffer and fill with test data.
+    let mut client_buf = client_pool.allocate().unwrap();
+    let test_data = b"Hello, Remote Read!";
+    client_buf[..test_data.len()].copy_from_slice(test_data);
+
+    // Get RemoteBufferInfo for the client's buffer.
+    let rbi = client_buf.remote_buffer_info(&client_device).unwrap();
+    let rbi_for_req = RemoteBufferInfo {
+        key: rbi.key,
+        addr: rbi.addr,
+        len: test_data.len() as u64,
+    };
+
+    // Create client context with MemoryService registered (so server can call back).
+    let ctx = Context::create_with_router_and_devices(
+        Router::default(),
+        &SocketPoolConfig::default(),
+        Some(client_devices.clone()),
+    )
+    .unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    // Call the server's ReadTestService — it will reverse-RPC to read our buffer.
+    let client = Client::default();
+    let rsp: RemoteReadRsp = client
+        .read_remote(&ctx, &RemoteReadReq { info: rbi_for_req })
+        .await
+        .unwrap();
+
+    assert_eq!(rsp.data, test_data);
+
+    server.stop();
+    server.join().await;
+}
+
+#[tokio::test]
+async fn test_tcp_remote_write() {
+    // Set up server devices.
+    let mut server_devices = Devices::new();
+    let _server_device = server_devices.add_tcp_device();
+    let server_devices = Arc::new(server_devices);
+
+    // Set up server with WriteTestService.
+    let write_svc = Arc::new(WriteTestImpl);
+    let mut router = Router::default();
+    write_svc.ruapc_export(&mut router);
+    let server = Server::create_with_devices(
+        router,
+        &SocketPoolConfig::default(),
+        Some(server_devices.clone()),
+    )
+    .unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    // Set up client with devices and MemoryService.
+    let mut client_devices = Devices::new();
+    let client_device = client_devices.add_tcp_device();
+    let client_devices = Arc::new(client_devices);
+
+    let client_pool =
+        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+
+    // Allocate client buffer (initially zeroed by the allocator).
+    let client_buf = client_pool.allocate().unwrap();
+    // Verify it starts as zeros.
+    assert!(client_buf[..10].iter().all(|&b| b == 0));
+
+    // Get RemoteBufferInfo for the client's buffer.
+    let rbi = client_buf.remote_buffer_info(&client_device).unwrap();
+    let write_data = b"Hello, Remote Write!";
+    let rbi_for_req = RemoteBufferInfo {
+        key: rbi.key,
+        addr: rbi.addr,
+        len: write_data.len() as u64,
+    };
+
+    // Create client context with MemoryService registered.
+    let ctx = Context::create_with_router_and_devices(
+        Router::default(),
+        &SocketPoolConfig::default(),
+        Some(client_devices.clone()),
+    )
+    .unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    // Call the server's WriteTestService — it will reverse-RPC to write to our buffer.
+    let client = Client::default();
+    client
+        .write_remote(
+            &ctx,
+            &RemoteWriteReq {
+                info: rbi_for_req,
+                data: write_data.to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Verify the data was written to our buffer.
+    assert_eq!(&client_buf[..write_data.len()], write_data);
+
+    server.stop();
+    server.join().await;
+}
+
+#[tokio::test]
+async fn test_tcp_remote_read_bounds_check() {
+    // Set up server devices.
+    let mut server_devices = Devices::new();
+    server_devices.add_tcp_device();
+    let server_devices = Arc::new(server_devices);
+
+    // Set up server with ReadTestService.
+    let read_svc = Arc::new(ReadTestImpl);
+    let mut router = Router::default();
+    read_svc.ruapc_export(&mut router);
+    let server = Server::create_with_devices(
+        router,
+        &SocketPoolConfig::default(),
+        Some(server_devices.clone()),
+    )
+    .unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    // Set up client with devices and MemoryService.
+    let mut client_devices = Devices::new();
+    let client_device = client_devices.add_tcp_device();
+    let client_devices = Arc::new(client_devices);
+
+    let client_pool =
+        BufferPool::new(client_devices.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+    let client_buf = client_pool.allocate().unwrap();
+    let rbi = client_buf.remote_buffer_info(&client_device).unwrap();
+
+    // Try to read beyond the buffer bounds.
+    let bad_rbi = RemoteBufferInfo {
+        key: rbi.key,
+        addr: rbi.addr,
+        len: (3 * 1024 * 1024) as u64, // Exceeds 2 MiB buffer
+    };
+
+    let ctx = Context::create_with_router_and_devices(
+        Router::default(),
+        &SocketPoolConfig::default(),
+        Some(client_devices.clone()),
+    )
+    .unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    let client = Client::default();
+    let result: Result<RemoteReadRsp> = client
+        .read_remote(&ctx, &RemoteReadReq { info: bad_rbi })
+        .await;
+
+    // Should fail with a bounds error.
+    assert!(result.is_err());
+
+    server.stop();
+    server.join().await;
+}


### PR DESCRIPTION
## Summary
- Add `MemoryService` (built-in `#[ruapc::service]`) for handling Remote Read/Write requests via reverse RPC
- Add `TcpDevice::read_memory` / `write_memory` with safety validation (bounds checking)
- Add `Context::remote_read` / `remote_write` convenience methods
- Auto-register MemoryService when `devices` is provided to State/Context
- Add `create_with_devices` constructors for Server and Context

Phase 3 of the Remote Read/Write design (DESIGN.md) — TCP implementation.

## Test plan
- [x] `test_tcp_remote_read` — Server reads Client's registered memory via reverse RPC
- [x] `test_tcp_remote_write` — Server writes to Client's registered memory via reverse RPC
- [x] `test_tcp_remote_read_bounds_check` — Out-of-bounds access correctly rejected
- [x] All existing tests pass (no regressions)
- [x] Zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)