### PR TITLE
feat(ruapc-rdma): add bin feature with ibv_devinfo Rust binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         ibv_devinfo -d rxe_0 -v
         cargo fmt -- --check
         cargo clippy --release -- -D warnings
-        cargo llvm-cov --all-features --ignore-filename-regex "ruapc-demo/*|ruapc-macro/*|ruapc/src/bin/*" --cobertura --output-path cobertura.xml
+        cargo llvm-cov --all-features --ignore-filename-regex "ruapc-demo/*|ruapc-macro/*|ruapc/src/bin/*|ruapc-rdma/src/bin/*" --cobertura --output-path cobertura.xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-rdma"
-version = "0.1.2"
+version = "0.1.4"
 description = "Low-level FFI bindings to libibverbs with type-safe device management for RDMA operations"
 authors.workspace = true
 edition.workspace = true
@@ -8,11 +8,20 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[features]
+bin = ["dep:clap"]
+
 [dependencies]
+clap = { workspace = true, optional = true }
 libc.workspace = true
 ruapc-bufpool = { path = "../ruapc-bufpool" }
 schemars.workspace = true
 serde.workspace = true
+
+[[bin]]
+name = "ibv_devinfo"
+path = "src/bin/ibv_devinfo.rs"
+required-features = ["bin"]
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/ruapc-rdma/build.rs
+++ b/ruapc-rdma/build.rs
@@ -22,8 +22,15 @@ impl ParseCallbacks for CustomDerive {
     /// These types need JSON serialization support for the ruapc project
     fn add_derives(&self, info: &DeriveInfo<'_>) -> Vec<String> {
         match info.name {
-            "ibv_device_attr" | "ibv_atomic_cap" | "ibv_port_state" | "ibv_mtu"
-            | "ibv_port_cap_flags" | "ibv_port_attr" => {
+            "ibv_device_attr"
+            | "ibv_atomic_cap"
+            | "ibv_port_state"
+            | "ibv_mtu"
+            | "ibv_port_cap_flags"
+            | "ibv_port_cap_flags2"
+            | "ibv_port_attr"
+            | "ibv_transport_type"
+            | "ibv_device_cap_flags" => {
                 vec![
                     "Serialize".to_string(),
                     "Deserialize".to_string(),
@@ -63,6 +70,10 @@ fn replace_custom_types(input: &str) -> String {
                                         field.ty = syn::parse_str("Guid")
                                             .expect("Failed to parse Guid type");
                                     }
+                                    "device_cap_flags" => {
+                                        field.ty = syn::parse_str("ibv_device_cap_flags")
+                                            .expect("Failed to parse ibv_device_cap_flags type");
+                                    }
                                     _ => {}
                                 }
                             }
@@ -72,11 +83,22 @@ fn replace_custom_types(input: &str) -> String {
                 "ibv_port_attr" => {
                     if let syn::Fields::Named(ref mut fields) = struct_item.fields {
                         for field in fields.named.iter_mut() {
-                            if let Some(ident) = &field.ident
-                                && ident == "link_layer"
-                            {
-                                field.ty = syn::parse_str("LinkLayer")
-                                    .expect("Failed to parse LinkLayer type");
+                            if let Some(ident) = &field.ident {
+                                match ident.to_string().as_str() {
+                                    "link_layer" => {
+                                        field.ty = syn::parse_str("LinkLayer")
+                                            .expect("Failed to parse LinkLayer type");
+                                    }
+                                    "port_cap_flags" => {
+                                        field.ty = syn::parse_str("ibv_port_cap_flags")
+                                            .expect("Failed to parse ibv_port_cap_flags type");
+                                    }
+                                    "port_cap_flags2" => {
+                                        field.ty = syn::parse_str("ibv_port_cap_flags2")
+                                            .expect("Failed to parse ibv_port_cap_flags2 type");
+                                    }
+                                    _ => {}
+                                }
                             }
                         }
                     }
@@ -152,6 +174,8 @@ fn main() {
         .allowlist_type("ibv_atomic_cap")
         .allowlist_type("ibv_device_attr")
         .allowlist_type("ibv_device_cap_flags")
+        .allowlist_type("ibv_port_cap_flags")
+        .allowlist_type("ibv_port_cap_flags2")
         .allowlist_function("ibv_ack_cq_events")
         .allowlist_function("ibv_alloc_pd")
         .allowlist_function("ibv_close_device")
@@ -182,6 +206,8 @@ fn main() {
         .bitfield_enum("ibv_wc_flags")
         .bitfield_enum("ibv_qp_attr_mask")
         .bitfield_enum("ibv_device_cap_flags")
+        .bitfield_enum("ibv_port_cap_flags")
+        .bitfield_enum("ibv_port_cap_flags2")
         .parse_callbacks(Box::new(CustomDerive))
         // Types with function pointers shouldn't implement Copy
         .no_copy("ibv_context")

--- a/ruapc-rdma/src/bin/ibv_devinfo.rs
+++ b/ruapc-rdma/src/bin/ibv_devinfo.rs
@@ -1,0 +1,310 @@
+use std::{path::Path, process::exit};
+
+use clap::Parser;
+use ruapc_rdma::{ActiveDevice, GidType, Port, ibv_mtu, ibv_transport_type};
+
+#[derive(Parser)]
+#[command(name = "ibv_devinfo", about = "Query RDMA devices")]
+struct Args {
+    #[arg(short = 'd', long = "ib-dev")]
+    device: Option<String>,
+
+    #[arg(short = 'l', long)]
+    list: bool,
+
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[arg(short = 'p', long)]
+    port: Option<u8>,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let devices = match ActiveDevice::available() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Failed to query RDMA devices: {e}");
+            exit(1);
+        }
+    };
+
+    if args.list {
+        let plural = if devices.len() == 1 { "" } else { "s" };
+        println!("{} HCA{} found:", devices.len(), plural);
+        for dev in &devices {
+            println!("\t{}", dev.info().name);
+        }
+        println!();
+        return;
+    }
+
+    for dev in &devices {
+        if let Some(ref name) = args.device
+            && dev.info().name != *name
+        {
+            continue;
+        }
+        print_device(dev, args.verbose, args.port);
+    }
+}
+
+fn read_sysfs(path: &Path, file: &str) -> String {
+    std::fs::read_to_string(path.join(file))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn mtu_raw(m: ibv_mtu) -> u32 {
+    unsafe { std::mem::transmute::<ibv_mtu, i32>(m) as u32 }
+}
+
+fn mtu_bytes(raw: u32) -> u32 {
+    match raw {
+        1 => 256,
+        2 => 512,
+        3 => 1024,
+        4 => 2048,
+        5 => 4096,
+        _ => 0,
+    }
+}
+
+fn transport_str(t: ibv_transport_type) -> &'static str {
+    match t {
+        ibv_transport_type::IBV_TRANSPORT_IB => "InfiniBand",
+        ibv_transport_type::IBV_TRANSPORT_IWARP => "iWARP",
+        ibv_transport_type::IBV_TRANSPORT_USNIC => "usNIC",
+        ibv_transport_type::IBV_TRANSPORT_USNIC_UDP => "usNIC UDP",
+        ibv_transport_type::IBV_TRANSPORT_UNSPECIFIED => "unspecified",
+        _ => "invalid transport",
+    }
+}
+
+fn active_width_str(w: u8) -> &'static str {
+    match w {
+        1 => "1",
+        2 => "4",
+        4 => "8",
+        8 => "12",
+        16 => "2",
+        _ => "invalid width",
+    }
+}
+
+fn active_speed_str(s: u8) -> &'static str {
+    match s {
+        1 => "2.5 Gbps",
+        2 => "5.0 Gbps",
+        4 | 8 => "10.0 Gbps",
+        16 => "14.0 Gbps",
+        32 => "25.0 Gbps",
+        64 => "50.0 Gbps",
+        128 => "100.0 Gbps",
+        _ => "invalid speed",
+    }
+}
+
+fn phys_state_str(s: u8) -> &'static str {
+    match s {
+        1 => "SLEEP",
+        2 => "POLLING",
+        3 => "DISABLED",
+        4 => "PORT_CONFIGURATION TRAINNING",
+        5 => "LINK_UP",
+        6 => "LINK_ERROR_RECOVERY",
+        7 => "PHY TEST",
+        _ => "invalid physical state",
+    }
+}
+
+fn vendor_id_display(vendor_id: u32) -> String {
+    format!("0x{vendor_id:04x}")
+}
+
+fn hw_ver_display(hw_ver: u32) -> String {
+    format!("0x{hw_ver:x}")
+}
+
+fn gid_type_display(t: &GidType) -> String {
+    match t {
+        GidType::IB => "IB".to_string(),
+        GidType::RoCEv1 => "RoCE v1".to_string(),
+        GidType::RoCEv2 => "RoCE v2".to_string(),
+        GidType::Other(s) => s.clone(),
+    }
+}
+
+fn gid_v6_expanded(gid: &ruapc_rdma::ibv_gid) -> String {
+    let bits = gid.as_bits();
+    format!(
+        "{:04x}:{:04x}:{:04x}:{:04x}:{:04x}:{:04x}:{:04x}:{:04x}",
+        (bits >> 112) as u16,
+        (bits >> 96) as u16,
+        (bits >> 80) as u16,
+        (bits >> 64) as u16,
+        (bits >> 48) as u16,
+        (bits >> 32) as u16,
+        (bits >> 16) as u16,
+        bits as u16,
+    )
+}
+
+fn print_device(dev: &ActiveDevice, verbose: bool, port_filter: Option<u8>) {
+    let info = dev.info();
+    let attr = &info.device_attr;
+
+    println!("hca_id:\t{}", info.name);
+
+    let t = info.transport_type;
+    println!("\ttransport:\t\t\t{} ({})", transport_str(t), t as i32);
+
+    println!("\tfw_ver:\t\t\t\t{}", attr.fw_ver);
+    println!("\tnode_guid:\t\t\t{}", attr.node_guid);
+    println!("\tsys_image_guid:\t\t\t{}", attr.sys_image_guid);
+    println!("\tvendor_id:\t\t\t{}", vendor_id_display(attr.vendor_id));
+    println!("\tvendor_part_id:\t\t\t{}", attr.vendor_part_id);
+    println!("\thw_ver:\t\t\t\t{}", hw_ver_display(attr.hw_ver));
+
+    let board_id = read_sysfs(&info.ibdev_path, "board_id");
+    println!("\tboard_id:\t\t\t{board_id}");
+
+    println!("\tphys_port_cnt:\t\t\t{}", attr.phys_port_cnt);
+
+    if verbose {
+        print_verbose_device_attrs(attr);
+        let num_comp_vectors = unsafe { (*dev.context().as_ptr()).num_comp_vectors };
+        println!("\tnum_comp_vectors:\t\t{num_comp_vectors}");
+    }
+
+    for port in info
+        .ports
+        .iter()
+        .filter(|p| port_filter.is_none_or(|pf| p.port_num == pf))
+    {
+        print_port(port, verbose);
+    }
+
+    println!();
+}
+
+fn print_verbose_device_attrs(attr: &ruapc_rdma::ibv_device_attr) {
+    use ruapc_rdma::ibv_device_cap_flags;
+
+    println!("\tmax_mr_size:\t\t\t0x{:x}", attr.max_mr_size);
+    println!("\tpage_size_cap:\t\t\t0x{:x}", attr.page_size_cap);
+    println!("\tmax_qp:\t\t\t\t{}", attr.max_qp);
+    println!("\tmax_qp_wr:\t\t\t{}", attr.max_qp_wr);
+
+    let dev_flags = attr.device_cap_flags;
+    println!("\tdevice_cap_flags:\t\t{dev_flags}");
+    for bit in (0..32).map(|i| 1u32.wrapping_shl(i as u32)) {
+        if dev_flags.0 & bit != 0
+            && let Some(name) = ibv_device_cap_flags::flag_name(bit)
+        {
+            println!("\t\t\t\t\t{name}");
+        }
+    }
+
+    println!("\tmax_sge:\t\t\t{}", attr.max_sge);
+    println!("\tmax_sge_rd:\t\t\t{}", attr.max_sge_rd);
+    println!("\tmax_cq:\t\t\t\t{}", attr.max_cq);
+    println!("\tmax_cqe:\t\t\t{}", attr.max_cqe);
+    println!("\tmax_mr:\t\t\t\t{}", attr.max_mr);
+    println!("\tmax_pd:\t\t\t\t{}", attr.max_pd);
+    println!("\tmax_qp_rd_atom:\t\t\t{}", attr.max_qp_rd_atom);
+    println!("\tmax_ee_rd_atom:\t\t\t{}", attr.max_ee_rd_atom);
+    println!("\tmax_res_rd_atom:\t\t{}", attr.max_res_rd_atom);
+    println!("\tmax_qp_init_rd_atom:\t\t{}", attr.max_qp_init_rd_atom);
+    println!("\tmax_ee_init_rd_atom:\t\t{}", attr.max_ee_init_rd_atom);
+
+    let ac_name = format!("{:?}", attr.atomic_cap).replacen("IBV_", "", 1);
+    println!("\tatomic_cap:\t\t\t{ac_name} ({})", attr.atomic_cap as i32);
+
+    println!("\tmax_ee:\t\t\t\t{}", attr.max_ee);
+    println!("\tmax_rdd:\t\t\t{}", attr.max_rdd);
+    println!("\tmax_mw:\t\t\t\t{}", attr.max_mw);
+    println!("\tmax_raw_ipv6_qp:\t\t{}", attr.max_raw_ipv6_qp);
+    println!("\tmax_raw_ethy_qp:\t\t{}", attr.max_raw_ethy_qp);
+    println!("\tmax_mcast_grp:\t\t\t{}", attr.max_mcast_grp);
+    println!("\tmax_mcast_qp_attach:\t\t{}", attr.max_mcast_qp_attach);
+    println!(
+        "\tmax_total_mcast_qp_attach:\t{}",
+        attr.max_total_mcast_qp_attach
+    );
+    println!("\tmax_ah:\t\t\t\t{}", attr.max_ah);
+    println!("\tmax_fmr:\t\t\t{}", attr.max_fmr);
+    println!("\tmax_srq:\t\t\t{}", attr.max_srq);
+    println!("\tmax_srq_wr:\t\t\t{}", attr.max_srq_wr);
+    println!("\tmax_srq_sge:\t\t\t{}", attr.max_srq_sge);
+    println!("\tmax_pkeys:\t\t\t{}", attr.max_pkeys);
+    println!("\tlocal_ca_ack_delay:\t\t{}", attr.local_ca_ack_delay);
+}
+
+fn print_port(port: &Port, verbose: bool) {
+    let pa = &port.port_attr;
+
+    println!("\t\tport:\t{}", port.port_num);
+
+    let state_name = format!("{:?}", pa.state).replacen("IBV_", "", 1);
+    println!("\t\t\tstate:\t\t\t{} ({})", state_name, pa.state as i32);
+
+    let max_mtu = mtu_raw(pa.max_mtu);
+    let active_mtu = mtu_raw(pa.active_mtu);
+    println!("\t\t\tmax_mtu:\t\t{} ({max_mtu})", mtu_bytes(max_mtu));
+    println!(
+        "\t\t\tactive_mtu:\t\t{} ({active_mtu})",
+        mtu_bytes(active_mtu)
+    );
+
+    println!("\t\t\tsm_lid:\t\t\t{}", pa.sm_lid);
+    println!("\t\t\tport_lid:\t\t{}", pa.lid);
+    println!("\t\t\tport_lmc:\t\t0x{:02x}", pa.lmc);
+    println!("\t\t\tlink_layer:\t\t{}", pa.link_layer);
+
+    if verbose {
+        println!("\t\t\tmax_msg_sz:\t\t0x{:x}", pa.max_msg_sz);
+        println!("\t\t\tport_cap_flags:\t\t{}", pa.port_cap_flags);
+        println!("\t\t\tport_cap_flags2:\t{}", pa.port_cap_flags2);
+
+        if pa.max_vl_num == 0 {
+            println!("\t\t\tmax_vl_num:\t\tinvalid value (0)");
+        } else {
+            println!("\t\t\tmax_vl_num:\t\t{}", pa.max_vl_num);
+        }
+
+        println!("\t\t\tbad_pkey_cntr:\t\t0x{:x}", pa.bad_pkey_cntr);
+        println!("\t\t\tqkey_viol_cntr:\t\t0x{:x}", pa.qkey_viol_cntr);
+        println!("\t\t\tsm_sl:\t\t\t{}", pa.sm_sl);
+        println!("\t\t\tpkey_tbl_len:\t\t{}", pa.pkey_tbl_len);
+        println!("\t\t\tgid_tbl_len:\t\t{}", pa.gid_tbl_len);
+        println!("\t\t\tsubnet_timeout:\t\t{}", pa.subnet_timeout);
+        println!("\t\t\tinit_type_reply:\t{}", pa.init_type_reply);
+
+        println!(
+            "\t\t\tactive_width:\t\t{}X ({})",
+            active_width_str(pa.active_width),
+            pa.active_width
+        );
+        println!(
+            "\t\t\tactive_speed:\t\t{} ({})",
+            active_speed_str(pa.active_speed),
+            pa.active_speed
+        );
+        println!(
+            "\t\t\tphys_state:\t\t{} ({})",
+            phys_state_str(pa.phys_state),
+            pa.phys_state
+        );
+
+        for gid in &port.gids {
+            let gtype = gid_type_display(&gid.gid_type);
+            let gip = match gid.gid_type {
+                GidType::IB | GidType::RoCEv1 => gid_v6_expanded(&gid.gid),
+                _ => gid.gid.as_ipv6().to_string(),
+            };
+            println!("\t\t\tGID[{:3}]:\t\t{gip}, {gtype}", gid.index);
+        }
+    }
+}

--- a/ruapc-rdma/src/ffi.rs
+++ b/ruapc-rdma/src/ffi.rs
@@ -5,3 +5,10 @@ use crate::types::{pthread_cond_t, pthread_mutex_t};
 use crate::{FwVer, Guid, LinkLayer, WRID};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[allow(clippy::derivable_impls)]
+impl Default for ibv_transport_type {
+    fn default() -> Self {
+        ibv_transport_type::IBV_TRANSPORT_UNKNOWN
+    }
+}

--- a/ruapc-rdma/src/lib.rs
+++ b/ruapc-rdma/src/lib.rs
@@ -37,9 +37,10 @@ pub(crate) use ffi::*;
 // Publicly expose the generated types that appear in public API signatures
 pub use ffi::{
     ibv_access_flags, ibv_atomic_cap, ibv_comp_channel, ibv_context, ibv_cq, ibv_device_attr,
-    ibv_device_cap_flags, ibv_gid, ibv_mr, ibv_mtu, ibv_pd, ibv_port_attr, ibv_port_state, ibv_qp,
-    ibv_qp_attr, ibv_qp_attr_mask, ibv_qp_cap, ibv_qp_init_attr, ibv_qp_state, ibv_qp_type,
-    ibv_recv_wr, ibv_send_flags, ibv_send_wr, ibv_wc, ibv_wc_flags, ibv_wc_status,
+    ibv_device_cap_flags, ibv_gid, ibv_mr, ibv_mtu, ibv_pd, ibv_port_attr, ibv_port_cap_flags,
+    ibv_port_cap_flags2, ibv_port_state, ibv_qp, ibv_qp_attr, ibv_qp_attr_mask, ibv_qp_cap,
+    ibv_qp_init_attr, ibv_qp_state, ibv_qp_type, ibv_recv_wr, ibv_send_flags, ibv_send_wr,
+    ibv_transport_type, ibv_wc, ibv_wc_flags, ibv_wc_status,
 };
 
 mod error;

--- a/ruapc-rdma/src/types/device_cap_flags.rs
+++ b/ruapc-rdma/src/types/device_cap_flags.rs
@@ -1,0 +1,37 @@
+impl crate::ibv_device_cap_flags {
+    pub fn flag_name(bit: u32) -> Option<&'static str> {
+        match bit {
+            0x00000001 => Some("RESIZE_MAX_WR"),
+            0x00000002 => Some("BAD_PKEY_CNTR"),
+            0x00000004 => Some("BAD_QKEY_CNTR"),
+            0x00000008 => Some("RAW_MULTI"),
+            0x00000010 => Some("AUTO_PATH_MIG"),
+            0x00000020 => Some("CHANGE_PHY_PORT"),
+            0x00000040 => Some("UD_AV_PORT_ENFORCE"),
+            0x00000080 => Some("CURR_QP_STATE_MOD"),
+            0x00000100 => Some("SHUTDOWN_PORT"),
+            0x00000200 => Some("INIT_TYPE"),
+            0x00000400 => Some("PORT_ACTIVE_EVENT"),
+            0x00000800 => Some("SYS_IMAGE_GUID"),
+            0x00001000 => Some("RC_RNR_NAK_GEN"),
+            0x00002000 => Some("SRQ_RESIZE"),
+            0x00004000 => Some("N_NOTIFY_CQ"),
+            0x00020000 => Some("MEM_WINDOW"),
+            0x00040000 => Some("UD_IP_CSUM"),
+            0x00100000 => Some("XRC"),
+            0x00200000 => Some("MEM_MGT_EXTENSIONS"),
+            0x00800000 => Some("MEM_WINDOW_TYPE_2A"),
+            0x01000000 => Some("MEM_WINDOW_TYPE_2B"),
+            0x02000000 => Some("RC_IP_CSUM"),
+            0x04000000 => Some("RAW_IP_CSUM"),
+            0x20000000 => Some("MANAGED_FLOW_STEERING"),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for crate::ibv_device_cap_flags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{:08x}", self.0)
+    }
+}

--- a/ruapc-rdma/src/types/device_info.rs
+++ b/ruapc-rdma/src/types/device_info.rs
@@ -16,7 +16,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::{Guid, ibv_device_attr, ibv_gid, ibv_port_attr};
+use crate::{Guid, ibv_device_attr, ibv_gid, ibv_port_attr, ibv_transport_type};
 
 /// Information about an RDMA device.
 ///
@@ -28,6 +28,8 @@ pub struct DeviceInfo {
     pub name: String,
     /// Globally unique identifier for the device.
     pub guid: Guid,
+    /// Transport type of the device.
+    pub transport_type: ibv_transport_type,
     /// Path to the device in sysfs.
     pub ibdev_path: PathBuf,
     /// Device attributes including capabilities.

--- a/ruapc-rdma/src/types/mod.rs
+++ b/ruapc-rdma/src/types/mod.rs
@@ -43,3 +43,9 @@ pub use buffer::RdmaBuffer;
 
 mod device_info;
 pub use device_info::{DeviceInfo, Gid, GidType, Port};
+
+mod device_cap_flags;
+
+mod port_cap_flags;
+
+mod port_cap_flags2;

--- a/ruapc-rdma/src/types/port_cap_flags.rs
+++ b/ruapc-rdma/src/types/port_cap_flags.rs
@@ -1,0 +1,37 @@
+impl crate::ibv_port_cap_flags {
+    pub fn flag_name(bit: u32) -> Option<&'static str> {
+        match bit {
+            0x00000002 => Some("SM"),
+            0x00000004 => Some("NOTICE_SUP"),
+            0x00000008 => Some("TRAP_SUP"),
+            0x00000010 => Some("OPT_IPD_SUP"),
+            0x00000020 => Some("AUTO_MIGR_SUP"),
+            0x00000040 => Some("SL_MAP_SUP"),
+            0x00000080 => Some("MKEY_NVRAM"),
+            0x00000100 => Some("PKEY_NVRAM"),
+            0x00000200 => Some("LED_INFO_SUP"),
+            0x00000800 => Some("SYS_IMAGE_GUID_SUP"),
+            0x00001000 => Some("PKEY_SW_EXT_PORT_TRAP_SUP"),
+            0x00004000 => Some("EXTENDED_SPEEDS_SUP"),
+            0x00008000 => Some("CAP_MASK2_SUP"),
+            0x00010000 => Some("CM_SUP"),
+            0x00020000 => Some("SNMP_TUNNEL_SUP"),
+            0x00040000 => Some("REINIT_SUP"),
+            0x00080000 => Some("DEVICE_MGMT_SUP"),
+            0x00100000 => Some("VENDOR_CLASS_SUP"),
+            0x00200000 => Some("DR_NOTICE_SUP"),
+            0x00400000 => Some("CAP_MASK_NOTICE_SUP"),
+            0x00800000 => Some("BOOT_MGMT_SUP"),
+            0x01000000 => Some("LINK_LATENCY_SUP"),
+            0x02000000 => Some("CLIENT_REG_SUP"),
+            0x04000000 => Some("IP_BASED_GIDS"),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for crate::ibv_port_cap_flags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{:08x}", self.0)
+    }
+}

--- a/ruapc-rdma/src/types/port_cap_flags2.rs
+++ b/ruapc-rdma/src/types/port_cap_flags2.rs
@@ -1,0 +1,20 @@
+impl crate::ibv_port_cap_flags2 {
+    pub fn flag_name(bit: u16) -> Option<&'static str> {
+        match bit {
+            0x0001 => Some("SET_NODE_DESC_SUP"),
+            0x0002 => Some("INFO_EXT_SUP"),
+            0x0004 => Some("VIRT_SUP"),
+            0x0008 => Some("SWITCH_PORT_STATE_TABLE_SUP"),
+            0x0010 => Some("LINK_WIDTH_2X_SUP"),
+            0x0020 => Some("LINK_SPEED_HDR_SUP"),
+            0x0400 => Some("LINK_SPEED_NDR_SUP"),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for crate::ibv_port_cap_flags2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{:04x}", self.0)
+    }
+}

--- a/ruapc-rdma/src/verbs/device.rs
+++ b/ruapc-rdma/src/verbs/device.rs
@@ -22,6 +22,7 @@ pub struct Device {
     ptr: *mut crate::ibv_device,
     name: String,
     guid: Guid,
+    transport_type: crate::ibv_transport_type,
     ibdev_path: std::path::PathBuf,
 }
 
@@ -33,6 +34,7 @@ impl Device {
                 .to_string()
         };
         let guid = Guid::from_be(unsafe { crate::ibv_get_device_guid(ptr) });
+        let transport_type = unsafe { (*ptr).transport_type };
         let ibdev_path = unsafe {
             Path::new(std::ffi::OsStr::from_bytes(
                 CStr::from_ptr((*ptr).ibdev_path.as_ptr()).to_bytes(),
@@ -44,6 +46,7 @@ impl Device {
             ptr,
             name,
             guid,
+            transport_type,
             ibdev_path,
         }
     }
@@ -77,6 +80,7 @@ impl Device {
             info: DeviceInfo {
                 name: self.name.clone(),
                 guid: self.guid,
+                transport_type: self.transport_type,
                 ibdev_path: self.ibdev_path.clone(),
                 ..Default::default()
             },
@@ -92,6 +96,7 @@ impl std::fmt::Debug for Device {
         f.debug_struct("Device")
             .field("name", &self.name)
             .field("guid", &self.guid)
+            .field("transport_type", &self.transport_type)
             .finish()
     }
 }

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -10,12 +10,12 @@ license.workspace = true
 
 [features]
 rdma = ["ruapc-rdma"]
-default = []
+default = ["rdma"]
 
 [dependencies]
 ruapc-macro ={ version = "0.1.3", path = "../ruapc-macro" }
 ruapc-bufpool = { version = "0.1.0", path = "../ruapc-bufpool" }
-ruapc-rdma = { version = "0.1.2", path = "../ruapc-rdma", optional = true }
+ruapc-rdma = { version = "0.1.4", path = "../ruapc-rdma", optional = true }
 
 bitflags.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
- Add 'bin' feature to ruapc-rdma (enables clap dep)
- Add [[bin]] target ibv_devinfo with required-features = ["bin"]
- Implement ibv_devinfo binary using pure Rust + ruapc_rdma types
- Supports -d/--ib-dev, -l/--list, -v/--verbose, -p/--port flags
- Export ibv_transport_type and wire transport_type through DeviceInfo