### PR TITLE
refactor(bufpool): shrink BuddyBlock and simplify service registration

### DIFF
--- a/ruapc-bufpool/Cargo.toml
+++ b/ruapc-bufpool/Cargo.toml
@@ -15,10 +15,10 @@ aliasable.workspace = true
 dashmap.workspace = true
 schemars.workspace = true
 serde.workspace = true
-tokio = { workspace = true, features = ["sync", "macros", "time", "rt"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "macros", "time"] }
 
 [lints]
 workspace = true

--- a/ruapc-bufpool/src/buddy.rs
+++ b/ruapc-bufpool/src/buddy.rs
@@ -54,12 +54,10 @@ pub enum NodeState {
 }
 
 impl NodeState {
-    #[inline]
     pub const fn as_bits(self) -> u8 {
         self as u8
     }
 
-    #[inline]
     pub const fn from_bits(bits: u8) -> Self {
         match bits {
             0 => Self::Allocated,
@@ -75,10 +73,6 @@ impl NodeState {
 pub struct FreeNodeData {
     /// Pointer to the parent `BuddyBlock`.
     pub block: NonNull<BuddyBlock>,
-    /// Index of this block within the pool's block list.
-    pub block_index: usize,
-    /// Index within the level (0-based).
-    pub index_in_level: usize,
 }
 
 // SAFETY: FreeNodeData only contains NonNull which is Send if the pointed type is Send
@@ -104,76 +98,34 @@ pub struct BuddyBlock {
     /// Bit-packed allocation state for all nodes in the buddy tree.
     pub states: [u8; STATE_ARRAY_BYTES],
 
-    /// Free list nodes for level 0 (64 nodes of 1MiB each).
-    pub level0_nodes: [FreeNode; 64],
-
-    /// Free list nodes for level 1 (16 nodes of 4MiB each).
-    pub level1_nodes: [FreeNode; 16],
-
-    /// Free list nodes for level 2 (4 nodes of 16MiB each).
-    pub level2_nodes: [FreeNode; 4],
-
-    /// Free list node for level 3 (1 node of 64MiB).
-    pub level3_node: FreeNode,
+    /// Free list nodes for all levels, laid out as a flat array:
+    /// [level0: 64 nodes][level1: 16 nodes][level2: 4 nodes][level3: 1 node]
+    /// Use `LEVEL_STATE_OFFSETS[level] + index` to compute the flat index.
+    pub nodes: [FreeNode; TOTAL_STATE_NODES],
 }
 
 impl BuddyBlock {
     /// Creates a new `BuddyBlock` managing the given aligned memory.
     ///
-    /// `block_index` is the index of this block within the pool's block list.
     /// `registrations` are the device registrations for this memory region.
-    pub fn new(
-        memory: Arc<AlignedMemory>,
-        block_index: usize,
-        registrations: Vec<Box<dyn Registration>>,
-    ) -> Box<Self> {
-        const fn placeholder_data() -> FreeNodeData {
-            FreeNodeData {
-                block: NonNull::dangling(),
-                block_index: 0,
-                index_in_level: 0,
-            }
-        }
-
+    pub fn new(memory: Arc<AlignedMemory>, registrations: Vec<Box<dyn Registration>>) -> Box<Self> {
         let mut block = Box::new(Self {
             memory,
             registrations,
             states: [0u8; STATE_ARRAY_BYTES],
-            level0_nodes: std::array::from_fn(|_| FreeNode::new(placeholder_data())),
-            level1_nodes: std::array::from_fn(|_| FreeNode::new(placeholder_data())),
-            level2_nodes: std::array::from_fn(|_| FreeNode::new(placeholder_data())),
-            level3_node: FreeNode::new(placeholder_data()),
+            nodes: std::array::from_fn(|_| {
+                FreeNode::new(FreeNodeData {
+                    block: NonNull::dangling(),
+                })
+            }),
         });
 
         let block_ptr = NonNull::new(std::ptr::from_mut::<Self>(block.as_mut())).unwrap();
 
-        // Initialize all free list nodes with correct back-pointers
-        for (i, node) in block.level0_nodes.iter_mut().enumerate() {
-            node.data = FreeNodeData {
-                block: block_ptr,
-                block_index,
-                index_in_level: i,
-            };
+        // Initialize all free list nodes with correct back-pointer
+        for node in block.nodes.iter_mut() {
+            node.data = FreeNodeData { block: block_ptr };
         }
-        for (i, node) in block.level1_nodes.iter_mut().enumerate() {
-            node.data = FreeNodeData {
-                block: block_ptr,
-                block_index,
-                index_in_level: i,
-            };
-        }
-        for (i, node) in block.level2_nodes.iter_mut().enumerate() {
-            node.data = FreeNodeData {
-                block: block_ptr,
-                block_index,
-                index_in_level: i,
-            };
-        }
-        block.level3_node.data = FreeNodeData {
-            block: block_ptr,
-            block_index,
-            index_in_level: 0,
-        };
 
         // Initialize all states to Allocated (0x00) - already zeroed
         // Set root node to Free
@@ -184,27 +136,28 @@ impl BuddyBlock {
 
     /// Gets a mutable pointer to the free node for the given level and index.
     pub fn get_free_node_mut(&mut self, level: usize, index: usize) -> NonNull<FreeNode> {
-        let node = match level {
-            0 => &mut self.level0_nodes[index],
-            1 => &mut self.level1_nodes[index],
-            2 => &mut self.level2_nodes[index],
-            3 => {
-                debug_assert_eq!(index, 0);
-                &mut self.level3_node
-            }
-            _ => panic!("invalid level: {level}"),
-        };
-        NonNull::new(node).unwrap()
+        let flat_index = LEVEL_STATE_OFFSETS[level] + index;
+        NonNull::new(&mut self.nodes[flat_index]).unwrap()
+    }
+
+    /// Computes the index within a level from a node pointer.
+    ///
+    /// Given a node that was popped from `free_lists[level]`, returns its
+    /// index within that level by computing its offset in the flat `nodes` array.
+    pub fn node_index_in_level(&self, node: NonNull<FreeNode>, level: usize) -> usize {
+        let base = self.nodes.as_ptr() as usize;
+        let node_addr = node.as_ptr() as usize;
+        let flat_index = (node_addr - base) / std::mem::size_of::<FreeNode>();
+        debug_assert!(flat_index < TOTAL_STATE_NODES);
+        flat_index - LEVEL_STATE_OFFSETS[level]
     }
 
     /// Gets the state array index for a node at the given level and index.
-    #[inline]
     pub const fn state_index(level: usize, index: usize) -> usize {
         LEVEL_STATE_OFFSETS[level] + index
     }
 
     /// Gets the state of a node.
-    #[inline]
     pub const fn get_state(&self, level: usize, index: usize) -> NodeState {
         let idx = Self::state_index(level, index);
         let byte_idx = idx / 4;
@@ -215,7 +168,6 @@ impl BuddyBlock {
     }
 
     /// Sets the state of a node.
-    #[inline]
     pub const fn set_state(&mut self, level: usize, index: usize, state: NodeState) {
         let idx = Self::state_index(level, index);
         let byte_idx = idx / 4;
@@ -227,7 +179,6 @@ impl BuddyBlock {
     }
 
     /// Gets the memory address for a node at the given level and index.
-    #[inline]
     pub fn get_memory_addr(&self, level: usize, index: usize) -> *mut u8 {
         let offset = index * LEVEL_SIZES[level];
         unsafe { self.memory.as_mut_ptr().add(offset) }
@@ -235,7 +186,6 @@ impl BuddyBlock {
 
     /// Gets the parent level and index for a node.
     /// Returns `None` for level 3 (root) nodes.
-    #[inline]
     pub const fn get_parent(level: usize, index: usize) -> Option<(usize, usize)> {
         if level >= 3 {
             None
@@ -245,7 +195,6 @@ impl BuddyBlock {
     }
 
     /// Gets the sibling indices for a node (all 4 siblings including itself).
-    #[inline]
     pub const fn get_siblings(index: usize) -> [usize; 4] {
         let base = (index / 4) * 4;
         [base, base + 1, base + 2, base + 3]
@@ -253,7 +202,6 @@ impl BuddyBlock {
 
     /// Gets the first child index for a node.
     /// Returns `None` for level 0 (leaf) nodes.
-    #[inline]
     pub const fn get_first_child(level: usize, index: usize) -> Option<(usize, usize)> {
         if level == 0 {
             None
@@ -351,7 +299,7 @@ mod tests {
     #[test]
     fn test_buddy_block_creation() {
         let mem = Arc::new(crate::AlignedMemory::new(SIZE_64MIB).unwrap());
-        let block = BuddyBlock::new(mem, 0, Vec::new());
+        let block = BuddyBlock::new(mem, Vec::new());
 
         // Root is free
         assert_eq!(block.get_state(3, 0), NodeState::Free);
@@ -372,7 +320,7 @@ mod tests {
     fn test_memory_address_calculation() {
         let mem = Arc::new(crate::AlignedMemory::new(SIZE_64MIB).unwrap());
         let base = mem.as_mut_ptr();
-        let block = BuddyBlock::new(mem, 0, Vec::new());
+        let block = BuddyBlock::new(mem, Vec::new());
 
         assert_eq!(block.get_memory_addr(3, 0), base);
         assert_eq!(block.get_memory_addr(2, 0), base);

--- a/ruapc-bufpool/src/buffer.rs
+++ b/ruapc-bufpool/src/buffer.rs
@@ -1,11 +1,11 @@
 //! Buffer type that automatically returns to the pool on drop.
 
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use std::sync::Arc;
 
-use crate::buddy::{BuddyBlock, FreeNode};
+use crate::buddy::BuddyBlock;
 use crate::{AsDeviceIndex, BufferPool, MemoryKey, RemoteBufferInfo};
 
 /// A buffer allocated from the pool.
@@ -25,9 +25,6 @@ pub struct Buffer {
 
     /// Pointer to the buddy block this buffer belongs to.
     block: NonNull<BuddyBlock>,
-
-    /// Index of the block within the pool's block list (for registration lookup).
-    block_index: usize,
 
     /// Logical length of data in the buffer (may be less than capacity).
     len: usize,
@@ -62,20 +59,19 @@ impl Buffer {
         level: usize,
         index: usize,
         block: NonNull<BuddyBlock>,
-        block_index: usize,
         pool: Arc<BufferPool>,
     ) -> Self {
         debug_assert!(level < crate::buddy::NUM_LEVELS, "level must be 0-3");
         debug_assert!(
-            index < crate::buddy::NODES_PER_LEVEL[0],
-            "index must be less than 64"
+            index < crate::buddy::NODES_PER_LEVEL[level],
+            "index must be less than {}",
+            crate::buddy::NODES_PER_LEVEL[level]
         );
         let capacity = crate::buddy::LEVEL_SIZES[level];
         Self {
             ptr,
             pool,
             block,
-            block_index,
             len: capacity,
             #[allow(clippy::cast_possible_truncation)]
             level: level as u8,
@@ -87,7 +83,6 @@ impl Buffer {
     /// Returns the logical length of the buffer in bytes.
     ///
     /// Initially set to the full capacity. Use `set_len` to adjust.
-    #[inline]
     #[must_use]
     pub const fn len(&self) -> usize {
         self.len
@@ -99,14 +94,12 @@ impl Buffer {
     /// - Level 1: 4 MiB
     /// - Level 2: 16 MiB
     /// - Level 3: 64 MiB
-    #[inline]
     #[must_use]
     pub const fn capacity(&self) -> usize {
         crate::buddy::LEVEL_SIZES[self.level as usize]
     }
 
     /// Returns `true` if the buffer's logical length is 0.
-    #[inline]
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.len == 0
@@ -117,7 +110,6 @@ impl Buffer {
     /// # Panics
     ///
     /// Panics if `len` exceeds the buffer's capacity.
-    #[inline]
     pub fn set_len(&mut self, len: usize) {
         assert!(
             len <= self.capacity(),
@@ -157,60 +149,27 @@ impl Buffer {
     }
 
     /// Returns a raw pointer to the buffer's memory.
-    #[inline]
     #[must_use]
     pub const fn as_ptr(&self) -> *const u8 {
         self.ptr.as_ptr()
     }
 
     /// Returns a mutable raw pointer to the buffer's memory.
-    #[inline]
     #[must_use]
     pub const fn as_mut_ptr(&mut self) -> *mut u8 {
         self.ptr.as_ptr()
     }
 
     /// Returns the buffer as a byte slice (up to the logical length).
-    #[inline]
     #[must_use]
     pub const fn as_slice(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
 
     /// Returns the buffer as a mutable byte slice (up to the logical length).
-    #[inline]
     #[must_use]
     pub const fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
-    }
-
-    /// Returns the allocation level of this buffer (0-3).
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) const fn level(&self) -> usize {
-        self.level as usize
-    }
-
-    /// Returns the index within the level (0-63).
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) const fn index(&self) -> usize {
-        self.index as usize
-    }
-
-    /// Returns the buddy block pointer.
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) const fn block(&self) -> NonNull<BuddyBlock> {
-        self.block
-    }
-
-    /// Returns a pointer to the free node for this buffer.
-    #[allow(dead_code)]
-    pub(crate) unsafe fn free_node(&self) -> NonNull<FreeNode> {
-        unsafe {
-            (*self.block.as_ptr()).get_free_node_mut(self.level as usize, self.index as usize)
-        }
     }
 
     /// Returns the memory key for this buffer's underlying block on the given device.
@@ -219,7 +178,17 @@ impl Buffer {
     ///
     /// Returns an error if the device index is not registered.
     pub fn memory_key(&self, device_index: &impl AsDeviceIndex) -> Result<MemoryKey> {
-        self.pool.memory_key(self.block_index, device_index)
+        let idx = device_index.as_device_index();
+        unsafe { &*self.block.as_ptr() }
+            .registrations
+            .get(idx.index as usize)
+            .map(|r| r.memory_key())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("memory not registered on device index {}", idx.index),
+                )
+            })
     }
 
     /// Returns the remote buffer info for RDMA-style operations.
@@ -252,28 +221,24 @@ impl Drop for Buffer {
 impl Deref for Buffer {
     type Target = [u8];
 
-    #[inline]
     fn deref(&self) -> &Self::Target {
         self.as_slice()
     }
 }
 
 impl DerefMut for Buffer {
-    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_slice()
     }
 }
 
 impl AsRef<[u8]> for Buffer {
-    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 
 impl AsMut<[u8]> for Buffer {
-    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
     }

--- a/ruapc-bufpool/src/pool.rs
+++ b/ruapc-bufpool/src/pool.rs
@@ -186,27 +186,6 @@ impl BufferPool {
     pub fn devices(&self) -> &Arc<dyn Devices> {
         &self.devices
     }
-
-    /// Returns the memory key for a given block and device.
-    pub(crate) fn memory_key(
-        &self,
-        block_index: usize,
-        device_index: &impl crate::AsDeviceIndex,
-    ) -> Result<crate::MemoryKey> {
-        let inner = self.inner.lock().expect("BufferPool mutex poisoned");
-        let idx = device_index.as_device_index();
-        inner
-            .blocks
-            .get(block_index)
-            .and_then(|block| block.registrations.get(idx.index as usize))
-            .map(|r| r.memory_key())
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("memory not registered on device index {}", idx.index),
-                )
-            })
-    }
 }
 
 impl std::fmt::Debug for BufferPool {
@@ -285,14 +264,8 @@ impl PoolInner {
     ) -> Buffer {
         let node = self.free_lists[from_level].pop_front().unwrap();
 
-        let (block, block_index, index_in_level) = unsafe {
-            let node_ref = &*node.as_ptr();
-            (
-                node_ref.data.block,
-                node_ref.data.block_index,
-                node_ref.data.index_in_level,
-            )
-        };
+        let block = unsafe { (*node.as_ptr()).data.block };
+        let index_in_level = unsafe { (*block.as_ptr()).node_index_in_level(node, from_level) };
 
         let block_ref = unsafe { &mut *block.as_ptr() };
 
@@ -306,26 +279,17 @@ impl PoolInner {
                     from_level,
                     index_in_level,
                     block,
-                    block_index,
                     pool,
                 )
             }
         } else {
-            self.split_and_allocate(
-                block,
-                block_index,
-                from_level,
-                index_in_level,
-                target_level,
-                pool,
-            )
+            self.split_and_allocate(block, from_level, index_in_level, target_level, pool)
         }
     }
 
     fn split_and_allocate(
         &mut self,
         block: NonNull<BuddyBlock>,
-        block_index: usize,
         from_level: usize,
         from_index: usize,
         target_level: usize,
@@ -366,7 +330,6 @@ impl PoolInner {
                 current_level,
                 current_index,
                 block,
-                block_index,
                 pool,
             )
         }
@@ -383,10 +346,8 @@ impl PoolInner {
         // Register with all devices.
         let regs = devices.register(&aligned)?;
 
-        let block_index = self.blocks.len();
-
         // Create buddy block with memory and registrations.
-        let block = BuddyBlock::new(aligned, block_index, regs);
+        let block = BuddyBlock::new(aligned, regs);
 
         // Wrap in AliasableBox to allow aliasing via NonNull<BuddyBlock> in
         // Buffer and free-list nodes without violating noalias semantics.

--- a/ruapc/src/core/router.rs
+++ b/ruapc/src/core/router.rs
@@ -17,7 +17,7 @@ use crate::rdma::RdmaService;
 use crate::{
     Context, Payload,
     error::{Error, ErrorKind, Result},
-    services::MetaService,
+    services::{MemoryService, MetaService},
 };
 
 /// Type alias for service method handler functions.
@@ -74,9 +74,11 @@ impl Default for Router {
             methods: HashMap::default(),
             openapi: OpenAPI::default(),
         };
-        MetaService::ruapc_export(Arc::new(()), &mut this);
+        let dummy = Arc::new(());
+        MetaService::ruapc_export(dummy.clone(), &mut this);
+        MemoryService::ruapc_export(dummy.clone(), &mut this);
         #[cfg(feature = "rdma")]
-        RdmaService::ruapc_export(Arc::new(()), &mut this);
+        RdmaService::ruapc_export(dummy.clone(), &mut this);
         this
     }
 }

--- a/ruapc/src/core/state.rs
+++ b/ruapc/src/core/state.rs
@@ -5,7 +5,6 @@ use tokio_util::sync::DropGuard;
 use crate::{
     BufferPool, Context, Devices, Message, RawStream, Result, Router, Socket, SocketPool,
     SocketPoolConfig, Waiter,
-    services::{MemoryService, MemoryServiceImpl},
 };
 
 /// Shared state for the RPC system.
@@ -52,10 +51,6 @@ impl State {
 
         // Create a shared buffer pool backed by all discovered devices.
         let buffer_pool = ruapc_bufpool::BufferPoolBuilder::new(devices.clone()).build();
-
-        // Always register MemoryService for Remote Read/Write support.
-        let mem_svc = Arc::new(MemoryServiceImpl);
-        mem_svc.ruapc_export(&mut router);
 
         router.build_open_api()?;
         let socket_pool = SocketPool::create(config, &devices, &buffer_pool)?;

--- a/ruapc/src/services/memory_service.rs
+++ b/ruapc/src/services/memory_service.rs
@@ -76,10 +76,7 @@ pub trait MemoryService {
     async fn rdma_pull(&self, ctx: &Context, req: &MemoryPullReq) -> Result<()>;
 }
 
-/// Implementation of MemoryService backed by a Devices collection.
-pub struct MemoryServiceImpl;
-
-impl MemoryService for MemoryServiceImpl {
+impl MemoryService for () {
     async fn tcp_read(&self, ctx: &Context, req: &MemoryReadReq) -> Result<Vec<u8>> {
         let data = ctx
             .state

--- a/ruapc/src/services/mod.rs
+++ b/ruapc/src/services/mod.rs
@@ -9,6 +9,4 @@ mod meta_service;
 pub use meta_service::{MetaService, Metadata};
 
 mod memory_service;
-pub use memory_service::{
-    MemoryPullReq, MemoryPushReq, MemoryReadReq, MemoryService, MemoryServiceImpl,
-};
+pub use memory_service::{MemoryPullReq, MemoryPushReq, MemoryReadReq, MemoryService};


### PR DESCRIPTION
- Remove FreeNodeData::block_index and index_in_level fields; compute index_in_level from node pointer arithmetic against the flat nodes array
- Merge per-level node arrays into a single nodes: [FreeNode; 85], reducing BuddyBlock size by ~25% (2774B -> 2094B)
- Remove BufferPool::memory_key indirection: Buffer::memory_key now reads registrations directly from BuddyBlock via NonNull (no mutex needed)
- Replace MemoryServiceImpl with impl MemoryService for () and register in Router::default() alongside MetaService for self-contained routing
- Move tokio time/macros/rt features to dev-dependencies only