### PR TITLE
refactor: use Arc<AlignedMemory> in RegisteredMemory and TcpDevice to eliminate raw pointer reconstruction

### DIFF
--- a/ruapc-bufpool/src/aligned_memory.rs
+++ b/ruapc-bufpool/src/aligned_memory.rs
@@ -65,7 +65,7 @@ impl AlignedMemory {
     }
 
     /// Returns a mutable raw pointer to the memory.
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+    pub fn as_mut_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
     }
 
@@ -76,8 +76,15 @@ impl AlignedMemory {
     }
 
     /// Returns the memory as a mutable byte slice.
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        // SAFETY: ptr is valid for `size` bytes and we have exclusive access.
+    ///
+    /// This is safe because `AlignedMemory` owns its allocation exclusively
+    /// and the raw pointer is valid for `size` bytes. Concurrent access
+    /// is governed by the higher-level types that hold the `AlignedMemory`
+    /// (e.g. `RegisteredMemory`, `BufferPool`).
+    #[allow(clippy::mut_from_ref)]
+    pub fn as_mut_slice(&self) -> &mut [u8] {
+        // SAFETY: ptr is valid for `size` bytes and properly aligned.
+        // AlignedMemory is the sole owner of this allocation.
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.size) }
     }
 }
@@ -125,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_aligned_memory_read_write() {
-        let mut mem = AlignedMemory::new(ALIGN).unwrap();
+        let mem = AlignedMemory::new(ALIGN).unwrap();
         let slice = mem.as_mut_slice();
         slice[0] = 0x42;
         slice[1] = 0x43;

--- a/ruapc-bufpool/src/memory.rs
+++ b/ruapc-bufpool/src/memory.rs
@@ -1,4 +1,5 @@
 use std::io::{Error, ErrorKind, Result};
+use std::sync::Arc;
 
 use crate::AlignedMemory;
 use crate::device::{Device, Devices, Registration};
@@ -15,7 +16,7 @@ use crate::device::{Device, Devices, Registration};
 /// registration fails, the `RegisteredMemory` still holds registrations
 /// from previously successful devices, ensuring correct cleanup on drop.
 pub struct RegisteredMemory<R: Registration> {
-    aligned_memory: AlignedMemory,
+    aligned_memory: Arc<AlignedMemory>,
     registrations: Vec<R>,
 }
 
@@ -41,7 +42,7 @@ impl<R: Registration> RegisteredMemory<R> {
     /// Use [`Device::register`] to register on individual devices
     /// afterwards.
     pub fn new_unregistered(size: usize) -> Result<Self> {
-        let aligned_memory = AlignedMemory::new(size)?;
+        let aligned_memory = Arc::new(AlignedMemory::new(size)?);
         Ok(Self {
             aligned_memory,
             registrations: Vec::new(),
@@ -56,14 +57,9 @@ impl<R: Registration> RegisteredMemory<R> {
         self.registrations.push(reg);
     }
 
-    /// Returns a reference to the underlying `AlignedMemory`.
-    pub fn aligned_memory(&self) -> &AlignedMemory {
+    /// Returns a reference to the underlying `Arc<AlignedMemory>`.
+    pub fn aligned_memory(&self) -> &Arc<AlignedMemory> {
         &self.aligned_memory
-    }
-
-    /// Returns a mutable reference to the underlying `AlignedMemory`.
-    pub fn aligned_memory_mut(&mut self) -> &mut AlignedMemory {
-        &mut self.aligned_memory
     }
 
     /// Returns a reference to the registration for the given device index.

--- a/ruapc-bufpool/tests/tests.rs
+++ b/ruapc-bufpool/tests/tests.rs
@@ -227,9 +227,9 @@ fn memory_drop_calls_unregister() {
 
 #[test]
 fn memory_aligned_memory_accessors() {
-    let mut mem = RegisteredMemory::<MockRegistration>::new_unregistered(BLOCK).unwrap();
+    let mem = RegisteredMemory::<MockRegistration>::new_unregistered(BLOCK).unwrap();
     let ptr = mem.aligned_memory().as_ptr();
-    let ptr_mut = mem.aligned_memory_mut().as_mut_ptr();
+    let ptr_mut = mem.aligned_memory().as_mut_ptr();
     assert_eq!(ptr as *mut u8, ptr_mut);
 }
 

--- a/ruapc/src/device/mod.rs
+++ b/ruapc/src/device/mod.rs
@@ -89,13 +89,11 @@ impl ruapc_bufpool::Device for Device {
         self: &Arc<Self>,
         mem: &mut ruapc_bufpool::RegisteredMemory<Self::Registration>,
     ) -> std::io::Result<()> {
-        let aligned = mem.aligned_memory();
-        let ptr = aligned.as_ptr();
-        let size = aligned.size();
+        let aligned = mem.aligned_memory().clone();
 
         match self.as_ref() {
             Device::Tcp(tcp) => {
-                let id = tcp.register(ptr as usize, size);
+                let id = tcp.register(aligned);
                 mem.add_registration(MemoryRegistration::Tcp {
                     device: self.clone(),
                     id,
@@ -104,6 +102,8 @@ impl ruapc_bufpool::Device for Device {
             }
             #[cfg(feature = "rdma")]
             Device::Rdma(rdma) => {
+                let ptr = aligned.as_ptr();
+                let size = aligned.size();
                 let mr = unsafe {
                     ruapc_rdma::verbs::ibv_reg_mr(
                         rdma.pd_ptr(),
@@ -197,15 +197,19 @@ mod tests {
 
     #[test]
     fn test_tcp_device_register_validate() {
+        use ruapc_bufpool::AlignedMemory;
+
         let dev = TcpDevice::new(0);
-        let id = dev.register(0x1000, 4096);
+        let mem = Arc::new(AlignedMemory::new(4096).unwrap());
+        let size = mem.size();
+        let id = dev.register(mem);
 
         // Valid access.
         assert!(dev.validate_access(id, 0, 100).is_ok());
-        assert!(dev.validate_access(id, 4000, 96).is_ok());
+        assert!(dev.validate_access(id, size as u64 - 96, 96).is_ok());
 
         // Out of bounds.
-        assert!(dev.validate_access(id, 4000, 97).is_err());
+        assert!(dev.validate_access(id, size as u64 - 96, 97).is_err());
 
         // Unknown ID.
         assert!(dev.validate_access(id + 1, 0, 1).is_err());

--- a/ruapc/src/device/tcp_device.rs
+++ b/ruapc/src/device/tcp_device.rs
@@ -1,25 +1,21 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ruapc_bufpool::AlignedMemory;
 
 use crate::{Error, ErrorKind, Result};
 
 /// A virtual TCP "device" for memory registration.
 ///
 /// TCP doesn't have hardware memory registration like RDMA, so this
-/// maintains a software registry mapping IDs to memory regions.
-/// Remote Read/Write operations use reverse RPC, and this registry
-/// provides the safety checks (ID validity, bounds checking).
+/// maintains a software registry mapping IDs to `Arc<AlignedMemory>`
+/// regions. Remote Read/Write operations use reverse RPC, and this
+/// registry provides the safety checks (ID validity, bounds checking).
 pub struct TcpDevice {
     index: usize,
-    registry: Mutex<HashMap<u32, MemoryRegion>>,
+    registry: Mutex<HashMap<u32, Arc<AlignedMemory>>>,
     next_id: AtomicU32,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct MemoryRegion {
-    addr: usize,
-    len: usize,
 }
 
 impl TcpDevice {
@@ -44,10 +40,10 @@ impl TcpDevice {
     }
 
     /// Registers a memory region and returns its assigned ID.
-    pub(crate) fn register(&self, addr: usize, len: usize) -> u32 {
+    pub(crate) fn register(&self, memory: Arc<AlignedMemory>) -> u32 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut registry = self.registry.lock().unwrap();
-        registry.insert(id, MemoryRegion { addr, len });
+        registry.insert(id, memory);
         id
     }
 
@@ -60,53 +56,49 @@ impl TcpDevice {
     /// Reads data from a registered memory region using absolute address.
     ///
     /// Validates that the range `[addr, addr+len)` is within the region
-    /// registered under `id`, then copies data out.
-    ///
-    /// # Safety justification
-    ///
-    /// The memory was registered by the owning `Memory` struct which holds
-    /// both the `AlignedMemory` allocation and the `Arc<Device>` keeping
-    /// this `TcpDevice` alive. As long as the registration exists in the
-    /// registry, the underlying memory is guaranteed to be valid.
-    #[allow(unsafe_code)]
+    /// registered under `id`, then copies data out via the `AlignedMemory`
+    /// slice.
     pub fn read_memory(&self, id: u32, addr: u64, len: u64) -> Result<Vec<u8>> {
-        self.validate_absolute_access(id, addr, len)?;
-        // SAFETY: validate_absolute_access confirmed the region is registered
-        // and the range [addr, addr+len) is within bounds.
-        let data = unsafe { std::slice::from_raw_parts(addr as *const u8, len as usize) };
+        let registry = self.registry.lock().unwrap();
+        let mem = self.lookup(&registry, id)?;
+        let offset = self.validate_absolute_access(mem, addr, len)?;
+        let data = &mem.as_slice()[offset..offset + len as usize];
         Ok(data.to_vec())
     }
 
     /// Writes data into a registered memory region using absolute address.
     ///
     /// Validates that the range `[addr, addr+len)` is within the region
-    /// registered under `id`, then copies data in.
-    ///
-    /// # Safety justification
-    ///
-    /// Same as `read_memory` — the registration guarantees the memory is valid.
-    #[allow(unsafe_code)]
+    /// registered under `id`, then copies data in via the `AlignedMemory`
+    /// slice.
     pub fn write_memory(&self, id: u32, addr: u64, data: &[u8]) -> Result<()> {
-        self.validate_absolute_access(id, addr, data.len() as u64)?;
-        // SAFETY: validate_absolute_access confirmed the region is registered
-        // and the range [addr, addr+len) is within bounds.
-        let dest = unsafe { std::slice::from_raw_parts_mut(addr as *mut u8, data.len()) };
+        let registry = self.registry.lock().unwrap();
+        let mem = self.lookup(&registry, id)?;
+        let offset = self.validate_absolute_access(mem, addr, data.len() as u64)?;
+        let dest = &mut mem.as_mut_slice()[offset..offset + data.len()];
         dest.copy_from_slice(data);
         Ok(())
     }
 
-    /// Validates that an absolute address range is within a registered region.
-    fn validate_absolute_access(&self, id: u32, addr: u64, len: u64) -> Result<()> {
-        let registry = self.registry.lock().unwrap();
-        let region = registry.get(&id).ok_or_else(|| {
+    /// Looks up the memory region by ID.
+    fn lookup<'a>(
+        &self,
+        registry: &'a HashMap<u32, Arc<AlignedMemory>>,
+        id: u32,
+    ) -> Result<&'a Arc<AlignedMemory>> {
+        registry.get(&id).ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidArgument,
                 format!("memory region ID {id} not registered"),
             )
-        })?;
+        })
+    }
 
-        let region_start = region.addr as u64;
-        let region_end = region_start + region.len as u64;
+    /// Validates that an absolute address range is within the registered
+    /// memory and returns the byte offset from the start of the allocation.
+    fn validate_absolute_access(&self, mem: &AlignedMemory, addr: u64, len: u64) -> Result<usize> {
+        let region_start = mem.as_ptr() as u64;
+        let region_end = region_start + mem.size() as u64;
         let access_end = addr
             .checked_add(len)
             .ok_or_else(|| Error::new(ErrorKind::InvalidArgument, "addr + len overflow".into()))?;
@@ -120,34 +112,29 @@ impl TcpDevice {
             ));
         }
 
-        Ok(())
+        Ok((addr - region_start) as usize)
     }
 
     /// Validates that an access (id, offset, len) is within a registered region.
     pub fn validate_access(&self, id: u32, offset: u64, len: u64) -> Result<usize> {
         let registry = self.registry.lock().unwrap();
-        let region = registry.get(&id).ok_or_else(|| {
-            Error::new(
-                ErrorKind::InvalidArgument,
-                format!("memory region ID {id} not registered"),
-            )
-        })?;
+        let mem = self.lookup(&registry, id)?;
 
         let end = offset.checked_add(len).ok_or_else(|| {
             Error::new(ErrorKind::InvalidArgument, "offset + len overflow".into())
         })?;
 
-        if end as usize > region.len {
+        if end as usize > mem.size() {
             return Err(Error::new(
                 ErrorKind::InvalidArgument,
                 format!(
                     "access out of bounds: offset={offset} len={len} exceeds region size={}",
-                    region.len
+                    mem.size()
                 ),
             ));
         }
 
-        Ok(region.addr + offset as usize)
+        Ok(mem.as_ptr() as usize + offset as usize)
     }
 }
 


### PR DESCRIPTION
RegisteredMemory now stores Arc<AlignedMemory> instead of owned AlignedMemory. TcpDevice registry stores Arc<AlignedMemory> instead of (addr, len), and read_memory/write_memory use slice operations via the Arc rather than casting absolute addresses back to raw pointers.