### PR TITLE
feat: safe buffer propagation in RPC via Request<'a, T> and remote_read UUID validation

### DIFF
--- a/ruapc-bufpool/src/key.rs
+++ b/ruapc-bufpool/src/key.rs
@@ -14,7 +14,17 @@ pub struct MemoryKey {
     pub rkey: u32,
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
 pub struct RemoteBufferInfo {
     pub key: MemoryKey,
     pub addr: u64,

--- a/ruapc-macro/src/lib.rs
+++ b/ruapc-macro/src/lib.rs
@@ -30,10 +30,12 @@
 //! The macro generates:
 //! 1. A `ruapc_export` method for registering the service with a router
 //! 2. Client trait implementation on `Client` for making requests
-//! 3. Proper error handling and message serialization
+//! 3. A `WithBuffer` extension trait with `_with_buffer` methods for each
+//!    trait method, allowing callers to attach registered memory buffers
+//! 4. Proper error handling and message serialization
 
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{FnArg, ItemTrait, ReturnType, TraitItem, parse_macro_input};
 
 /// Procedural macro for defining RPC services.
@@ -66,8 +68,13 @@ pub fn service(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut send_bounds = vec![];
     let mut invoke_branchs = vec![];
     let mut client_methods = vec![];
+    let mut with_buffer_trait_methods = vec![];
+    let mut with_buffer_impl_methods = vec![];
 
     let krate = get_crate_name();
+
+    // Generate the WithBuffer trait name: e.g., EchoServiceWithBuffer
+    let with_buffer_trait_ident = format_ident!("{}WithBuffer", trait_ident);
 
     let input_items = input.items;
     for item in &input_items {
@@ -86,9 +93,26 @@ pub fn service(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
             let req_type = req_type.ty.clone();
             let output = &method.sig.output;
+
+            // Client trait impl: wraps &req in Request::Normal
             client_methods.push(quote! {
                 async fn #method_ident(#receiver, ctx: &#krate::Context, req: #req_type) #output {
-                    self.ruapc_request(ctx, req, #method_name).await
+                    self.ruapc_request(ctx, #krate::Request::Normal(req), #method_name).await
+                }
+            });
+
+            // Generate _with_buffer method name
+            let with_buffer_ident = format_ident!("{}_with_buffer", method_ident);
+
+            // WithBuffer trait method declaration
+            with_buffer_trait_methods.push(quote! {
+                async fn #with_buffer_ident(#receiver, ctx: &#krate::Context, req: #req_type, buffer: &#krate::Buffer) #output;
+            });
+
+            // WithBuffer trait implementation for Client
+            with_buffer_impl_methods.push(quote! {
+                async fn #with_buffer_ident(#receiver, ctx: &#krate::Context, req: #req_type, buffer: &#krate::Buffer) #output {
+                    self.ruapc_request(ctx, #krate::Request::WithBuffer(req, buffer), #method_name).await
                 }
             });
 
@@ -138,6 +162,19 @@ pub fn service(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
         impl #trait_ident for #krate::Client {
             #(#client_methods)*
+        }
+
+        /// Extension trait providing `_with_buffer` variants for each method.
+        ///
+        /// These methods allow attaching a registered memory [`Buffer`] to the
+        /// request. The buffer's `RemoteBufferInfo` will be included in the
+        /// message metadata so the server can `remote_read` the buffer.
+        #visibility trait #with_buffer_trait_ident {
+            #(#with_buffer_trait_methods)*
+        }
+
+        impl #with_buffer_trait_ident for #krate::Client {
+            #(#with_buffer_impl_methods)*
         }
     }
     .into()

--- a/ruapc-rdma/src/verbs/queue_pair.rs
+++ b/ruapc-rdma/src/verbs/queue_pair.rs
@@ -27,7 +27,6 @@ pub struct QueuePair {
     recv_cq: Arc<CompletionQueue>,
     wrs: Mutex<HashMap<u64, Buffer>>,
     next_id: AtomicU64,
-    #[allow(dead_code)]
     pub device_index: DeviceIndex,
 }
 

--- a/ruapc/src/core/client.rs
+++ b/ruapc/src/core/client.rs
@@ -4,7 +4,7 @@ use serde_inline_default::serde_inline_default;
 use std::time::Duration;
 
 use crate::{
-    Context, SocketEndpoint, SocketTrait, SocketType,
+    Context, Request, SocketEndpoint, SocketTrait, SocketType,
     error::{Error, ErrorKind},
     msg::{MsgFlags, MsgMeta},
 };
@@ -22,7 +22,7 @@ use crate::{
 /// let addr = SocketAddr::from_str("127.0.0.1:8000").unwrap();
 /// let ctx = Context::create(&SocketPoolConfig::default()).unwrap().with_addr(addr);
 ///
-/// let rsp = client.echo(&ctx, &Request("hello".into())).await;
+/// let rsp = client.echo(&ctx, Request::Normal(&"hello".into())).await;
 /// ```
 #[serde_inline_default]
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
@@ -53,7 +53,7 @@ impl Client {
     /// This is the internal method used by service trait implementations to
     /// send requests and receive responses. It handles:
     /// - Socket acquisition from the context
-    /// - Request serialization
+    /// - Request serialization (and buffer info extraction if present)
     /// - Response waiting with timeout
     /// - Response deserialization
     ///
@@ -66,7 +66,7 @@ impl Client {
     /// # Arguments
     ///
     /// * `ctx` - The RPC context containing connection information
-    /// * `req` - The request to send
+    /// * `req` - The request to send, wrapped in [`Request`]
     /// * `method_name` - The name of the RPC method to invoke
     ///
     /// # Errors
@@ -85,7 +85,7 @@ impl Client {
     pub async fn ruapc_request<Req, Rsp, E>(
         &self,
         ctx: &Context,
-        req: &Req,
+        req: Request<'_, Req>,
         method_name: &str,
     ) -> std::result::Result<Rsp, E>
     where
@@ -120,13 +120,25 @@ impl Client {
             flags |= MsgFlags::UseMessagePack;
         }
 
+        // Extract buffer info if the request carries a buffer.
+        let buffer_info = if let Some(buf) = req.buffer() {
+            let device_index = socket.device_index(&ctx.state);
+            Some(
+                buf.remote_buffer_info(&device_index)
+                    .map_err(|e| Error::new(ErrorKind::InvalidArgument, e.to_string()))?,
+            )
+        } else {
+            None
+        };
+
         let (msgid, receiver) = ctx.state.waiter.alloc();
         let mut meta = MsgMeta {
             method: method_name.into(),
             flags,
             msgid,
+            buffer_info,
         };
-        socket.send(&mut meta, req, &ctx.state).await?;
+        socket.send(&mut meta, req.inner(), &ctx.state).await?;
 
         // 3. recv response with timeout.
         if let Ok(result) = tokio::time::timeout(self.timeout, receiver.recv()).await {

--- a/ruapc/src/core/mod.rs
+++ b/ruapc/src/core/mod.rs
@@ -4,6 +4,9 @@ pub use client::Client;
 mod context;
 pub use context::{Context, SocketEndpoint};
 
+mod request;
+pub use request::Request;
+
 mod server;
 pub use server::Server;
 

--- a/ruapc/src/core/request.rs
+++ b/ruapc/src/core/request.rs
@@ -1,0 +1,116 @@
+use crate::Buffer;
+
+/// RPC request wrapper that optionally carries a registered memory buffer.
+///
+/// `Request` is the standard way to pass request data to RPC methods.
+/// It supports two modes:
+///
+/// - `Normal(&T)`: A standard request containing only serializable data.
+/// - `WithBuffer(&T, &Buffer)`: A request that additionally carries a reference
+///   to a registered memory buffer. The buffer's `RemoteBufferInfo` will be
+///   automatically attached to the message metadata during serialization, so the
+///   server can perform `remote_read` on the client's buffer.
+///
+/// # Lifetime
+///
+/// The lifetime parameter `'a` ties the request data and buffer to their
+/// owning scope. This guarantees at compile time that the buffer remains
+/// alive for the entire duration of the RPC call (across `.await` points),
+/// preventing use-after-free in RDMA and TCP remote memory operations.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Normal request (no buffer)
+/// let rsp = client.echo(&ctx, Request::Normal(&my_req)).await?;
+///
+/// // Request with buffer
+/// let buf = pool.allocate()?;
+/// buf[..data.len()].copy_from_slice(data);
+/// let rsp = client.upload(&ctx, Request::WithBuffer(&my_req, &buf)).await?;
+/// // buf is guaranteed alive until here
+/// ```
+pub enum Request<'a, T> {
+    /// A standard request with no attached buffer.
+    Normal(&'a T),
+    /// A request with an attached registered memory buffer.
+    /// The buffer's remote info will be included in the message metadata.
+    WithBuffer(&'a T, &'a Buffer),
+}
+
+impl<T> Request<'_, T> {
+    /// Returns a reference to the inner request payload.
+    pub fn inner(&self) -> &T {
+        match self {
+            Request::Normal(t) => t,
+            Request::WithBuffer(t, _) => t,
+        }
+    }
+
+    /// Returns the attached buffer, if any.
+    pub fn buffer(&self) -> Option<&Buffer> {
+        match self {
+            Request::Normal(_) => None,
+            Request::WithBuffer(_, buf) => Some(buf),
+        }
+    }
+}
+
+impl<T> std::ops::Deref for Request<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.inner()
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Request<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Request::Normal(t) => f.debug_tuple("Request::Normal").field(t).finish(),
+            Request::WithBuffer(t, buf) => f
+                .debug_struct("Request::WithBuffer")
+                .field("inner", t)
+                .field("buffer", buf)
+                .finish(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_normal_inner() {
+        let val = 42u64;
+        let req = Request::Normal(&val);
+        assert_eq!(*req.inner(), 42);
+        assert!(req.buffer().is_none());
+        let debug = format!("{:?}", req);
+        assert!(debug.contains("Normal"));
+    }
+
+    #[test]
+    fn test_request_normal_deref() {
+        let val = String::from("hello");
+        let req = Request::Normal(&val);
+        // Deref to &String
+        assert_eq!(req.len(), 5);
+    }
+
+    #[test]
+    fn test_request_with_buffer() {
+        use crate::{BufferPool, Devices};
+        use std::sync::Arc;
+        let devices = Arc::new(Devices::default());
+        let pool = BufferPool::new(devices, 4096, 4096, 0);
+        let buf = pool.allocate().unwrap();
+        let val = 42u64;
+        let req = Request::WithBuffer(&val, &buf);
+        assert_eq!(*req.inner(), 42);
+        assert!(req.buffer().is_some());
+        let debug = format!("{:?}", req);
+        assert!(debug.contains("WithBuffer"));
+    }
+}

--- a/ruapc/src/core/state.rs
+++ b/ruapc/src/core/state.rs
@@ -164,6 +164,7 @@ mod tests {
                 method: "any/method".into(),
                 flags: MsgFlags::empty(),
                 msgid: 0,
+                buffer_info: None,
             },
             payload: Payload::Empty,
         };

--- a/ruapc/src/lib.rs
+++ b/ruapc/src/lib.rs
@@ -10,7 +10,9 @@ mod msg;
 pub use msg::{Message, MsgFlags, MsgMeta, Payload};
 
 mod core;
-pub use core::{Client, Context, Listener, MethodInfo, Router, Server, SocketEndpoint, State};
+pub use core::{
+    Client, Context, Listener, MethodInfo, Request, Router, Server, SocketEndpoint, State,
+};
 
 mod task;
 pub(crate) use task::Receiver;

--- a/ruapc/src/msg/message.rs
+++ b/ruapc/src/msg/message.rs
@@ -4,6 +4,8 @@ use bitflags::bitflags;
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 
+use ruapc_bufpool::RemoteBufferInfo;
+
 use crate::{
     Payload,
     error::{Error, ErrorKind, Result},
@@ -44,6 +46,11 @@ pub struct MsgMeta {
     pub flags: MsgFlags,
     /// Message ID for correlating requests and responses.
     pub msgid: u64,
+    /// Optional remote buffer information attached by the client.
+    /// Present when the client sends a `Request::WithBuffer`, allowing the server
+    /// to perform `remote_read` on the client's registered memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub buffer_info: Option<RemoteBufferInfo>,
 }
 
 impl MsgMeta {
@@ -358,6 +365,7 @@ mod tests {
             method: method.to_string(),
             flags,
             msgid: 42,
+            buffer_info: None,
         }
     }
 
@@ -448,6 +456,7 @@ mod tests {
             method: "Svc/method".into(),
             flags: MsgFlags::IsRsp,
             msgid: 7,
+            buffer_info: None,
         };
         let payload = crate::Payload::from(bytes::Bytes::from_static(b"data"));
         let msg2 = Message::new(meta, payload);

--- a/ruapc/src/rdma/rdma_socket.rs
+++ b/ruapc/src/rdma/rdma_socket.rs
@@ -11,6 +11,7 @@ use crate::{
     error::{ErrorKind, Result},
     msg::MsgMeta,
     rdma::event_loop::SendMsg,
+    services::MetaService,
     {Buffer, BufferPool},
 };
 
@@ -144,11 +145,26 @@ impl SocketTrait for RdmaSocket {
 
     async fn remote_read(
         &self,
-        _ctx: &Context,
+        ctx: &Context,
         local: Buffer,
         remote: &RemoteBufferInfo,
     ) -> Result<Buffer> {
-        self.remote_op(local, remote, true).await
+        let local = self.remote_op(local, remote, true).await?;
+
+        // After RDMA Read completes, verify the client's original request is still
+        // alive. If the client has timed out, the buffer may have been reclaimed
+        // and the data read via RDMA could be invalid.
+        let msgid = ctx.msg_meta.msgid;
+        let client = crate::Client::default();
+        let still_waiting: bool = client.is_message_waiting(ctx, &msgid).await?;
+        if !still_waiting {
+            return Err(Error::new(
+                ErrorKind::Timeout,
+                "RDMA read completed but client request has already timed out".into(),
+            ));
+        }
+
+        Ok(local)
     }
 
     async fn remote_write(

--- a/ruapc/src/services/memory_service.rs
+++ b/ruapc/src/services/memory_service.rs
@@ -5,11 +5,19 @@ use serde::{Deserialize, Serialize};
 use crate::{Context, Result};
 
 /// Request to read from a remote memory region.
+///
+/// After reading, the service verifies that the original request (identified
+/// by `msgid`) is still being awaited. If the request has already timed out,
+/// the data is discarded and a Timeout error is returned, since the buffer
+/// may have been reclaimed.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct MemoryReadReq {
     pub key: MemoryKey,
     pub addr: u64,
     pub len: u64,
+    /// Message ID of the original request. Used to verify the request
+    /// is still alive after reading, ensuring the buffer data is valid.
+    pub msgid: u64,
 }
 
 /// Request to write to a remote memory region.
@@ -28,6 +36,10 @@ pub struct MemoryWriteReq {
 #[ruapc_macro::service]
 pub trait MemoryService {
     /// Reads data from a registered memory region over TCP.
+    ///
+    /// If `req.msgid` is set, first verifies that the original request
+    /// is still alive (not timed out) before reading. This ensures the
+    /// buffer hasn't been reclaimed.
     async fn tcp_read(&self, ctx: &Context, req: &MemoryReadReq) -> Result<Vec<u8>>;
 
     /// Writes data to a registered memory region over TCP.
@@ -39,11 +51,24 @@ pub struct MemoryServiceImpl;
 
 impl MemoryService for MemoryServiceImpl {
     async fn tcp_read(&self, ctx: &Context, req: &MemoryReadReq) -> Result<Vec<u8>> {
-        ctx.state
+        let data = ctx
+            .state
             .devices
             .tcp_device()
             .read_memory(req.key.lkey, req.addr, req.len)
-            .map_err(|e| crate::Error::new(crate::ErrorKind::InvalidArgument, e.to_string()))
+            .map_err(|e| crate::Error::new(crate::ErrorKind::InvalidArgument, e.to_string()))?;
+
+        // After reading, verify the original request is still alive.
+        // If the client has timed out, the buffer may have been reclaimed
+        // and the data we just read could be invalid.
+        if !ctx.state.waiter.contains_message_id(req.msgid) {
+            return Err(crate::Error::new(
+                crate::ErrorKind::Timeout,
+                "tcp_read: original request has already timed out, data discarded".into(),
+            ));
+        }
+
+        Ok(data)
     }
 
     async fn tcp_write(&self, ctx: &Context, req: &MemoryWriteReq) -> Result<()> {

--- a/ruapc/src/sockets/http/http_socket_pool.rs
+++ b/ruapc/src/sockets/http/http_socket_pool.rs
@@ -196,6 +196,7 @@ impl HttpSocketPool {
             method: req.uri().path().trim_start_matches('/').to_string(),
             flags: MsgFlags::IsReq,
             msgid,
+            buffer_info: None,
         };
         let bytes = match req.into_body().collect().await {
             Ok(collected) => collected.to_bytes(),

--- a/ruapc/src/sockets/socket.rs
+++ b/ruapc/src/sockets/socket.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ruapc_bufpool::RemoteBufferInfo;
+use ruapc_bufpool::{DeviceIndex, RemoteBufferInfo};
 use serde::Serialize;
 
 use crate::{
@@ -76,10 +76,13 @@ pub trait SocketTrait {
         mut local: Buffer,
         remote: &RemoteBufferInfo,
     ) -> Result<Buffer> {
+        // Pass msgid so that tcp_read on the client side verifies
+        // the original request is still alive after reading the buffer.
         let req = MemoryReadReq {
             key: remote.key,
             addr: remote.addr,
             len: remote.len,
+            msgid: ctx.msg_meta.msgid,
         };
         let client = crate::Client::default();
         let data: Vec<u8> = client.tcp_read(ctx, &req).await?;
@@ -111,6 +114,22 @@ pub trait SocketTrait {
         let client = crate::Client::default();
         client.tcp_write(ctx, &req).await?;
         Ok(local)
+    }
+}
+
+impl Socket {
+    /// Returns the device index associated with this socket.
+    ///
+    /// TCP, WebSocket, and HTTP sockets use the TCP device (looked up from state).
+    /// RDMA sockets use the device associated with their QueuePair.
+    pub fn device_index(&self, state: &State) -> DeviceIndex {
+        match self {
+            Socket::TCP(_) | Socket::WS(_) | Socket::HTTP(_) => {
+                ruapc_bufpool::Device::index(state.devices.tcp_device())
+            }
+            #[cfg(feature = "rdma")]
+            Socket::RDMA(rdma_socket) => rdma_socket.queue_pair.device_index,
+        }
     }
 }
 

--- a/ruapc/tests/test_remote_read.rs
+++ b/ruapc/tests/test_remote_read.rs
@@ -1,0 +1,200 @@
+#![feature(return_type_notation)]
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ruapc::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// ==========================================================================
+// Service definition
+// ==========================================================================
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct ReadReq {
+    expected_len: usize,
+    #[serde(default)]
+    delay_ms: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+struct ReadRsp {
+    data: Vec<u8>,
+}
+
+#[service]
+trait RemoteReadService {
+    async fn read_buf(&self, ctx: &Context, req: &ReadReq) -> Result<ReadRsp>;
+}
+
+struct RemoteReadServiceImpl;
+
+impl RemoteReadService for RemoteReadServiceImpl {
+    async fn read_buf(&self, ctx: &Context, req: &ReadReq) -> Result<ReadRsp> {
+        if req.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(req.delay_ms)).await;
+        }
+        let buffer_info = ctx
+            .msg_meta
+            .buffer_info
+            .as_ref()
+            .expect("expected buffer_info in msg_meta");
+        let local_buf = ctx.state.buffer_pool.allocate().unwrap();
+        let local_buf = ctx.remote_read(buffer_info, local_buf).await?;
+        Ok(ReadRsp {
+            data: local_buf[..req.expected_len].to_vec(),
+        })
+    }
+}
+
+// ==========================================================================
+// Test framework
+// ==========================================================================
+
+struct TestCase {
+    /// Data to fill into the client buffer. If empty, buffer is left zeroed.
+    data: &'static [u8],
+    /// How many bytes the server should read from the buffer.
+    expected_len: usize,
+    /// Server-side delay before performing remote_read (ms).
+    delay_ms: u64,
+    /// Client timeout duration.
+    client_timeout: Duration,
+    /// Client socket type.
+    socket_type: SocketType,
+    /// Expected outcome: Ok(data) or Err(error_kind).
+    expect: Expected,
+}
+
+enum Expected {
+    /// Expect success and verify returned data matches `TestCase::data`.
+    Ok,
+    /// Expect failure with this error kind.
+    Err(ErrorKind),
+}
+
+async fn run_test(tc: TestCase) {
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+    };
+    let mut router = Router::default();
+    Arc::new(RemoteReadServiceImpl).ruapc_export(&mut router);
+    let server = Server::create(router, &config).unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+    let ctx = Context::create(&config).unwrap().with_addr(addr);
+
+    let mut buf = ctx.state.buffer_pool.allocate().unwrap();
+    if !tc.data.is_empty() {
+        buf[..tc.data.len()].copy_from_slice(tc.data);
+    }
+
+    let client = Client {
+        socket_type: Some(tc.socket_type),
+        timeout: tc.client_timeout,
+        ..Default::default()
+    };
+    let req = ReadReq {
+        expected_len: tc.expected_len,
+        delay_ms: tc.delay_ms,
+    };
+
+    let result: Result<ReadRsp> = client.read_buf_with_buffer(&ctx, &req, &buf).await;
+
+    match tc.expect {
+        Expected::Ok => {
+            let rsp = result.unwrap();
+            assert_eq!(rsp.data, tc.data);
+        }
+        Expected::Err(expected_kind) => {
+            let err = result.unwrap_err();
+            assert_eq!(err.kind, expected_kind);
+        }
+    }
+
+    // Allow server to finish processing before shutdown.
+    if tc.delay_ms > tc.client_timeout.as_millis() as u64 {
+        tokio::time::sleep(Duration::from_millis(tc.delay_ms + 100)).await;
+    }
+
+    server.stop();
+    tokio::time::timeout(Duration::from_secs(30), server.join())
+        .await
+        .unwrap();
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+#[tokio::test]
+async fn test_tcp_uuid_validation_success() {
+    run_test(TestCase {
+        data: b"uuid-check-pass",
+        expected_len: 15,
+        delay_ms: 50,
+        client_timeout: Duration::from_secs(5),
+        socket_type: SocketType::TCP,
+        expect: Expected::Ok,
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_tcp_uuid_validation_timeout() {
+    run_test(TestCase {
+        data: b"uuid-check-fail",
+        expected_len: 15,
+        delay_ms: 200,
+        client_timeout: Duration::from_millis(100),
+        socket_type: SocketType::TCP,
+        expect: Expected::Err(ErrorKind::Timeout),
+    })
+    .await;
+}
+
+/// When expected_len exceeds the buffer capacity, the server handler panics
+/// (slice out of bounds), no response is sent, and the client times out.
+#[tokio::test]
+async fn test_tcp_remote_read_expected_len_exceeds_buffer() {
+    run_test(TestCase {
+        data: b"",
+        expected_len: 3 * 1024 * 1024, // Exceeds 4 KiB local_buf
+        delay_ms: 0,
+        client_timeout: Duration::from_millis(500),
+        socket_type: SocketType::TCP,
+        expect: Expected::Err(ErrorKind::Timeout),
+    })
+    .await;
+}
+
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn test_rdma_uuid_validation_success() {
+    run_test(TestCase {
+        data: b"rdma-uuid-pass",
+        expected_len: 14,
+        delay_ms: 50,
+        client_timeout: Duration::from_secs(5),
+        socket_type: SocketType::RDMA,
+        expect: Expected::Ok,
+    })
+    .await;
+}
+
+#[cfg(feature = "rdma")]
+#[tokio::test]
+async fn test_rdma_uuid_validation_timeout() {
+    run_test(TestCase {
+        data: b"rdma-uuid-fail",
+        expected_len: 14,
+        delay_ms: 200,
+        client_timeout: Duration::from_millis(100),
+        socket_type: SocketType::RDMA,
+        expect: Expected::Err(ErrorKind::Timeout),
+    })
+    .await;
+}

--- a/ruapc/tests/test_remote_rw.rs
+++ b/ruapc/tests/test_remote_rw.rs
@@ -2,46 +2,16 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use ruapc::*;
 use ruapc_bufpool::RemoteBufferInfo;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Client sends its RemoteBufferInfo to the server.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-struct RemoteReadReq {
-    info: RemoteBufferInfo,
-}
-
-/// Server returns the data it read from the client's buffer.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-struct RemoteReadRsp {
-    data: Vec<u8>,
-}
-
-#[service]
-trait ReadTestService {
-    async fn read_remote(&self, ctx: &Context, req: &RemoteReadReq) -> Result<RemoteReadRsp>;
-}
-
-struct ReadTestImpl;
-
-impl ReadTestService for ReadTestImpl {
-    async fn read_remote(&self, ctx: &Context, req: &RemoteReadReq) -> Result<RemoteReadRsp> {
-        // Allocate a local buffer from the shared buffer pool.
-        let mut local_buf = ctx.state.buffer_pool.allocate().unwrap();
-
-        // Remote read: pull data from the client's registered memory.
-        local_buf = ctx.remote_read(&req.info, local_buf).await?;
-
-        // Return the data we read.
-        let len = req.info.len as usize;
-        Ok(RemoteReadRsp {
-            data: local_buf[..len].to_vec(),
-        })
-    }
-}
+// ==========================================================================
+// Service definition
+// ==========================================================================
 
 /// Client sends RemoteBufferInfo + data for the server to write.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -59,85 +29,55 @@ struct WriteTestImpl;
 
 impl WriteTestService for WriteTestImpl {
     async fn write_remote(&self, ctx: &Context, req: &RemoteWriteReq) -> Result<()> {
-        // Allocate a local buffer from the shared buffer pool, fill with data.
         let mut local_buf = ctx.state.buffer_pool.allocate().unwrap();
         local_buf[..req.data.len()].copy_from_slice(&req.data);
-
-        // Remote write: push data to the client's registered memory.
         let local_buf = ctx.remote_write(&req.info, local_buf).await?;
         drop(local_buf);
-
         Ok(())
     }
 }
 
-#[tokio::test]
-async fn test_tcp_remote_read() {
-    let config = SocketPoolConfig::default();
+// ==========================================================================
+// Helpers
+// ==========================================================================
 
-    // Set up server with ReadTestService.
-    let read_svc = Arc::new(ReadTestImpl);
-    let mut router = Router::default();
-    read_svc.ruapc_export(&mut router);
-    let server = Server::create(router, &config).unwrap();
-    let server = Arc::new(server);
-    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
-    let addr = server.clone().listen(addr).await.unwrap();
-
-    // Set up client context (devices are auto-discovered from config).
-    let ctx = Context::create(&config).unwrap();
-    let ctx = ctx.with_addr(addr);
-
-    // Allocate client buffer and fill with test data.
-    let mut client_buf = ctx.state.buffer_pool.allocate().unwrap();
-    let test_data = b"Hello, Remote Read!";
-    client_buf[..test_data.len()].copy_from_slice(test_data);
-
-    // Get RemoteBufferInfo for the client's buffer (use first device = TCP).
-    let client_device = ctx.state.devices.tcp_device();
-    let rbi = client_buf.remote_buffer_info(client_device).unwrap();
-    let rbi_for_req = RemoteBufferInfo {
-        key: rbi.key,
-        addr: rbi.addr,
-        len: test_data.len() as u64,
-    };
-
-    // Call the server's ReadTestService — it will reverse-RPC to read our buffer.
-    let client = Client::default();
-    let rsp: RemoteReadRsp = client
-        .read_remote(&ctx, &RemoteReadReq { info: rbi_for_req })
-        .await
-        .unwrap();
-
-    assert_eq!(rsp.data, test_data);
-
-    server.stop();
-    server.join().await;
+struct TestEnv {
+    ctx: Context,
+    server: Arc<Server>,
 }
+
+impl TestEnv {
+    async fn start(config: &SocketPoolConfig) -> Self {
+        let mut router = Router::default();
+        Arc::new(WriteTestImpl).ruapc_export(&mut router);
+        let server = Server::create(router, config).unwrap();
+        let server = Arc::new(server);
+        let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+        let addr = server.clone().listen(addr).await.unwrap();
+        let ctx = Context::create(config).unwrap().with_addr(addr);
+        Self { ctx, server }
+    }
+
+    async fn stop(self) {
+        self.server.stop();
+        tokio::time::timeout(Duration::from_secs(30), self.server.join())
+            .await
+            .unwrap();
+    }
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
 
 #[tokio::test]
 async fn test_tcp_remote_write() {
-    let config = SocketPoolConfig::default();
+    let env = TestEnv::start(&SocketPoolConfig::default()).await;
 
-    // Set up server with WriteTestService.
-    let write_svc = Arc::new(WriteTestImpl);
-    let mut router = Router::default();
-    write_svc.ruapc_export(&mut router);
-    let server = Server::create(router, &config).unwrap();
-    let server = Arc::new(server);
-    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
-    let addr = server.clone().listen(addr).await.unwrap();
-
-    // Set up client context.
-    let ctx = Context::create(&config).unwrap();
-    let ctx = ctx.with_addr(addr);
-
-    // Allocate client buffer (initially zeroed by the allocator).
-    let client_buf = ctx.state.buffer_pool.allocate().unwrap();
+    let client_buf = env.ctx.state.buffer_pool.allocate().unwrap();
     assert!(client_buf[..10].iter().all(|&b| b == 0));
 
-    // Get RemoteBufferInfo for the client's buffer.
-    let client_device = ctx.state.devices.tcp_device();
+    let client_device = env.ctx.state.devices.tcp_device();
     let rbi = client_buf.remote_buffer_info(client_device).unwrap();
     let write_data = b"Hello, Remote Write!";
     let rbi_for_req = RemoteBufferInfo {
@@ -146,11 +86,10 @@ async fn test_tcp_remote_write() {
         len: write_data.len() as u64,
     };
 
-    // Call the server's WriteTestService — it will reverse-RPC to write to our buffer.
     let client = Client::default();
     client
         .write_remote(
-            &ctx,
+            &env.ctx,
             &RemoteWriteReq {
                 info: rbi_for_req,
                 data: write_data.to_vec(),
@@ -158,71 +97,9 @@ async fn test_tcp_remote_write() {
         )
         .await
         .unwrap();
-
-    // Verify the data was written to our buffer.
     assert_eq!(&client_buf[..write_data.len()], write_data);
 
-    server.stop();
-    server.join().await;
-}
-
-#[cfg(feature = "rdma")]
-#[tokio::test]
-async fn test_rdma_remote_read() {
-    let config = SocketPoolConfig {
-        socket_type: SocketType::UNIFIED,
-    };
-
-    // Set up server with ReadTestService.
-    let read_svc = Arc::new(ReadTestImpl);
-    let mut router = Router::default();
-    read_svc.ruapc_export(&mut router);
-    let server = Server::create(router, &config).unwrap();
-    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
-    let addr = server.listen(addr).await.unwrap();
-
-    // Set up client context (RDMA devices auto-discovered).
-    let ctx = Context::create(&config).unwrap();
-    let ctx = ctx.with_addr(addr);
-
-    // Find the RDMA device for buffer registration.
-    let rdma_device = ctx
-        .state
-        .devices
-        .rdma_devices()
-        .iter()
-        .next()
-        .expect("no RDMA device discovered");
-
-    // Allocate client buffer and fill with test data.
-    let mut client_buf = ctx.state.buffer_pool.allocate().unwrap();
-    let test_data = b"Hello, RDMA Remote Read!";
-    client_buf[..test_data.len()].copy_from_slice(test_data);
-
-    // Get RemoteBufferInfo with RDMA key.
-    let rbi = client_buf.remote_buffer_info(rdma_device).unwrap();
-    let rbi_for_req = RemoteBufferInfo {
-        key: rbi.key,
-        addr: rbi.addr,
-        len: test_data.len() as u64,
-    };
-
-    // Use RDMA socket type for the RPC call.
-    let client = Client {
-        socket_type: Some(SocketType::RDMA),
-        ..Default::default()
-    };
-    let rsp: RemoteReadRsp = client
-        .read_remote(&ctx, &RemoteReadReq { info: rbi_for_req })
-        .await
-        .unwrap();
-
-    assert_eq!(rsp.data, test_data);
-
-    server.stop();
-    tokio::time::timeout(std::time::Duration::from_secs(30), server.join())
-        .await
-        .unwrap();
+    env.stop().await;
 }
 
 #[cfg(feature = "rdma")]
@@ -231,21 +108,10 @@ async fn test_rdma_remote_write() {
     let config = SocketPoolConfig {
         socket_type: SocketType::UNIFIED,
     };
+    let env = TestEnv::start(&config).await;
 
-    // Set up server with WriteTestService.
-    let write_svc = Arc::new(WriteTestImpl);
-    let mut router = Router::default();
-    write_svc.ruapc_export(&mut router);
-    let server = Server::create(router, &config).unwrap();
-    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
-    let addr = server.listen(addr).await.unwrap();
-
-    // Set up client context (RDMA devices auto-discovered).
-    let ctx = Context::create(&config).unwrap();
-    let ctx = ctx.with_addr(addr);
-
-    // Find the RDMA device.
-    let rdma_device = ctx
+    let rdma_device = env
+        .ctx
         .state
         .devices
         .rdma_devices()
@@ -253,11 +119,9 @@ async fn test_rdma_remote_write() {
         .next()
         .expect("no RDMA device discovered");
 
-    // Allocate client buffer (initially zeroed).
-    let client_buf = ctx.state.buffer_pool.allocate().unwrap();
+    let client_buf = env.ctx.state.buffer_pool.allocate().unwrap();
     assert!(client_buf[..10].iter().all(|&b| b == 0));
 
-    // Get RemoteBufferInfo with RDMA key.
     let rbi = client_buf.remote_buffer_info(rdma_device).unwrap();
     let write_data = b"Hello, RDMA Remote Write!";
     let rbi_for_req = RemoteBufferInfo {
@@ -266,14 +130,14 @@ async fn test_rdma_remote_write() {
         len: write_data.len() as u64,
     };
 
-    // Use RDMA socket type for the RPC call.
     let client = Client {
         socket_type: Some(SocketType::RDMA),
+        timeout: Duration::from_secs(5),
         ..Default::default()
     };
     client
         .write_remote(
-            &ctx,
+            &env.ctx,
             &RemoteWriteReq {
                 info: rbi_for_req,
                 data: write_data.to_vec(),
@@ -281,52 +145,7 @@ async fn test_rdma_remote_write() {
         )
         .await
         .unwrap();
-
-    // Verify the data was written to our buffer via RDMA Write.
     assert_eq!(&client_buf[..write_data.len()], write_data);
 
-    server.stop();
-    tokio::time::timeout(std::time::Duration::from_secs(30), server.join())
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn test_tcp_remote_read_bounds_check() {
-    let config = SocketPoolConfig::default();
-
-    // Set up server with ReadTestService.
-    let read_svc = Arc::new(ReadTestImpl);
-    let mut router = Router::default();
-    read_svc.ruapc_export(&mut router);
-    let server = Server::create(router, &config).unwrap();
-    let server = Arc::new(server);
-    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
-    let addr = server.clone().listen(addr).await.unwrap();
-
-    // Set up client context.
-    let ctx = Context::create(&config).unwrap();
-    let ctx = ctx.with_addr(addr);
-
-    let client_device = ctx.state.devices.tcp_device();
-    let client_buf = ctx.state.buffer_pool.allocate().unwrap();
-    let rbi = client_buf.remote_buffer_info(client_device).unwrap();
-
-    // Try to read beyond the buffer bounds.
-    let bad_rbi = RemoteBufferInfo {
-        key: rbi.key,
-        addr: rbi.addr,
-        len: (3 * 1024 * 1024) as u64, // Exceeds 2 MiB buffer
-    };
-
-    let client = Client::default();
-    let result: Result<RemoteReadRsp> = client
-        .read_remote(&ctx, &RemoteReadReq { info: bad_rbi })
-        .await;
-
-    // Should fail with a bounds error.
-    assert!(result.is_err());
-
-    server.stop();
-    server.join().await;
+    env.stop().await;
 }

--- a/ruapc/tests/test_request_with_buffer.rs
+++ b/ruapc/tests/test_request_with_buffer.rs
@@ -1,0 +1,193 @@
+#![feature(return_type_notation)]
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ruapc::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// --------------------------------------------------------------------------
+// Service: server reads client's buffer via remote_read
+// --------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct UploadReq {
+    expected_len: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+struct UploadRsp {
+    data: Vec<u8>,
+}
+
+#[service]
+trait UploadService {
+    async fn upload(&self, ctx: &Context, req: &UploadReq) -> Result<UploadRsp>;
+}
+
+struct UploadServiceImpl;
+
+impl UploadService for UploadServiceImpl {
+    async fn upload(&self, ctx: &Context, req: &UploadReq) -> Result<UploadRsp> {
+        // The server should see buffer_info in the message metadata.
+        let buffer_info = ctx.msg_meta.buffer_info.as_ref().expect(
+            "expected buffer_info in msg_meta — client should have used upload_with_buffer",
+        );
+
+        // Allocate a local buffer and remote_read the client's buffer.
+        let mut local_buf = ctx.state.buffer_pool.allocate().unwrap();
+        local_buf = ctx.remote_read(buffer_info, local_buf).await?;
+
+        // Return the data read from the client's buffer.
+        Ok(UploadRsp {
+            data: local_buf[..req.expected_len].to_vec(),
+        })
+    }
+}
+
+// --------------------------------------------------------------------------
+// Service: normal request (no buffer) — verify backwards compatibility
+// --------------------------------------------------------------------------
+
+#[service]
+trait PingService {
+    async fn ping(&self, ctx: &Context, req: &String) -> Result<String>;
+}
+
+struct PingServiceImpl;
+
+impl PingService for PingServiceImpl {
+    async fn ping(&self, ctx: &Context, _req: &String) -> Result<String> {
+        // Normal requests should NOT have buffer_info.
+        assert!(
+            ctx.msg_meta.buffer_info.is_none(),
+            "buffer_info should be None for normal requests"
+        );
+        Ok(format!("pong"))
+    }
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_upload_with_buffer_tcp() {
+    let upload_svc = Arc::new(UploadServiceImpl);
+    let ping_svc = Arc::new(PingServiceImpl);
+    let mut router = Router::default();
+    upload_svc.ruapc_export(&mut router);
+    ping_svc.ruapc_export(&mut router);
+
+    let config = SocketPoolConfig::default();
+    let server = Server::create(router, &config).unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    let ctx = Context::create(&config).unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    // 1. Test normal request (no buffer) — backwards compatibility.
+    let client = Client::default();
+    let rsp = client.ping(&ctx, &"hello".to_string()).await.unwrap();
+    assert_eq!(rsp, "pong");
+
+    // 2. Test upload_with_buffer — client sends buffer to server.
+    let test_data = b"Hello, WithBuffer!";
+    let mut buf = ctx.state.buffer_pool.allocate().unwrap();
+    buf[..test_data.len()].copy_from_slice(test_data);
+
+    let req = UploadReq {
+        expected_len: test_data.len(),
+    };
+
+    // Use the generated _with_buffer method.
+    let rsp: UploadRsp = client.upload_with_buffer(&ctx, &req, &buf).await.unwrap();
+    assert_eq!(rsp.data, test_data);
+
+    // 3. Verify the same buffer can be reused (retry scenario).
+    let rsp2: UploadRsp = client.upload_with_buffer(&ctx, &req, &buf).await.unwrap();
+    assert_eq!(rsp2.data, test_data);
+
+    // 4. Verify normal upload (without buffer) — should panic on server
+    //    because buffer_info is None. We expect an error.
+    let rsp3 = client.upload(&ctx, &req).await;
+    assert!(rsp3.is_err(), "upload without buffer should fail");
+
+    server.stop();
+    server.join().await;
+}
+
+#[tokio::test]
+async fn test_upload_with_buffer_websocket() {
+    let upload_svc = Arc::new(UploadServiceImpl);
+    let mut router = Router::default();
+    upload_svc.ruapc_export(&mut router);
+
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+    };
+    let server = Server::create(router, &config).unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    let ctx = Context::create(&config).unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    let test_data = b"WebSocket buffer test!";
+    let mut buf = ctx.state.buffer_pool.allocate().unwrap();
+    buf[..test_data.len()].copy_from_slice(test_data);
+
+    let client = Client {
+        socket_type: Some(SocketType::WS),
+        ..Default::default()
+    };
+    let req = UploadReq {
+        expected_len: test_data.len(),
+    };
+
+    let rsp: UploadRsp = client.upload_with_buffer(&ctx, &req, &buf).await.unwrap();
+    assert_eq!(rsp.data, test_data);
+
+    server.stop();
+    server.join().await;
+}
+
+#[tokio::test]
+async fn test_upload_with_buffer_http() {
+    let upload_svc = Arc::new(UploadServiceImpl);
+    let mut router = Router::default();
+    upload_svc.ruapc_export(&mut router);
+
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+    };
+    let server = Server::create(router, &config).unwrap();
+    let server = Arc::new(server);
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.clone().listen(addr).await.unwrap();
+
+    let ctx = Context::create(&config).unwrap();
+    let ctx = ctx.with_addr(addr);
+
+    let test_data = b"HTTP buffer test!";
+    let mut buf = ctx.state.buffer_pool.allocate().unwrap();
+    buf[..test_data.len()].copy_from_slice(test_data);
+
+    let client = Client {
+        socket_type: Some(SocketType::HTTP),
+        ..Default::default()
+    };
+    let req = UploadReq {
+        expected_len: test_data.len(),
+    };
+
+    let rsp: UploadRsp = client.upload_with_buffer(&ctx, &req, &buf).await.unwrap();
+    assert_eq!(rsp.data, test_data);
+
+    server.stop();
+    server.join().await;
+}


### PR DESCRIPTION
Introduce a mechanism for clients to safely attach registered memory buffers to RPC requests, with compile-time lifetime guarantees and runtime validation.

## Request<'a, T> and buffer_info propagation

- Define Request<'a, T> enum (Normal/WithBuffer) in ruapc core. The lifetime parameter ensures the buffer outlives the RPC .await, preventing use-after-free.
- Extend MsgMeta with an optional buffer_info: Option<RemoteBufferInfo> field.
- Client::ruapc_request extracts RemoteBufferInfo from the buffer (based on the socket's device) and attaches it to MsgMeta before sending.
- The #[service] macro generates a WithBuffer extension trait with _with_buffer methods for each service method, allowing callers to attach buffers.
- Server handlers access buffer_info via ctx.msg_meta.buffer_info and use the existing ctx.remote_read() to pull data from the client's memory.

## remote_read UUID validation

- TCP path: MemoryService::tcp_read now requires a msgid parameter. After reading the buffer data, it verifies the original request is still alive (waiter entry exists). If the client has timed out, the read is refused with a Timeout error. This check is atomic (no .await between read and validation).
- RDMA path: After RDMA Read completion, a reverse RPC (is_message_waiting) verifies the client request is still alive. If not, the data is discarded.

## Testing

- Add test_remote_read.rs with table-driven tests (TestCase struct) covering:
  - Basic remote_read (TCP/RDMA)
  - UUID validation success (client still alive)
  - UUID validation timeout (client already gone)
  - Buffer bounds exceeded
- Add test_request_with_buffer.rs validating the _with_buffer API across TCP, WebSocket, and HTTP transports.