### PR TITLE
test(ruapc-bufpool): achieve 100% line/function coverage

### DIFF
--- a/ruapc-bufpool/src/aligned_memory.rs
+++ b/ruapc-bufpool/src/aligned_memory.rs
@@ -139,4 +139,34 @@ mod tests {
         assert_eq!(mem.as_slice()[0], 0x42);
         assert_eq!(mem.as_slice()[1], 0x43);
     }
+
+    #[test]
+    fn test_aligned_memory_debug() {
+        let mem = AlignedMemory::new(ALIGN).unwrap();
+        let debug = format!("{mem:?}");
+        assert!(debug.contains("AlignedMemory"));
+        assert!(debug.contains("size"));
+    }
+
+    #[test]
+    fn test_aligned_memory_mut_ptr() {
+        let mem = AlignedMemory::new(ALIGN).unwrap();
+        let ptr = mem.as_ptr();
+        let mut_ptr = mem.as_mut_ptr();
+        assert_eq!(ptr, mut_ptr as *const u8);
+    }
+
+    #[test]
+    fn test_aligned_memory_layout_too_large() {
+        // Size just above isize::MAX triggers Layout::from_size_align error.
+        let result = AlignedMemory::new(isize::MAX as usize + 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aligned_memory_alloc_failure() {
+        // Request a valid-layout but impossibly large allocation (1 EiB).
+        let result = AlignedMemory::new(1_usize << 60);
+        assert!(result.is_err());
+    }
 }

--- a/ruapc-bufpool/src/buffer_pool.rs
+++ b/ruapc-bufpool/src/buffer_pool.rs
@@ -113,9 +113,12 @@ impl<D: Device> BufferPool<D> {
 
         if self.max_memory == 0 || inner.allocated_memory + self.chunk_size <= self.max_memory {
             self.allocate_chunk(inner)?;
-            if let Some(slot) = inner.free_list.pop_front() {
-                return self.make_buffer(inner, slot);
-            }
+            // allocate_chunk always pushes at least one slot.
+            let slot = inner
+                .free_list
+                .pop_front()
+                .expect("allocate_chunk pushed no slots");
+            return self.make_buffer(inner, slot);
         }
 
         Err(Error::other("buffer pool exhausted"))

--- a/ruapc-bufpool/tests/tests.rs
+++ b/ruapc-bufpool/tests/tests.rs
@@ -521,3 +521,83 @@ async fn pool_async_allocate_waits_for_return() {
     let buf2 = handle.await.unwrap();
     assert_eq!(buf2.capacity(), BLOCK);
 }
+
+// ---------------------------------------------------------------------------
+// Coverage gap tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn aligned_memory_debug_format() {
+    let mem = ruapc_bufpool::AlignedMemory::new(4096).unwrap();
+    let debug = format!("{mem:?}");
+    assert!(debug.contains("AlignedMemory"));
+    assert!(debug.contains("size"));
+}
+
+#[test]
+fn registered_memory_debug_format() {
+    let mem = RegisteredMemory::<MockRegistration>::new_unregistered(BLOCK).unwrap();
+    let debug = format!("{mem:?}");
+    assert!(debug.contains("RegisteredMemory"));
+    assert!(debug.contains("registrations"));
+}
+
+#[test]
+fn buffer_pool_accessor() {
+    let devices = mock_devices(1);
+    let pool = mock_pool(devices, 0);
+    let buf = pool.allocate().unwrap();
+
+    // buf.pool() should return a reference to the same pool.
+    assert_eq!(buf.pool().block_size(), BLOCK);
+}
+
+#[test]
+fn pool_allocate_chunk_failure() {
+    // All devices fail immediately, so the first allocate() triggers
+    // allocate_chunk -> RegisteredMemory::new -> device.register -> Err.
+    let mut devices = Devices::new();
+    devices.add(PartialDevice::new(0)); // always fails
+    let devices = Arc::new(devices);
+    let pool = BufferPool::new(devices, BLOCK, BLOCK, 0);
+
+    assert!(pool.allocate().is_err());
+}
+
+#[test]
+fn registered_memory_new_unregistered_zero_size() {
+    // Triggers AlignedMemory::new(0) -> Err inside new_unregistered.
+    let result = RegisteredMemory::<MockRegistration>::new_unregistered(0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn registered_memory_new_first_device_fails() {
+    // Triggers the `?` error return at the top of the device iteration loop
+    // inside RegisteredMemory::new (memory.rs:30).
+    let mut devices = Devices::new();
+    devices.add(PartialDevice::new(0)); // first device always fails
+    let result = RegisteredMemory::new(BLOCK, &devices);
+    assert!(result.is_err());
+}
+
+#[test]
+fn pool_multi_block_chunk() {
+    // Use a chunk size that is a multiple of the block size to get
+    // multiple blocks per chunk.
+    let devices = mock_devices(1);
+    let pool = BufferPool::new(devices, BLOCK, BLOCK * 2, 0);
+
+    let buf1 = pool.allocate().unwrap();
+    let buf2 = pool.allocate().unwrap();
+
+    // Both should come from the same chunk (single allocation).
+    assert_eq!(pool.allocated_memory(), BLOCK * 2);
+
+    // They must have different addresses.
+    assert_ne!(buf1.as_ptr(), buf2.as_ptr());
+
+    drop(buf1);
+    drop(buf2);
+    assert_eq!(pool.free_count(), 2);
+}


### PR DESCRIPTION
Add tests for error paths (layout failure, alloc failure, chunk allocation failure, zero-size allocation, first-device registration failure), Debug impls, pool() accessor, and multi-block chunks. Replace unreachable if-let with expect in allocate_inner.