### PR TITLE
feat: RDMA device Remote Read/Write via QP verbs

### DIFF
--- a/ruapc-rdma/src/devices.rs
+++ b/ruapc-rdma/src/devices.rs
@@ -421,6 +421,15 @@ impl Devices {
             Ok(Devices(devices))
         }
     }
+
+    /// Creates a `Devices` collection from an existing set of device `Arc`s.
+    ///
+    /// Use this when you already have opened devices and want to share them
+    /// with a component that expects a `Devices` collection (e.g. to reuse
+    /// the same protection domain across buffer registration and QP creation).
+    pub fn from_arcs(arcs: Vec<Arc<Device>>) -> Self {
+        Devices(arcs)
+    }
 }
 
 impl Deref for Devices {

--- a/ruapc-rdma/src/queue_pair.rs
+++ b/ruapc-rdma/src/queue_pair.rs
@@ -166,10 +166,46 @@ impl QueuePair {
         remote_addr: u64,
         rkey: u32,
     ) -> Result<()> {
+        self.rdma_read_raw(
+            wr_id,
+            local_buf.as_ptr() as u64,
+            local_buf.capacity() as u32,
+            local_buf.lkey(&self.device),
+            remote_addr,
+            rkey,
+        )
+    }
+
+    pub fn rdma_write(
+        &self,
+        wr_id: verbs::WRID,
+        local_buf: &Buffer,
+        remote_addr: u64,
+        rkey: u32,
+    ) -> Result<()> {
+        self.rdma_write_raw(
+            wr_id,
+            local_buf.as_ptr() as u64,
+            local_buf.len() as u32,
+            local_buf.lkey(&self.device),
+            remote_addr,
+            rkey,
+        )
+    }
+
+    pub fn rdma_read_raw(
+        &self,
+        wr_id: verbs::WRID,
+        local_addr: u64,
+        local_len: u32,
+        local_lkey: u32,
+        remote_addr: u64,
+        remote_rkey: u32,
+    ) -> Result<()> {
         let mut send_sge = verbs::ibv_sge {
-            addr: local_buf.as_ptr() as _,
-            length: local_buf.capacity() as _,
-            lkey: local_buf.lkey(&self.device),
+            addr: local_addr,
+            length: local_len,
+            lkey: local_lkey,
         };
         let mut send_wr = verbs::ibv_send_wr {
             wr_id,
@@ -180,7 +216,7 @@ impl QueuePair {
             ..Default::default()
         };
         send_wr.wr.rdma.remote_addr = remote_addr;
-        send_wr.wr.rdma.rkey = rkey;
+        send_wr.wr.rdma.rkey = remote_rkey;
 
         match self.post_send(&mut send_wr) {
             0 => Ok(()),
@@ -188,17 +224,19 @@ impl QueuePair {
         }
     }
 
-    pub fn rdma_write(
+    pub fn rdma_write_raw(
         &self,
         wr_id: verbs::WRID,
-        local_buf: &Buffer,
+        local_addr: u64,
+        local_len: u32,
+        local_lkey: u32,
         remote_addr: u64,
-        rkey: u32,
+        remote_rkey: u32,
     ) -> Result<()> {
         let mut send_sge = verbs::ibv_sge {
-            addr: local_buf.as_ptr() as _,
-            length: local_buf.len() as _,
-            lkey: local_buf.lkey(&self.device),
+            addr: local_addr,
+            length: local_len,
+            lkey: local_lkey,
         };
         let mut send_wr = verbs::ibv_send_wr {
             wr_id,
@@ -209,7 +247,7 @@ impl QueuePair {
             ..Default::default()
         };
         send_wr.wr.rdma.remote_addr = remote_addr;
-        send_wr.wr.rdma.rkey = rkey;
+        send_wr.wr.rdma.rkey = remote_rkey;
 
         match self.post_send(&mut send_wr) {
             0 => Ok(()),

--- a/ruapc/src/context.rs
+++ b/ruapc/src/context.rs
@@ -219,17 +219,53 @@ impl Context {
         self.send_rsp::<(), Error>(Err(err)).await;
     }
 
-    /// Reads data from a remote peer's registered memory via reverse RPC.
+    /// Reads data from a remote peer's registered memory.
     ///
-    /// Sends a `MemoryService/read` request to the peer, which validates
-    /// the access and returns the data. The returned data is copied into
-    /// `local_buf` starting at offset 0.
+    /// For TCP: sends a `MemoryService/read` reverse RPC request.
+    /// For RDMA: issues a one-sided RDMA Read via QP verbs.
     ///
     /// # Arguments
     ///
     /// * `remote` - Remote buffer info (key, addr, len) obtained from the peer
     /// * `local_buf` - Local buffer to write the received data into
     pub async fn remote_read(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &mut crate::Buffer,
+    ) -> Result<()> {
+        #[cfg(feature = "rdma")]
+        if let crate::MemoryKey::Rdma { lkey: _, rkey } = remote.key {
+            return self.rdma_remote_read(remote, local_buf, rkey).await;
+        }
+
+        self.tcp_remote_read(remote, local_buf).await
+    }
+
+    /// Writes data from a local buffer to a remote peer's registered memory.
+    ///
+    /// For TCP: sends a `MemoryService/write` reverse RPC request.
+    /// For RDMA: issues a one-sided RDMA Write via QP verbs.
+    ///
+    /// # Arguments
+    ///
+    /// * `remote` - Remote buffer info (key, addr, len) obtained from the peer
+    /// * `local_buf` - Local buffer containing the data to write
+    /// * `len` - Number of bytes to write from `local_buf`
+    pub async fn remote_write(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &crate::Buffer,
+        len: usize,
+    ) -> Result<()> {
+        #[cfg(feature = "rdma")]
+        if let crate::MemoryKey::Rdma { lkey: _, rkey } = remote.key {
+            return self.rdma_remote_write(remote, local_buf, len, rkey).await;
+        }
+
+        self.tcp_remote_write(remote, local_buf, len).await
+    }
+
+    async fn tcp_remote_read(
         &self,
         remote: &crate::RemoteBufferInfo,
         local_buf: &mut crate::Buffer,
@@ -257,18 +293,7 @@ impl Context {
         Ok(())
     }
 
-    /// Writes data from a local buffer to a remote peer's registered memory
-    /// via reverse RPC.
-    ///
-    /// Sends a `MemoryService/write` request to the peer with the data,
-    /// which validates the access and writes the data.
-    ///
-    /// # Arguments
-    ///
-    /// * `remote` - Remote buffer info (key, addr, len) obtained from the peer
-    /// * `local_buf` - Local buffer containing the data to write
-    /// * `len` - Number of bytes to write from `local_buf`
-    pub async fn remote_write(
+    async fn tcp_remote_write(
         &self,
         remote: &crate::RemoteBufferInfo,
         local_buf: &crate::Buffer,
@@ -283,6 +308,127 @@ impl Context {
         };
         let client = crate::Client::default();
         client.write(self, &req).await?;
+        Ok(())
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn rdma_remote_read(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &mut crate::Buffer,
+        rkey: u32,
+    ) -> Result<()> {
+        let rdma_socket = self.get_rdma_socket()?;
+
+        // Register local buffer on the QP's device to get a valid lkey.
+        let mr = Self::register_on_qp_device(&rdma_socket.queue_pair, local_buf)?;
+        let local_lkey = mr.lkey;
+
+        let wr_id = ruapc_rdma::verbs::WRID::send_data(0);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        rdma_socket.rdma_completions.insert(wr_id, tx);
+
+        rdma_socket.queue_pair.rdma_read_raw(
+            wr_id,
+            local_buf.as_ptr() as u64,
+            remote.len as u32,
+            local_lkey,
+            remote.addr,
+            rkey,
+        )?;
+
+        let result = Self::await_rdma_completion(rx).await;
+        drop(mr);
+        result
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn rdma_remote_write(
+        &self,
+        remote: &crate::RemoteBufferInfo,
+        local_buf: &crate::Buffer,
+        len: usize,
+        rkey: u32,
+    ) -> Result<()> {
+        let rdma_socket = self.get_rdma_socket()?;
+
+        // Register local buffer on the QP's device to get a valid lkey.
+        let mr = Self::register_on_qp_device(&rdma_socket.queue_pair, local_buf)?;
+        let local_lkey = mr.lkey;
+
+        let wr_id = ruapc_rdma::verbs::WRID::send_data(0);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        rdma_socket.rdma_completions.insert(wr_id, tx);
+
+        rdma_socket.queue_pair.rdma_write_raw(
+            wr_id,
+            local_buf.as_ptr() as u64,
+            len as u32,
+            local_lkey,
+            remote.addr,
+            rkey,
+        )?;
+
+        let result = Self::await_rdma_completion(rx).await;
+        drop(mr);
+        result
+    }
+
+    #[cfg(feature = "rdma")]
+    fn get_rdma_socket(&self) -> Result<std::sync::Arc<crate::rdma::RdmaSocket>> {
+        match &self.endpoint {
+            SocketEndpoint::Connected(Socket::RDMA(s)) => Ok(s.clone()),
+            _ => Err(Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "RDMA remote read/write requires a connected RDMA socket".into(),
+            )),
+        }
+    }
+
+    /// Registers a buffer's memory on the QP's protection domain.
+    ///
+    /// The QP and the buffer may be on different protection domains
+    /// (RdmaSocketPool creates its own devices internally). This method
+    /// registers the buffer on the QP's pd to get a valid lkey.
+    #[cfg(feature = "rdma")]
+    #[allow(unsafe_code)]
+    fn register_on_qp_device(
+        qp: &ruapc_rdma::QueuePair,
+        buf: &crate::Buffer,
+    ) -> Result<ruapc_rdma::RawMemoryRegion> {
+        let mr = unsafe {
+            ruapc_rdma::verbs::ibv_reg_mr(
+                qp.device.pd_ptr(),
+                buf.as_ptr() as *mut _,
+                buf.len(),
+                ruapc_rdma::verbs::ACCESS_FLAGS as _,
+            )
+        };
+        if mr.is_null() {
+            return Err(Error::new(
+                crate::ErrorKind::RdmaSendFailed,
+                "failed to register local buffer on QP device".into(),
+            ));
+        }
+        Ok(unsafe { ruapc_rdma::RawMemoryRegion::from_raw(mr) })
+    }
+
+    #[cfg(feature = "rdma")]
+    async fn await_rdma_completion(
+        rx: tokio::sync::oneshot::Receiver<ruapc_rdma::verbs::ibv_wc_status>,
+    ) -> Result<()> {
+        let status = rx.await.map_err(|_| {
+            Error::new(
+                crate::ErrorKind::RdmaSendFailed,
+                "RDMA completion channel closed".into(),
+            )
+        })?;
+        if status != ruapc_rdma::verbs::ibv_wc_status::IBV_WC_SUCCESS {
+            return Err(Error::new(
+                crate::ErrorKind::RdmaSendFailed,
+                format!("RDMA operation failed with status {:?}", status),
+            ));
+        }
         Ok(())
     }
 }

--- a/ruapc/src/device/mod.rs
+++ b/ruapc/src/device/mod.rs
@@ -109,6 +109,28 @@ impl Devices {
     pub fn get(&self, index: usize) -> Option<&Arc<Device>> {
         self.devices.get(index)
     }
+
+    /// Collects the inner `ruapc_rdma::Device` arcs from all RDMA devices.
+    ///
+    /// Returns a `ruapc_rdma::Devices` built from the same `Arc`s that back
+    /// the RDMA entries in this collection, so any QPs or buffer pools created
+    /// from the returned value share the same protection domain as memory
+    /// registered through these devices.
+    #[cfg(feature = "rdma")]
+    pub fn rdma_inner_devices(&self) -> ruapc_rdma::Devices {
+        let arcs = self
+            .devices
+            .iter()
+            .filter_map(|d| {
+                if let Device::Rdma(r) = d.as_ref() {
+                    Some(r.inner().clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        ruapc_rdma::Devices::from_arcs(arcs)
+    }
 }
 
 impl Default for Devices {

--- a/ruapc/src/sockets/rdma/event_loop.rs
+++ b/ruapc/src/sockets/rdma/event_loop.rs
@@ -131,6 +131,12 @@ struct SendHandler {
 
 impl SendHandler {
     fn handle_completion(&mut self, wc: &verbs::ibv_wc, socket: &RdmaSocket) -> Result<()> {
+        // Check if this is an RDMA one-sided operation completion.
+        if let Some((_, sender)) = socket.rdma_completions.remove(&wc.wr_id) {
+            let _ = sender.send(wc.status);
+            return Ok(());
+        }
+
         if wc.is_send_imm() {
             self.ack_completed += 1;
         } else {

--- a/ruapc/src/sockets/rdma/rdma_socket.rs
+++ b/ruapc/src/sockets/rdma/rdma_socket.rs
@@ -18,6 +18,9 @@ pub struct RdmaSocket {
     pub(crate) send_buffers: dashmap::DashMap<u64, Arc<Buffer>>,
     pub(crate) state: RdmaState,
     pub(crate) pending_sender: Sender<u64>,
+    /// Pending RDMA one-sided operation completions (wr_id -> status sender).
+    pub(crate) rdma_completions:
+        dashmap::DashMap<WRID, tokio::sync::oneshot::Sender<ruapc_rdma::verbs::ibv_wc_status>>,
 }
 
 impl RdmaSocket {
@@ -32,6 +35,7 @@ impl RdmaSocket {
             send_buffers: dashmap::DashMap::default(),
             state: RdmaState::new(32),
             pending_sender,
+            rdma_completions: dashmap::DashMap::default(),
         }
     }
 

--- a/ruapc/src/sockets/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/sockets/rdma/rdma_socket_pool.rs
@@ -42,19 +42,7 @@ impl SocketPoolTrait for RdmaSocketPool {
     /// * `Err(Error)` - If RDMA devices cannot be initialized or buffer pool creation fails
     fn create(_: &SocketPoolConfig) -> Result<Self> {
         let devices = Devices::availables()?;
-        let rdmabuf_pool = BufferPool::create(4096, 4096, &devices)?;
-        let this = Self {
-            acquire_client: Client {
-                timeout: std::time::Duration::from_secs(5),
-                use_msgpack: true,
-                socket_type: Some(SocketType::TCP),
-            },
-            rdmabuf_pool,
-            devices,
-            socket_map: RwLock::default(),
-            task_supervisor: TaskSupervisor::create(),
-        };
-        Ok(this)
+        Self::create_from_devices(devices)
     }
 
     /// Stops all tasks managed by the socket pool.
@@ -197,6 +185,27 @@ impl SocketPoolTrait for RdmaSocketPool {
 }
 
 impl RdmaSocketPool {
+    /// Creates a pool using the provided RDMA devices.
+    ///
+    /// Call this instead of [`SocketPoolTrait::create`] when you have
+    /// already-opened RDMA devices whose protection domain should be
+    /// shared with user buffer registrations. If `rdma_devices` is
+    /// empty, falls back to `Devices::availables()`.
+    pub fn create_from_devices(devices: Devices) -> Result<Self> {
+        let rdmabuf_pool = BufferPool::create(4096, 4096, &devices)?;
+        Ok(Self {
+            acquire_client: Client {
+                timeout: std::time::Duration::from_secs(5),
+                use_msgpack: true,
+                socket_type: Some(SocketType::TCP),
+            },
+            rdmabuf_pool,
+            devices,
+            socket_map: RwLock::default(),
+            task_supervisor: TaskSupervisor::create(),
+        })
+    }
+
     /// Starts the event loop for handling RDMA events on a socket.
     ///
     /// This method:

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -208,6 +208,30 @@ impl SocketPool {
             SocketPool::RDMA(_) => SocketType::RDMA,
         }
     }
+
+    /// Creates a pool, using the given RDMA devices for any RDMA sub-pool so
+    /// that QPs and user buffer registrations share the same protection domain.
+    ///
+    /// For non-RDMA pool types the `rdma_devices` argument is unused.
+    #[cfg(feature = "rdma")]
+    pub fn create_with_rdma_devices(
+        config: &SocketPoolConfig,
+        rdma_devices: ruapc_rdma::Devices,
+    ) -> Result<Self> {
+        match config.socket_type {
+            SocketType::TCP => Ok(SocketPool::TCP(TcpSocketPool::create(config)?)),
+            SocketType::WS => Ok(SocketPool::WS(WebSocketPool::create(config)?)),
+            SocketType::HTTP => Ok(SocketPool::HTTP(HttpSocketPool::create(config)?)),
+            SocketType::UNIFIED => Ok(SocketPool::UNIFIED(
+                UnifiedSocketPool::create_with_rdma_devices(config, rdma_devices)?,
+            )),
+            SocketType::RDMA => Ok(SocketPool::RDMA(if rdma_devices.is_empty() {
+                RdmaSocketPool::create(config)?
+            } else {
+                RdmaSocketPool::create_from_devices(rdma_devices)?
+            })),
+        }
+    }
 }
 
 impl SocketPoolTrait for SocketPool {

--- a/ruapc/src/sockets/unified/unified_socket_pool.rs
+++ b/ruapc/src/sockets/unified/unified_socket_pool.rs
@@ -24,31 +24,13 @@ pub struct UnifiedSocketPool {
 
 impl SocketPoolTrait for UnifiedSocketPool {
     fn create(config: &SocketPoolConfig) -> Result<Self> {
-        let this = Self {
-            tcp_socket_pool: TcpSocketPool::create(config)?,
-            web_socket_pool: WebSocketPool::create(config)?,
-            http_socket_pool: HttpSocketPool::create(config)?,
-            #[cfg(feature = "rdma")]
-            rdma_socket_pool: RdmaSocketPool::create(config)?,
-            task_supervisor: TaskSupervisor::create(),
-        };
-
-        let task_guard = this.task_supervisor.start_async_task();
-        let tcp_guard = this.tcp_socket_pool.drop_guard();
-        let web_guard = this.web_socket_pool.drop_guard();
-        let http_guard = this.http_socket_pool.drop_guard();
         #[cfg(feature = "rdma")]
-        let rdma_guard = this.rdma_socket_pool.drop_guard();
-        tokio::spawn(async move {
-            task_guard.stopped().await;
-            drop(http_guard);
-            drop(web_guard);
-            drop(tcp_guard);
+        let rdma_socket_pool = RdmaSocketPool::create(config)?;
+        Self::create_inner(
+            config,
             #[cfg(feature = "rdma")]
-            drop(rdma_guard);
-        });
-
-        Ok(this)
+            rdma_socket_pool,
+        )
     }
 
     async fn acquire(
@@ -146,5 +128,53 @@ impl SocketPoolTrait for UnifiedSocketPool {
 impl std::fmt::Debug for UnifiedSocketPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnifiedSocketPool").finish()
+    }
+}
+
+impl UnifiedSocketPool {
+    /// Creates a pool using the provided RDMA devices so QPs and user buffer
+    /// registrations share the same protection domain.
+    #[cfg(feature = "rdma")]
+    pub fn create_with_rdma_devices(
+        config: &SocketPoolConfig,
+        rdma_devices: ruapc_rdma::Devices,
+    ) -> Result<Self> {
+        let rdma_socket_pool = if rdma_devices.is_empty() {
+            RdmaSocketPool::create(config)?
+        } else {
+            RdmaSocketPool::create_from_devices(rdma_devices)?
+        };
+        Self::create_inner(config, rdma_socket_pool)
+    }
+
+    fn create_inner(
+        config: &SocketPoolConfig,
+        #[cfg(feature = "rdma")] rdma_socket_pool: RdmaSocketPool,
+    ) -> Result<Self> {
+        let this = Self {
+            tcp_socket_pool: TcpSocketPool::create(config)?,
+            web_socket_pool: WebSocketPool::create(config)?,
+            http_socket_pool: HttpSocketPool::create(config)?,
+            #[cfg(feature = "rdma")]
+            rdma_socket_pool,
+            task_supervisor: TaskSupervisor::create(),
+        };
+
+        let task_guard = this.task_supervisor.start_async_task();
+        let tcp_guard = this.tcp_socket_pool.drop_guard();
+        let web_guard = this.web_socket_pool.drop_guard();
+        let http_guard = this.http_socket_pool.drop_guard();
+        #[cfg(feature = "rdma")]
+        let rdma_guard = this.rdma_socket_pool.drop_guard();
+        tokio::spawn(async move {
+            task_guard.stopped().await;
+            drop(http_guard);
+            drop(web_guard);
+            drop(tcp_guard);
+            #[cfg(feature = "rdma")]
+            drop(rdma_guard);
+        });
+
+        Ok(this)
     }
 }

--- a/ruapc/src/state.rs
+++ b/ruapc/src/state.rs
@@ -66,10 +66,21 @@ impl State {
             mem_svc.ruapc_export(&mut router);
         }
         router.build_open_api()?;
+        let socket_pool = {
+            #[cfg(feature = "rdma")]
+            if let Some(ref devs) = devices {
+                let rdma_devices = devs.rdma_inner_devices();
+                SocketPool::create_with_rdma_devices(config, rdma_devices)?
+            } else {
+                SocketPool::create(config)?
+            }
+            #[cfg(not(feature = "rdma"))]
+            SocketPool::create(config)?
+        };
         let state = Self {
             router,
             waiter: Arc::default(),
-            socket_pool: SocketPool::create(config)?,
+            socket_pool,
             devices,
         };
         let state = Arc::new(state);

--- a/ruapc/tests/test_remote_rw.rs
+++ b/ruapc/tests/test_remote_rw.rs
@@ -208,6 +208,151 @@ async fn test_tcp_remote_write() {
     server.join().await;
 }
 
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn test_rdma_remote_read() {
+    // Get RDMA devices.
+    let rdma_devices = ruapc_rdma::Devices::availables().unwrap();
+
+    // Set up server with RDMA device.
+    let mut server_devs = Devices::new();
+    let _server_rdma = server_devs.add_rdma_device(rdma_devices[0].clone());
+    let server_devs = Arc::new(server_devs);
+
+    let read_svc = Arc::new(ReadTestImpl);
+    let mut router = Router::default();
+    read_svc.ruapc_export(&mut router);
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+    };
+    let server = Server::create_with_devices(router, &config, Some(server_devs.clone())).unwrap();
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.listen(addr).await.unwrap();
+
+    // Set up client with RDMA device.
+    let mut client_devs = Devices::new();
+    let client_rdma = client_devs.add_rdma_device(rdma_devices[0].clone());
+    let client_devs = Arc::new(client_devs);
+
+    let client_pool = BufferPool::new(client_devs.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+
+    // Allocate client buffer and fill with test data.
+    let mut client_buf = client_pool.allocate().unwrap();
+    let test_data = b"Hello, RDMA Remote Read!";
+    client_buf[..test_data.len()].copy_from_slice(test_data);
+
+    // Get RemoteBufferInfo with RDMA key.
+    let rbi = client_buf.remote_buffer_info(&client_rdma).unwrap();
+    assert!(matches!(rbi.key, MemoryKey::Rdma { .. }));
+    let rbi_for_req = RemoteBufferInfo {
+        key: rbi.key,
+        addr: rbi.addr,
+        len: test_data.len() as u64,
+    };
+
+    // Create client context with RDMA device (for lkey lookup on server side).
+    let ctx = Context::create_with_router_and_devices(
+        Router::default(),
+        &config,
+        Some(client_devs.clone()),
+    )
+    .unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    // Use RDMA socket type for the RPC call.
+    let client = Client {
+        socket_type: Some(SocketType::RDMA),
+        ..Default::default()
+    };
+    let rsp: RemoteReadRsp = client
+        .read_remote(&ctx, &RemoteReadReq { info: rbi_for_req })
+        .await
+        .unwrap();
+
+    assert_eq!(rsp.data, test_data);
+
+    server.stop();
+    tokio::time::timeout(std::time::Duration::from_secs(30), server.join())
+        .await
+        .unwrap();
+}
+
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn test_rdma_remote_write() {
+    // Get RDMA devices.
+    let rdma_devices = ruapc_rdma::Devices::availables().unwrap();
+
+    // Set up server with RDMA device.
+    let mut server_devs = Devices::new();
+    let _server_rdma = server_devs.add_rdma_device(rdma_devices[0].clone());
+    let server_devs = Arc::new(server_devs);
+
+    let write_svc = Arc::new(WriteTestImpl);
+    let mut router = Router::default();
+    write_svc.ruapc_export(&mut router);
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+    };
+    let server = Server::create_with_devices(router, &config, Some(server_devs.clone())).unwrap();
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.listen(addr).await.unwrap();
+
+    // Set up client with RDMA device.
+    let mut client_devs = Devices::new();
+    let client_rdma = client_devs.add_rdma_device(rdma_devices[0].clone());
+    let client_devs = Arc::new(client_devs);
+
+    let client_pool = BufferPool::new(client_devs.clone(), 2 * 1024 * 1024, 2 * 1024 * 1024, 0);
+
+    // Allocate client buffer (initially zeroed).
+    let client_buf = client_pool.allocate().unwrap();
+    assert!(client_buf[..10].iter().all(|&b| b == 0));
+
+    // Get RemoteBufferInfo with RDMA key.
+    let rbi = client_buf.remote_buffer_info(&client_rdma).unwrap();
+    assert!(matches!(rbi.key, MemoryKey::Rdma { .. }));
+    let write_data = b"Hello, RDMA Remote Write!";
+    let rbi_for_req = RemoteBufferInfo {
+        key: rbi.key,
+        addr: rbi.addr,
+        len: write_data.len() as u64,
+    };
+
+    // Create client context with RDMA device.
+    let ctx = Context::create_with_router_and_devices(
+        Router::default(),
+        &config,
+        Some(client_devs.clone()),
+    )
+    .unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    // Use RDMA socket type for the RPC call.
+    let client = Client {
+        socket_type: Some(SocketType::RDMA),
+        ..Default::default()
+    };
+    client
+        .write_remote(
+            &ctx,
+            &RemoteWriteReq {
+                info: rbi_for_req,
+                data: write_data.to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Verify the data was written to our buffer via RDMA Write.
+    assert_eq!(&client_buf[..write_data.len()], write_data);
+
+    server.stop();
+    tokio::time::timeout(std::time::Duration::from_secs(30), server.join())
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn test_tcp_remote_read_bounds_check() {
     // Set up server devices.


### PR DESCRIPTION
## Summary
- `Context::remote_read`/`remote_write` now dispatch on `MemoryKey` type: RDMA keys use one-sided QP verbs, TCP keys use MemoryService reverse RPC (existing path)
- Added `rdma_read_raw`/`rdma_write_raw` to `QueuePair` for raw addr/len/lkey parameters; refactored existing `rdma_read`/`rdma_write` to delegate
- RDMA completion tracking via `DashMap<WRID, oneshot::Sender<ibv_wc_status>>` on `RdmaSocket`
- `EventLoop::SendHandler` checks for one-sided operation completions before normal send flow
- `Context::register_on_qp_device` handles case where buffer and QP are on different protection domains
- Added end-to-end integration tests: `test_rdma_remote_read` and `test_rdma_remote_write`

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features rdma` zero warnings
- [x] `cargo check --features rdma` passes
- [x] `cargo test --features rdma --no-run` compiles all tests
- [ ] CI checks pass (RDMA tests require Soft-RoCE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)