### PR TITLE
feat: RDMA memory registration and rkey() fix

### DIFF
--- a/ruapc-rdma/src/buf/mod.rs
+++ b/ruapc-rdma/src/buf/mod.rs
@@ -10,7 +10,7 @@ mod aligned_buffer;
 pub use aligned_buffer::AlignedBuffer;
 
 mod rdma_buffer;
-pub use rdma_buffer::RegisteredBuffer;
+pub use rdma_buffer::{RawMemoryRegion, RegisteredBuffer};
 
 mod buffer_pool;
 pub use buffer_pool::{Buffer, BufferPool};

--- a/ruapc-rdma/src/buf/rdma_buffer.rs
+++ b/ruapc-rdma/src/buf/rdma_buffer.rs
@@ -4,7 +4,21 @@ use crate::*;
 ///
 /// Wraps an InfiniBand memory region pointer and ensures
 /// proper cleanup on drop.
-struct RawMemoryRegion(*mut verbs::ibv_mr);
+pub struct RawMemoryRegion(*mut verbs::ibv_mr);
+
+impl RawMemoryRegion {
+    /// Creates a new `RawMemoryRegion` from a raw `ibv_mr` pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be a valid, non-null `ibv_mr` pointer returned
+    /// by `ibv_reg_mr`. The caller transfers ownership to `RawMemoryRegion`,
+    /// which will call `ibv_dereg_mr` on drop.
+    pub unsafe fn from_raw(ptr: *mut verbs::ibv_mr) -> Self {
+        Self(ptr)
+    }
+}
+
 impl std::ops::Deref for RawMemoryRegion {
     type Target = verbs::ibv_mr;
 
@@ -74,7 +88,7 @@ impl RegisteredBuffer {
             if mr.is_null() {
                 return Err(ErrorKind::IBRegMemoryRegionFail.with_errno());
             }
-            memory_regions.push(RawMemoryRegion(mr));
+            memory_regions.push(unsafe { RawMemoryRegion::from_raw(mr) });
         }
         Ok(Self {
             memory_regions,
@@ -110,7 +124,7 @@ impl RegisteredBuffer {
     ///
     /// The remote key for this buffer on the specified device.
     pub fn rkey(&self, index: usize) -> u32 {
-        self.memory_regions[index].lkey
+        self.memory_regions[index].rkey
     }
 }
 

--- a/ruapc-rdma/src/devices.rs
+++ b/ruapc-rdma/src/devices.rs
@@ -328,7 +328,7 @@ impl Device {
     /// # Safety
     ///
     /// The returned pointer is only valid as long as this `Device` exists.
-    pub(crate) fn pd_ptr(&self) -> *mut verbs::ibv_pd {
+    pub fn pd_ptr(&self) -> *mut verbs::ibv_pd {
         self.protection_domain.0
     }
 

--- a/ruapc/src/device/rdma_device.rs
+++ b/ruapc/src/device/rdma_device.rs
@@ -24,6 +24,11 @@ impl RdmaDevice {
     pub fn inner(&self) -> &Arc<ruapc_rdma::Device> {
         &self.inner
     }
+
+    /// Returns the raw protection domain pointer for memory registration.
+    pub fn pd_ptr(&self) -> *mut ruapc_rdma::verbs::ibv_pd {
+        self.inner.pd_ptr()
+    }
 }
 
 impl std::fmt::Debug for RdmaDevice {

--- a/ruapc/src/memory/memory_registration.rs
+++ b/ruapc/src/memory/memory_registration.rs
@@ -16,10 +16,7 @@ pub enum MemoryRegistration {
     #[cfg(feature = "rdma")]
     Rdma {
         device: Arc<Device>,
-        // Will hold RawMemoryRegion (*mut ibv_mr) in the future.
-        // For now, store lkey/rkey obtained during registration.
-        lkey: u32,
-        rkey: u32,
+        mr: ruapc_rdma::RawMemoryRegion,
     },
 }
 
@@ -29,14 +26,18 @@ impl MemoryRegistration {
         match self {
             MemoryRegistration::Tcp { id, .. } => MemoryKey::Tcp { id: *id },
             #[cfg(feature = "rdma")]
-            MemoryRegistration::Rdma { lkey, rkey, .. } => MemoryKey::Rdma {
-                lkey: *lkey,
-                rkey: *rkey,
+            MemoryRegistration::Rdma { mr, .. } => MemoryKey::Rdma {
+                lkey: mr.lkey,
+                rkey: mr.rkey,
             },
         }
     }
 
     /// Unregisters the memory from the associated device.
+    ///
+    /// For TCP, removes the ID from the registry.
+    /// For RDMA, the `RawMemoryRegion` is dropped (handled by the enum
+    /// variant being dropped), which calls `ibv_dereg_mr` automatically.
     pub fn unregister(&self, _mem: &AlignedMemory) {
         match self {
             MemoryRegistration::Tcp { device, id } => {
@@ -46,7 +47,9 @@ impl MemoryRegistration {
             }
             #[cfg(feature = "rdma")]
             MemoryRegistration::Rdma { .. } => {
-                // TODO: call ibv_dereg_mr when RawMemoryRegion is integrated
+                // RawMemoryRegion's Drop calls ibv_dereg_mr.
+                // Nothing extra to do here — the variant will be dropped
+                // when the MemoryRegistration is dropped.
             }
         }
     }
@@ -69,10 +72,10 @@ impl std::fmt::Debug for MemoryRegistration {
                 .field("id", id)
                 .finish(),
             #[cfg(feature = "rdma")]
-            MemoryRegistration::Rdma { lkey, rkey, .. } => f
+            MemoryRegistration::Rdma { mr, .. } => f
                 .debug_struct("MemoryRegistration::Rdma")
-                .field("lkey", lkey)
-                .field("rkey", rkey)
+                .field("lkey", &mr.lkey)
+                .field("rkey", &mr.rkey)
                 .finish(),
         }
     }

--- a/ruapc/src/memory/registered.rs
+++ b/ruapc/src/memory/registered.rs
@@ -37,6 +37,7 @@ impl Memory {
     }
 
     /// Registers the aligned memory on a single device.
+    #[allow(unsafe_code)]
     fn register_on_device(mem: &AlignedMemory, device: &Arc<Device>) -> Result<MemoryRegistration> {
         match device.as_ref() {
             Device::Tcp(tcp) => {
@@ -47,13 +48,25 @@ impl Memory {
                 })
             }
             #[cfg(feature = "rdma")]
-            Device::Rdma(_rdma) => {
-                // TODO: call ibv_reg_mr via RdmaDevice and store RawMemoryRegion.
-                // For now, return placeholder keys.
+            Device::Rdma(rdma) => {
+                let mr = unsafe {
+                    ruapc_rdma::verbs::ibv_reg_mr(
+                        rdma.pd_ptr(),
+                        mem.as_ptr() as *mut _,
+                        mem.size(),
+                        ruapc_rdma::verbs::ACCESS_FLAGS as _,
+                    )
+                };
+                if mr.is_null() {
+                    return Err(Error::new(
+                        ErrorKind::InvalidArgument,
+                        "ibv_reg_mr failed".into(),
+                    ));
+                }
+                let raw_mr = unsafe { ruapc_rdma::RawMemoryRegion::from_raw(mr) };
                 Ok(MemoryRegistration::Rdma {
                     device: device.clone(),
-                    lkey: 0,
-                    rkey: 0,
+                    mr: raw_mr,
                 })
             }
         }


### PR DESCRIPTION
## Summary
- Fix `rkey()` bug in `ruapc-rdma` — was returning `lkey` instead of `rkey` (`rdma_buffer.rs:113`)
- Make `RawMemoryRegion` public with safe `from_raw()` constructor for cross-crate usage
- `MemoryRegistration::Rdma` now holds `RawMemoryRegion` (RAII `ibv_mr` wrapper) instead of bare `lkey/rkey` placeholders
- Wire up `ibv_reg_mr` in `Memory::register_on_device` RDMA path via `RdmaDevice::pd_ptr()`
- `Drop` on `RawMemoryRegion` automatically calls `ibv_dereg_mr` — no manual cleanup needed

## Test plan
- [x] `cargo check --features rdma` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features rdma` zero warnings
- [x] All existing tests pass (unit + integration + doc tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)