### PR TITLE
test: add RDMA device Remote Read/Write tests

### DIFF
--- a/ruapc-rdma/src/queue_pair.rs
+++ b/ruapc-rdma/src/queue_pair.rs
@@ -159,6 +159,64 @@ impl QueuePair {
         }
     }
 
+    pub fn rdma_read(
+        &self,
+        wr_id: verbs::WRID,
+        local_buf: &Buffer,
+        remote_addr: u64,
+        rkey: u32,
+    ) -> Result<()> {
+        let mut send_sge = verbs::ibv_sge {
+            addr: local_buf.as_ptr() as _,
+            length: local_buf.capacity() as _,
+            lkey: local_buf.lkey(&self.device),
+        };
+        let mut send_wr = verbs::ibv_send_wr {
+            wr_id,
+            sg_list: &mut send_sge as *mut _,
+            num_sge: 1,
+            opcode: verbs::ibv_wr_opcode::IBV_WR_RDMA_READ,
+            send_flags: verbs::ibv_send_flags::IBV_SEND_SIGNALED.0,
+            ..Default::default()
+        };
+        send_wr.wr.rdma.remote_addr = remote_addr;
+        send_wr.wr.rdma.rkey = rkey;
+
+        match self.post_send(&mut send_wr) {
+            0 => Ok(()),
+            _ => Err(ErrorKind::IBPostSendFailed.with_errno()),
+        }
+    }
+
+    pub fn rdma_write(
+        &self,
+        wr_id: verbs::WRID,
+        local_buf: &Buffer,
+        remote_addr: u64,
+        rkey: u32,
+    ) -> Result<()> {
+        let mut send_sge = verbs::ibv_sge {
+            addr: local_buf.as_ptr() as _,
+            length: local_buf.len() as _,
+            lkey: local_buf.lkey(&self.device),
+        };
+        let mut send_wr = verbs::ibv_send_wr {
+            wr_id,
+            sg_list: &mut send_sge as *mut _,
+            num_sge: 1,
+            opcode: verbs::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
+            send_flags: verbs::ibv_send_flags::IBV_SEND_SIGNALED.0,
+            ..Default::default()
+        };
+        send_wr.wr.rdma.remote_addr = remote_addr;
+        send_wr.wr.rdma.rkey = rkey;
+
+        match self.post_send(&mut send_wr) {
+            0 => Ok(()),
+            _ => Err(ErrorKind::IBPostSendFailed.with_errno()),
+        }
+    }
+
     pub fn ready_to_recv(&self, remote: &Endpoint) -> Result<()> {
         let mut attr = verbs::ibv_qp_attr {
             qp_state: verbs::ibv_qp_state::IBV_QPS_RTR,
@@ -381,5 +439,95 @@ mod tests {
         assert_eq!(comp_b[0].status, verbs::ibv_wc_status::IBV_WC_SUCCESS);
         assert_eq!(comp_b[0].byte_len, send_len as u32);
         assert!(&recv_slice[..send_len] == send_slice);
+    }
+
+    #[test]
+    fn test_rdma_read() {
+        let devices = Devices::availables().unwrap();
+
+        let cap = verbs::ibv_qp_cap {
+            max_send_wr: 64,
+            max_recv_wr: 64,
+            max_send_sge: 1,
+            max_recv_sge: 1,
+            max_inline_data: 0,
+        };
+
+        let qp_a = QueuePair::create(&devices[0], cap).unwrap();
+        let qp_b = QueuePair::create(&devices[0], cap).unwrap();
+        qp_a.connect(&qp_b.endpoint()).unwrap();
+        qp_b.connect(&qp_a.endpoint()).unwrap();
+
+        const LEN: usize = 4096;
+        let buffer_pool = BufferPool::create(LEN, 32, &devices).unwrap();
+
+        // A side: register memory and fill with test data.
+        let mut buf_a = buffer_pool.allocate().unwrap();
+        let test_data: Vec<u8> = (0..LEN).map(|i| (i % 251) as u8).collect();
+        buf_a.extend_from_slice(&test_data).unwrap();
+        let remote_addr = buf_a.as_ptr() as u64;
+        let rkey = buf_a.rkey(&devices[0]);
+
+        // B side: allocate empty buffer, issue RDMA Read from A.
+        let buf_b = buffer_pool.allocate().unwrap();
+        qp_b.rdma_read(WRID::send_data(1), &buf_b, remote_addr, rkey)
+            .unwrap();
+
+        // Wait and poll completion on B side.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let mut wcs = vec![verbs::ibv_wc::default(); 128];
+        let comp = qp_b.poll_cq(&mut wcs).unwrap();
+        assert_eq!(comp.len(), 1);
+        assert_eq!(comp[0].status, verbs::ibv_wc_status::IBV_WC_SUCCESS);
+
+        // Verify the data was read correctly.
+        // buf_b has length 0 (never extended), but RDMA wrote into raw memory.
+        let read_data = unsafe { std::slice::from_raw_parts(buf_b.as_ptr() as *const u8, LEN) };
+        assert_eq!(read_data, &test_data[..]);
+    }
+
+    #[test]
+    fn test_rdma_write() {
+        let devices = Devices::availables().unwrap();
+
+        let cap = verbs::ibv_qp_cap {
+            max_send_wr: 64,
+            max_recv_wr: 64,
+            max_send_sge: 1,
+            max_recv_sge: 1,
+            max_inline_data: 0,
+        };
+
+        let qp_a = QueuePair::create(&devices[0], cap).unwrap();
+        let qp_b = QueuePair::create(&devices[0], cap).unwrap();
+        qp_a.connect(&qp_b.endpoint()).unwrap();
+        qp_b.connect(&qp_a.endpoint()).unwrap();
+
+        const LEN: usize = 4096;
+        let buffer_pool = BufferPool::create(LEN, 32, &devices).unwrap();
+
+        // A side: register empty buffer (target for write).
+        let mut buf_a = buffer_pool.allocate().unwrap();
+        buf_a.extend_from_slice(&vec![0u8; LEN]).unwrap();
+        let remote_addr = buf_a.as_ptr() as u64;
+        let rkey = buf_a.rkey(&devices[0]);
+
+        // B side: fill buffer with test data, issue RDMA Write to A.
+        let mut buf_b = buffer_pool.allocate().unwrap();
+        let test_data: Vec<u8> = (0..LEN).map(|i| (i % 199) as u8).collect();
+        buf_b.extend_from_slice(&test_data).unwrap();
+        qp_b.rdma_write(WRID::send_data(1), &buf_b, remote_addr, rkey)
+            .unwrap();
+
+        // Wait and poll completion on B side.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let mut wcs = vec![verbs::ibv_wc::default(); 128];
+        let comp = qp_b.poll_cq(&mut wcs).unwrap();
+        assert_eq!(comp.len(), 1);
+        assert_eq!(comp[0].status, verbs::ibv_wc_status::IBV_WC_SUCCESS);
+
+        // Verify A side memory was modified.
+        let a_data: &[u8] = unsafe { std::mem::transmute(&*buf_a) };
+        assert_eq!(&a_data[..LEN], &test_data[..]);
     }
 }

--- a/ruapc/tests/test_rdma_memory.rs
+++ b/ruapc/tests/test_rdma_memory.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "rdma")]
+#![feature(return_type_notation)]
+
+use std::sync::Arc;
+
+use ruapc::*;
+
+fn make_rdma_devices() -> (Devices, Arc<Device>) {
+    let rdma_devices = ruapc_rdma::Devices::availables().unwrap();
+    let mut devices = Devices::new();
+    let device = devices.add_rdma_device(rdma_devices[0].clone());
+    (devices, device)
+}
+
+#[test]
+fn test_rdma_memory_registration() {
+    let (devices, device) = make_rdma_devices();
+
+    let mem = Memory::new(4096, &devices).unwrap();
+    let key = mem.get_memory_key(&device).unwrap();
+
+    // Should be an RDMA key with non-zero lkey and rkey.
+    match key {
+        MemoryKey::Rdma { lkey, rkey } => {
+            assert_ne!(lkey, 0, "lkey should be non-zero");
+            assert_ne!(rkey, 0, "rkey should be non-zero");
+        }
+        _ => panic!("expected MemoryKey::Rdma, got {:?}", key),
+    }
+}
+
+#[test]
+fn test_rdma_memory_drop_cleanup() {
+    let (devices, device) = make_rdma_devices();
+
+    // Create and drop memory — should not panic.
+    let mem = Memory::new(4096, &devices).unwrap();
+    let _key = mem.get_memory_key(&device).unwrap();
+    drop(mem);
+
+    // Allocate again to verify the device is still functional.
+    let mem2 = Memory::new(8192, &devices).unwrap();
+    let key2 = mem2.get_memory_key(&device).unwrap();
+    assert!(matches!(key2, MemoryKey::Rdma { .. }));
+}
+
+#[test]
+fn test_rdma_memory_mixed_devices() {
+    // Create both TCP and RDMA devices.
+    let rdma_devices = ruapc_rdma::Devices::availables().unwrap();
+    let mut devices = Devices::new();
+    let tcp_device = devices.add_tcp_device();
+    let rdma_device = devices.add_rdma_device(rdma_devices[0].clone());
+
+    let mem = Memory::new(4096, &devices).unwrap();
+
+    // TCP key should be Tcp variant.
+    let tcp_key = mem.get_memory_key(&tcp_device).unwrap();
+    assert!(matches!(tcp_key, MemoryKey::Tcp { .. }));
+
+    // RDMA key should be Rdma variant.
+    let rdma_key = mem.get_memory_key(&rdma_device).unwrap();
+    match rdma_key {
+        MemoryKey::Rdma { lkey, rkey } => {
+            assert_ne!(lkey, 0);
+            assert_ne!(rkey, 0);
+        }
+        _ => panic!("expected MemoryKey::Rdma"),
+    }
+}
+
+#[test]
+fn test_rdma_buffer_pool_allocate() {
+    let (devices, device) = make_rdma_devices();
+    let devices = Arc::new(devices);
+
+    let pool = BufferPool::new(devices, 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+    let buf = pool.allocate().unwrap();
+
+    assert_eq!(buf.len(), 2 * 1024 * 1024);
+
+    let info = buf.remote_buffer_info(&device).unwrap();
+    assert_eq!(info.len, 2 * 1024 * 1024);
+    assert_eq!(info.addr, buf.as_ptr() as u64);
+
+    match info.key {
+        MemoryKey::Rdma { lkey, rkey } => {
+            assert_ne!(lkey, 0);
+            assert_ne!(rkey, 0);
+        }
+        _ => panic!("expected MemoryKey::Rdma in RemoteBufferInfo"),
+    }
+}
+
+#[test]
+fn test_rdma_buffer_pool_multiple_buffers() {
+    let (devices, device) = make_rdma_devices();
+    let devices = Arc::new(devices);
+
+    let pool = BufferPool::new(devices, 2 * 1024 * 1024, 4 * 1024 * 1024, 0);
+
+    let buf1 = pool.allocate().unwrap();
+    let buf2 = pool.allocate().unwrap();
+
+    // Both buffers should have valid RDMA keys.
+    let info1 = buf1.remote_buffer_info(&device).unwrap();
+    let info2 = buf2.remote_buffer_info(&device).unwrap();
+
+    assert!(matches!(info1.key, MemoryKey::Rdma { .. }));
+    assert!(matches!(info2.key, MemoryKey::Rdma { .. }));
+
+    // Different buffers should have different addresses.
+    assert_ne!(info1.addr, info2.addr);
+
+    // Same memory chunk, so same keys.
+    assert_eq!(info1.key, info2.key);
+}


### PR DESCRIPTION
## Summary
- Add 5 integration tests for RDMA memory registration and BufferPool in `ruapc/tests/test_rdma_memory.rs`
  - Memory registration returns valid non-zero lkey/rkey
  - Drop cleanup doesn't break device
  - Mixed TCP + RDMA device registration
  - BufferPool allocate with RDMA device returns correct RemoteBufferInfo
  - Multiple buffers from same chunk share MemoryKey
- Add `rdma_read()` / `rdma_write()` methods to `QueuePair` in `ruapc-rdma`
- Add 2 loopback tests for one-sided RDMA Read and Write operations

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features rdma` zero warnings
- [ ] CI checks pass (tests require Soft-RoCE, set up in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)