### PR TITLE
RDMA device query handshake and port refresh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 aliasable = "0.1"
+arc-swap = "1.9"
 bindgen = "0.72"
 bitflags = "2.9"
 bytes = "1.10"

--- a/ruapc-rdma/src/types/link_layer.rs
+++ b/ruapc-rdma/src/types/link_layer.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Corresponds to the `ibv_link_layer` enum from libibverbs:
 /// - IBV_LINK_LAYER_UNSPECIFIED = 0
 /// - IBV_LINK_LAYER_INFINIBAND = 1
-/// - IBV_LINK_LAYER_ETHERNET = 4
+/// - IBV_LINK_LAYER_ETHERNET = 2
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum LinkLayer {
@@ -21,7 +21,7 @@ pub enum LinkLayer {
     /// InfiniBand link layer
     InfiniBand = 1,
     /// Ethernet link layer (used for RoCE)
-    Ethernet = 4,
+    Ethernet = 2,
 }
 
 impl LinkLayer {
@@ -32,7 +32,7 @@ impl LinkLayer {
         match value {
             0 => Self::Unspecified,
             1 => Self::InfiniBand,
-            4 => Self::Ethernet,
+            2 => Self::Ethernet,
             _ => Self::Unspecified,
         }
     }
@@ -83,7 +83,7 @@ mod tests {
     fn test_link_layer_from_u8() {
         assert_eq!(LinkLayer::from_u8(0), LinkLayer::Unspecified);
         assert_eq!(LinkLayer::from_u8(1), LinkLayer::InfiniBand);
-        assert_eq!(LinkLayer::from_u8(4), LinkLayer::Ethernet);
+        assert_eq!(LinkLayer::from_u8(2), LinkLayer::Ethernet);
         assert_eq!(LinkLayer::from_u8(99), LinkLayer::Unspecified);
     }
 
@@ -91,14 +91,14 @@ mod tests {
     fn test_link_layer_from() {
         assert_eq!(LinkLayer::from(0u8), LinkLayer::Unspecified);
         assert_eq!(LinkLayer::from(1u8), LinkLayer::InfiniBand);
-        assert_eq!(LinkLayer::from(4u8), LinkLayer::Ethernet);
+        assert_eq!(LinkLayer::from(2u8), LinkLayer::Ethernet);
     }
 
     #[test]
     fn test_link_layer_to_u8() {
         assert_eq!(u8::from(LinkLayer::Unspecified), 0);
         assert_eq!(u8::from(LinkLayer::InfiniBand), 1);
-        assert_eq!(u8::from(LinkLayer::Ethernet), 4);
+        assert_eq!(u8::from(LinkLayer::Ethernet), 2);
     }
 
     #[test]

--- a/ruapc-rdma/src/verbs/queue_pair.rs
+++ b/ruapc-rdma/src/verbs/queue_pair.rs
@@ -11,8 +11,8 @@ use ruapc_bufpool::{Buffer, DeviceIndex};
 
 use super::{completion_queue::CompletionQueue, protection_domain::ProtectionDomain};
 use crate::{
-    Error, ErrorKind, Result, WRID, ibv_gid, ibv_mtu, ibv_qp_attr, ibv_qp_attr_mask, ibv_qp_state,
-    ibv_wc,
+    Error, ErrorKind, LinkLayer, Result, WRID, ibv_gid, ibv_mtu, ibv_qp_attr, ibv_qp_attr_mask,
+    ibv_qp_state, ibv_wc,
 };
 
 pub struct Completion {
@@ -285,29 +285,55 @@ impl QueuePair {
         self.modify(&mut attr, mask.0 as _)
     }
 
-    pub fn ready_to_recv(&self, remote_qp_num: u32, gid: ibv_gid, lid: u16) -> Result<()> {
+    pub fn ready_to_recv(
+        &self,
+        remote_qp_num: u32,
+        remote_gid: ibv_gid,
+        remote_lid: u16,
+        local_port_num: u8,
+        local_gid_index: u8,
+        link_layer: LinkLayer,
+        path_mtu: ibv_mtu,
+    ) -> Result<()> {
+        let mut ah_attr = crate::ibv_ah_attr {
+            sl: 0,
+            src_path_bits: 0,
+            static_rate: 0,
+            port_num: local_port_num,
+            ..Default::default()
+        };
+
+        match link_layer {
+            LinkLayer::InfiniBand => {
+                ah_attr.dlid = remote_lid;
+                ah_attr.is_global = 0;
+            }
+            LinkLayer::Ethernet => {
+                ah_attr.grh = crate::ibv_global_route {
+                    dgid: remote_gid,
+                    flow_label: 0,
+                    sgid_index: local_gid_index,
+                    hop_limit: 0xff,
+                    traffic_class: 0,
+                };
+                ah_attr.is_global = 1;
+            }
+            LinkLayer::Unspecified => {
+                return Err(Error::new(
+                    ErrorKind::IBModifyQueuePairFail,
+                    "RDMA link layer is unspecified".into(),
+                ));
+            }
+        }
+
         let mut attr = ibv_qp_attr {
             qp_state: ibv_qp_state::IBV_QPS_RTR,
-            path_mtu: ibv_mtu::IBV_MTU_512,
+            path_mtu,
             dest_qp_num: remote_qp_num,
             rq_psn: 0,
             max_dest_rd_atomic: 1,
             min_rnr_timer: 0x12,
-            ah_attr: crate::ibv_ah_attr {
-                grh: crate::ibv_global_route {
-                    dgid: gid,
-                    flow_label: 0,
-                    sgid_index: 1,
-                    hop_limit: 0xff,
-                    traffic_class: 0,
-                },
-                dlid: lid,
-                sl: 0,
-                src_path_bits: 0,
-                static_rate: 0,
-                is_global: 1,
-                port_num: 1,
-            },
+            ah_attr,
             ..Default::default()
         };
         let mask = ibv_qp_attr_mask::IBV_QP_STATE
@@ -339,9 +365,26 @@ impl QueuePair {
         self.modify(&mut attr, mask.0 as _)
     }
 
-    pub fn connect(&self, remote_qp_num: u32, gid: ibv_gid, lid: u16) -> Result<()> {
-        self.init(1)?;
-        self.ready_to_recv(remote_qp_num, gid, lid)?;
+    pub fn connect(
+        &self,
+        local_port_num: u8,
+        local_gid_index: u8,
+        link_layer: LinkLayer,
+        path_mtu: ibv_mtu,
+        remote_qp_num: u32,
+        remote_gid: ibv_gid,
+        remote_lid: u16,
+    ) -> Result<()> {
+        self.init(local_port_num)?;
+        self.ready_to_recv(
+            remote_qp_num,
+            remote_gid,
+            remote_lid,
+            local_port_num,
+            local_gid_index,
+            link_layer,
+            path_mtu,
+        )?;
         self.ready_to_send()
     }
 

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -17,6 +17,7 @@ ruapc-macro ={ version = "0.1.3", path = "../ruapc-macro" }
 ruapc-bufpool = { version = "0.1.0", path = "../ruapc-bufpool" }
 ruapc-rdma = { version = "0.1.4", path = "../ruapc-rdma", optional = true }
 
+arc-swap.workspace = true
 bitflags.workspace = true
 bytes.workspace = true
 clap.workspace = true

--- a/ruapc/src/rdma/endpoint.rs
+++ b/ruapc/src/rdma/endpoint.rs
@@ -1,17 +1,44 @@
-use ruapc_rdma::ibv_gid;
+use ruapc_rdma::{LinkLayer, ibv_gid, ibv_mtu};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// RDMA connection endpoint information.
 ///
-/// Contains the necessary information to establish an RDMA connection
-/// between two queue pairs, including queue pair number, local ID, and GID.
+/// Contains the QP and address metadata needed to move a queue pair to RTR/RTS.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 pub struct Endpoint {
     /// Queue pair number.
     pub qp_num: u32,
+    /// Local port number used by this QP.
+    pub port_num: u8,
+    /// Local GID index used by this QP.
+    pub gid_index: u8,
     /// Local Identifier for InfiniBand routing.
     pub lid: u16,
     /// Global Identifier for RoCE routing.
     pub gid: ibv_gid,
+    /// Link layer for this endpoint.
+    pub link_layer: LinkLayer,
+    /// Active MTU for the selected port.
+    pub active_mtu: ibv_mtu,
+}
+
+/// Server-side RDMA device/port/GID selected by the client.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct DeviceSelection {
+    /// RDMA device name, such as mlx5_0.
+    pub device_name: String,
+    /// Target port number on the device.
+    pub port_num: u8,
+    /// Target GID index on the port.
+    pub gid_index: u8,
+}
+
+/// RDMA connection request sent after the client has selected a server port.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct ConnectRequest {
+    /// Client endpoint to connect with.
+    pub endpoint: Endpoint,
+    /// Server device/port/GID that should accept this connection.
+    pub target: DeviceSelection,
 }

--- a/ruapc/src/rdma/mod.rs
+++ b/ruapc/src/rdma/mod.rs
@@ -1,8 +1,8 @@
 mod endpoint;
-pub(crate) use endpoint::Endpoint;
+pub(crate) use endpoint::{ConnectRequest, DeviceSelection, Endpoint};
 
 mod rdma_device;
-pub(crate) use rdma_device::RdmaDevice;
+pub(crate) use rdma_device::{RdmaDevice, RdmaDeviceRefresher};
 
 mod rdma_service;
 pub(crate) use rdma_service::{RdmaInfo, RdmaService};

--- a/ruapc/src/rdma/rdma_device.rs
+++ b/ruapc/src/rdma/rdma_device.rs
@@ -1,18 +1,29 @@
-use std::sync::Arc;
+use std::{
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
 
+use arc_swap::ArcSwap;
 use ruapc_bufpool::DeviceIndex;
-use ruapc_rdma::{ActiveDevice, ProtectionDomain};
+use ruapc_rdma::{ActiveDevice, DeviceInfo, Gid, ProtectionDomain};
 
 pub struct RdmaDevice {
     index: DeviceIndex,
     inner: ActiveDevice,
+    info: ArcSwap<DeviceInfo>,
 }
 
 impl RdmaDevice {
     pub fn new(inner: ActiveDevice) -> Self {
+        let info = Arc::new(inner.info().clone());
         Self {
             index: DeviceIndex::default(),
             inner,
+            info: ArcSwap::from(info),
         }
     }
 
@@ -22,6 +33,151 @@ impl RdmaDevice {
 
     pub fn pd(&self) -> &Arc<ProtectionDomain> {
         self.inner.pd()
+    }
+
+    pub fn info(&self) -> Arc<DeviceInfo> {
+        self.info.load_full()
+    }
+
+    pub fn refresh_port_attrs(&self) -> ruapc_rdma::Result<()> {
+        let mut info = (*self.info()).clone();
+        let device_attr = self.inner.context().query_device()?;
+
+        let mut ports = Vec::with_capacity(device_attr.phys_port_cnt as usize);
+        for port_num in 1..=device_attr.phys_port_cnt {
+            let port_attr = self.inner.context().query_port(port_num)?;
+            let gids = self.collect_port_gids(port_num, &port_attr, &info);
+            ports.push(ruapc_rdma::Port {
+                port_num,
+                port_attr,
+                gids,
+            });
+        }
+
+        info.device_attr = device_attr;
+        info.ports = ports;
+        self.info.store(Arc::new(info));
+        Ok(())
+    }
+
+    fn collect_port_gids(
+        &self,
+        port_num: u8,
+        port_attr: &ruapc_rdma::ibv_port_attr,
+        info: &DeviceInfo,
+    ) -> Vec<Gid> {
+        let mut gids = Vec::with_capacity(port_attr.gid_tbl_len as usize);
+        for gid_index in 0..port_attr.gid_tbl_len as u16 {
+            let Ok(gid) = self.inner.context().query_gid(port_num, gid_index) else {
+                continue;
+            };
+            if let Ok(gid_type) = self.inner.context().query_gid_type(
+                port_num,
+                gid_index,
+                &info.ibdev_path,
+                port_attr,
+            ) {
+                gids.push(Gid {
+                    index: gid_index,
+                    gid,
+                    gid_type,
+                });
+            }
+        }
+        gids
+    }
+}
+
+struct RefreshSignal {
+    stop: AtomicBool,
+    mutex: Mutex<()>,
+    condvar: Condvar,
+}
+
+impl RefreshSignal {
+    fn new() -> Self {
+        Self {
+            stop: AtomicBool::new(false),
+            mutex: Mutex::new(()),
+            condvar: Condvar::new(),
+        }
+    }
+}
+
+pub(crate) struct RdmaDeviceRefresher {
+    signal: Arc<RefreshSignal>,
+    handle: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl RdmaDeviceRefresher {
+    const REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+
+    pub(crate) fn start(devices: Arc<crate::Devices>) -> crate::Result<Self> {
+        let signal = Arc::new(RefreshSignal::new());
+        let thread_signal = signal.clone();
+        let handle = thread::Builder::new()
+            .name("ruapc-rdma-port-refresh".into())
+            .spawn(move || {
+                while !thread_signal.stop.load(Ordering::Relaxed) {
+                    Self::refresh_all(&devices);
+
+                    let guard = thread_signal.mutex.lock().expect("RDMA refresher poisoned");
+                    let _ = thread_signal
+                        .condvar
+                        .wait_timeout_while(guard, Self::REFRESH_INTERVAL, |_| {
+                            !thread_signal.stop.load(Ordering::Relaxed)
+                        })
+                        .expect("RDMA refresher poisoned");
+                }
+            })
+            .map_err(|e| {
+                crate::Error::new(
+                    crate::ErrorKind::Unknown("RdmaDeviceRefresher".into()),
+                    e.to_string(),
+                )
+            })?;
+
+        Ok(Self {
+            signal,
+            handle: Mutex::new(Some(handle)),
+        })
+    }
+
+    pub(crate) fn stop(&self) {
+        self.signal.stop.store(true, Ordering::Relaxed);
+        self.signal.condvar.notify_all();
+
+        let Some(handle) = self
+            .handle
+            .lock()
+            .expect("RDMA refresher handle poisoned")
+            .take()
+        else {
+            return;
+        };
+
+        if handle.join().is_err() {
+            tracing::warn!("RDMA port attribute refresher thread panicked");
+        }
+    }
+
+    fn refresh_all(devices: &crate::Devices) {
+        for dev in devices.rdma_devices() {
+            if let Err(err) = dev.refresh_port_attrs() {
+                let info = dev.info();
+                tracing::warn!(
+                    device = %info.name,
+                    error = %err,
+                    "failed to refresh RDMA port attributes"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for RdmaDeviceRefresher {
+    fn drop(&mut self) {
+        self.stop();
     }
 }
 

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -7,7 +7,7 @@ use crate::{Context, Result, rdma, service};
 ///
 /// This structure is used to exchange RDMA device capabilities and
 /// configuration between services.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct RdmaInfo {
     /// List of available RDMA devices and their capabilities
     pub devices: Vec<ruapc_rdma::DeviceInfo>,

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -23,8 +23,12 @@ pub trait RdmaService {
     /// Retrieves information about available RDMA devices.
     async fn info(&self, ctx: &Context, _: &()) -> Result<rdma::RdmaInfo>;
 
-    /// Establishes an RDMA connection with the specified endpoint.
-    async fn connect(&self, ctx: &Context, endpoint: &rdma::Endpoint) -> Result<rdma::Endpoint>;
+    /// Establishes an RDMA connection with the selected server endpoint.
+    async fn connect(
+        &self,
+        ctx: &Context,
+        request: &rdma::ConnectRequest,
+    ) -> Result<rdma::Endpoint>;
 }
 
 /// Default implementation of `RdmaService` for the unit type.
@@ -38,8 +42,12 @@ impl RdmaService for () {
     }
 
     /// Establishes an RDMA connection using the socket pool.
-    async fn connect(&self, ctx: &Context, endpoint: &rdma::Endpoint) -> Result<rdma::Endpoint> {
-        ctx.state.socket_pool.rdma_connect(endpoint, &ctx.state)
+    async fn connect(
+        &self,
+        ctx: &Context,
+        request: &rdma::ConnectRequest,
+    ) -> Result<rdma::Endpoint> {
+        ctx.state.socket_pool.rdma_connect(request, &ctx.state)
     }
 }
 
@@ -81,10 +89,22 @@ mod tests {
         let ctx = Context::create(&SocketPoolConfig::default()).unwrap();
         let endpoint = rdma::Endpoint {
             qp_num: 0,
+            port_num: 1,
+            gid_index: 0,
             gid: ruapc_rdma::ibv_gid::default(),
             lid: 0,
+            link_layer: ruapc_rdma::LinkLayer::Ethernet,
+            active_mtu: ruapc_rdma::ibv_mtu::IBV_MTU_512,
         };
-        let result = ().connect(&ctx, &endpoint).await;
+        let request = rdma::ConnectRequest {
+            endpoint,
+            target: rdma::DeviceSelection {
+                device_name: "missing".into(),
+                port_num: 1,
+                gid_index: 0,
+            },
+        };
+        let result = ().connect(&ctx, &request).await;
         assert!(result.is_err());
     }
 }

--- a/ruapc/src/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/rdma/rdma_socket_pool.rs
@@ -8,12 +8,16 @@ use std::{
 use foldhash::fast::RandomState;
 use ruapc_bufpool::Device as _;
 use ruapc_rdma::{
-    CompChannel, CompletionQueue, QueuePair, ibv_qp_cap, ibv_qp_init_attr, ibv_qp_type,
+    CompChannel, CompletionQueue, DeviceInfo, Gid, GidType, LinkLayer, Port, QueuePair, ibv_mtu,
+    ibv_port_state, ibv_qp_cap, ibv_qp_init_attr, ibv_qp_type,
 };
 use tokio::sync::RwLock;
 use tokio_util::sync::DropGuard;
 
-use super::{Endpoint, EventLoop, RdmaDevice, RdmaInfo, RdmaService, RdmaSocket};
+use super::{
+    ConnectRequest, DeviceSelection, Endpoint, EventLoop, RdmaDevice, RdmaDeviceRefresher,
+    RdmaInfo, RdmaService, RdmaSocket,
+};
 use crate::{
     BufferPool, Client, Context, Devices, Error, ErrorKind, Result, Socket, SocketPoolConfig,
     SocketPoolTrait, SocketType, State, TaskSupervisor, rdma::event_loop::SendMsg,
@@ -37,6 +41,8 @@ pub struct RdmaSocketPool {
     /// Supervisor for managing asynchronous tasks — dropped first so that
     /// all spawned EventLoop tasks finish and release their `Arc<RdmaSocket>`.
     pub task_supervisor: TaskSupervisor,
+    /// Background port/GID cache refresher. Dropped before RDMA devices.
+    pub(crate) port_refresher: RdmaDeviceRefresher,
     /// Thread-safe map of active RDMA sockets indexed by their addresses.
     /// Dropped after tasks stop → destroys QPs.
     pub socket_map: RwLock<HashMap<SocketAddr, Arc<RdmaSocket>, RandomState>>,
@@ -56,12 +62,13 @@ impl SocketPoolTrait for RdmaSocketPool {
         devices: &Arc<Devices>,
         buffer_pool: &Arc<BufferPool>,
     ) -> Result<Self> {
-        Ok(Self::new(devices.clone(), buffer_pool.clone()))
+        Self::new(devices.clone(), buffer_pool.clone())
     }
 
     /// Stops all tasks managed by the socket pool.
     fn stop(&self) {
         self.task_supervisor.stop();
+        self.port_refresher.stop();
     }
 
     /// Returns a guard that will stop all tasks when dropped.
@@ -81,20 +88,23 @@ impl SocketPoolTrait for RdmaSocketPool {
                 .devices
                 .rdma_devices()
                 .iter()
-                .map(|d| d.inner().info().clone())
+                .map(|d| (*d.info()).clone())
                 .collect(),
         })
     }
 
     /// Establishes a new RDMA connection with the specified endpoint.
-    fn rdma_connect(&self, endpoint: &Endpoint, state: &Arc<State>) -> Result<Endpoint> {
-        let device = self.pick_rdma_device()?;
+    fn rdma_connect(&self, request: &ConnectRequest, state: &Arc<State>) -> Result<Endpoint> {
+        let device = self.find_rdma_device(&request.target)?;
         let (queue_pair, comp_channel, cq) = self.create_queue_pair(device)?;
-        queue_pair
-            .connect(endpoint.qp_num, endpoint.gid, endpoint.lid)
-            .map_err(|e| Error::new(ErrorKind::RdmaSendFailed, e.to_string()))?;
+        let local_endpoint = self.make_endpoint(
+            &queue_pair,
+            device,
+            request.target.port_num,
+            request.target.gid_index,
+        )?;
+        self.connect_queue_pair(&queue_pair, &local_endpoint, &request.endpoint)?;
 
-        let local_endpoint = self.make_endpoint(&queue_pair, device);
         let (tx, rx) = tokio::sync::mpsc::channel::<SendMsg>(1024);
         let rdma_socket = RdmaSocket::new(queue_pair, self.buffer_pool.clone(), tx);
         self.start_event_loop(Arc::new(rdma_socket), state.clone(), comp_channel, cq, rx)?;
@@ -128,20 +138,35 @@ impl SocketPoolTrait for RdmaSocketPool {
             return Ok(socket.into());
         }
 
-        let device = self.pick_rdma_device()?;
-        let (queue_pair, comp_channel, cq) = self.create_queue_pair(device)?;
-        let local_endpoint = self.make_endpoint(&queue_pair, device);
-
         let acquire_ctx = Context::create_with_state_and_addr(state, addr);
+        let remote_info = Box::pin(self.acquire_client.info(&acquire_ctx, &())).await?;
+        let selection = self.select_device(&remote_info)?;
+
+        let device = self
+            .devices
+            .rdma_devices()
+            .get(selection.local_device_index)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidArgument,
+                    "selected RDMA device disappeared".into(),
+                )
+            })?;
+        let (queue_pair, comp_channel, cq) = self.create_queue_pair(device)?;
+        let local_endpoint = self.make_endpoint(
+            &queue_pair,
+            device,
+            selection.local_port_num,
+            selection.local_gid_index,
+        )?;
+
+        let connect_request = ConnectRequest {
+            endpoint: local_endpoint,
+            target: selection.remote,
+        };
         let remote_endpoint =
-            Box::pin(self.acquire_client.connect(&acquire_ctx, &local_endpoint)).await?;
-        queue_pair
-            .connect(
-                remote_endpoint.qp_num,
-                remote_endpoint.gid,
-                remote_endpoint.lid,
-            )
-            .map_err(|e| Error::new(ErrorKind::RdmaSendFailed, e.to_string()))?;
+            Box::pin(self.acquire_client.connect(&acquire_ctx, &connect_request)).await?;
+        self.connect_queue_pair(&queue_pair, &local_endpoint, &remote_endpoint)?;
         tracing::info!("acquired socket: {:?}", queue_pair);
 
         let (tx, rx) = tokio::sync::mpsc::channel::<SendMsg>(1024);
@@ -167,32 +192,33 @@ impl SocketPoolTrait for RdmaSocketPool {
 
 impl RdmaSocketPool {
     /// Creates a new pool using the shared devices and buffer pool.
-    pub fn new(devices: Arc<Devices>, buffer_pool: Arc<BufferPool>) -> Self {
-        Self {
+    pub fn new(devices: Arc<Devices>, buffer_pool: Arc<BufferPool>) -> Result<Self> {
+        Ok(Self {
             acquire_client: Client {
                 timeout: std::time::Duration::from_secs(5),
                 use_msgpack: true,
                 socket_type: Some(SocketType::TCP),
             },
             task_supervisor: TaskSupervisor::create(),
+            port_refresher: RdmaDeviceRefresher::start(devices.clone())?,
             socket_map: RwLock::default(),
             buffer_pool,
             devices,
             next_device: AtomicUsize::new(0),
-        }
+        })
     }
 
-    /// Returns an RDMA device and its index using round-robin selection.
-    fn pick_rdma_device(&self) -> Result<&RdmaDevice> {
-        let rdma_devices = self.devices.rdma_devices();
-        if rdma_devices.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidArgument,
-                "no RDMA device available".into(),
-            ));
-        }
-        let idx = self.next_device.fetch_add(1, Ordering::Relaxed) % rdma_devices.len();
-        Ok(&rdma_devices[idx])
+    fn find_rdma_device(&self, selection: &DeviceSelection) -> Result<&RdmaDevice> {
+        self.devices
+            .rdma_devices()
+            .iter()
+            .find(|device| device.info().name.as_str() == selection.device_name)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidArgument,
+                    format!("RDMA device {} not found", selection.device_name),
+                )
+            })
     }
 
     /// Creates a QueuePair along with its CompChannel and CompletionQueue.
@@ -231,14 +257,239 @@ impl RdmaSocketPool {
         Ok((queue_pair, comp_channel, cq))
     }
 
-    /// Constructs an Endpoint from a QueuePair.
-    fn make_endpoint(&self, qp: &QueuePair, device: &RdmaDevice) -> Endpoint {
-        let info = device.inner().info();
-        Endpoint {
-            qp_num: qp.qp_num(),
-            lid: 0,
-            gid: info.ports[0].gids[1].gid,
+    fn select_device(&self, remote_info: &RdmaInfo) -> Result<SelectedDevice> {
+        let local_devices = self.devices.rdma_devices();
+        if local_devices.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                "no local RDMA device available".into(),
+            ));
         }
+
+        let mut ib_matches = Vec::new();
+        let mut roce_matches = Vec::new();
+        let mut remote_usable_ports = 0usize;
+        let mut local_usable_ports = 0usize;
+        let mut link_layer_matches = 0usize;
+
+        for remote_device in &remote_info.devices {
+            for remote_port in &remote_device.ports {
+                if !Self::port_is_usable(remote_port) {
+                    continue;
+                }
+                remote_usable_ports += 1;
+
+                for (local_device_index, local_device) in local_devices.iter().enumerate() {
+                    let local_info = local_device.info();
+                    for local_port in &local_info.ports {
+                        if !Self::port_is_usable(local_port) {
+                            continue;
+                        }
+                        local_usable_ports += 1;
+                        if local_port.port_attr.link_layer != remote_port.port_attr.link_layer {
+                            continue;
+                        }
+                        link_layer_matches += 1;
+
+                        let Some((local_gid_index, remote_gid_index)) =
+                            Self::select_gid_pair(local_port, remote_port)
+                        else {
+                            continue;
+                        };
+
+                        let selected = SelectedDevice {
+                            local_device_index,
+                            local_port_num: local_port.port_num,
+                            local_gid_index,
+                            remote: DeviceSelection {
+                                device_name: remote_device.name.clone(),
+                                port_num: remote_port.port_num,
+                                gid_index: remote_gid_index,
+                            },
+                        };
+
+                        match local_port.port_attr.link_layer {
+                            LinkLayer::InfiniBand => ib_matches.push(selected),
+                            LinkLayer::Ethernet => roce_matches.push(selected),
+                            LinkLayer::Unspecified => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        let matches = if ib_matches.is_empty() {
+            &roce_matches
+        } else {
+            &ib_matches
+        };
+        if matches.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "no compatible RDMA device/port/GID pair found: remote_devices={} local_devices={} remote_usable_ports={} local_usable_ports={} link_layer_matches={}",
+                    remote_info.devices.len(),
+                    local_devices.len(),
+                    remote_usable_ports,
+                    local_usable_ports,
+                    link_layer_matches
+                ),
+            ));
+        }
+
+        let idx = self.next_device.fetch_add(1, Ordering::Relaxed) % matches.len();
+        Ok(matches[idx].clone())
+    }
+
+    fn port_is_usable(port: &Port) -> bool {
+        matches!(
+            port.port_attr.state,
+            ibv_port_state::IBV_PORT_ACTIVE | ibv_port_state::IBV_PORT_ACTIVE_DEFER
+        ) && matches!(
+            port.port_attr.link_layer,
+            LinkLayer::InfiniBand | LinkLayer::Ethernet
+        )
+    }
+
+    fn select_gid_pair(local_port: &Port, remote_port: &Port) -> Option<(u8, u8)> {
+        match local_port.port_attr.link_layer {
+            LinkLayer::InfiniBand => Some((
+                Self::first_gid_index(local_port, |_| true).unwrap_or(0),
+                Self::first_gid_index(remote_port, |_| true).unwrap_or(0),
+            )),
+            LinkLayer::Ethernet => Self::select_roce_gid_pair(local_port, remote_port),
+            LinkLayer::Unspecified => None,
+        }
+    }
+
+    fn select_roce_gid_pair(local_port: &Port, remote_port: &Port) -> Option<(u8, u8)> {
+        let preferred = [
+            (
+                Self::first_gid_index(local_port, |gid| matches!(gid.gid_type, GidType::RoCEv2)),
+                Self::first_gid_index(remote_port, |gid| matches!(gid.gid_type, GidType::RoCEv2)),
+            ),
+            (
+                Self::first_gid_index(local_port, |gid| matches!(gid.gid_type, GidType::RoCEv1)),
+                Self::first_gid_index(remote_port, |gid| matches!(gid.gid_type, GidType::RoCEv1)),
+            ),
+        ];
+
+        for (local, remote) in preferred {
+            if let (Some(local), Some(remote)) = (local, remote) {
+                return Some((local, remote));
+            }
+        }
+
+        for local_gid in &local_port.gids {
+            for remote_gid in &remote_port.gids {
+                if local_gid.gid_type == remote_gid.gid_type {
+                    return Some((
+                        u8::try_from(local_gid.index).ok()?,
+                        u8::try_from(remote_gid.index).ok()?,
+                    ));
+                }
+            }
+        }
+
+        Some((
+            Self::first_gid_index(local_port, |_| true)?,
+            Self::first_gid_index(remote_port, |_| true)?,
+        ))
+    }
+
+    fn first_gid_index(port: &Port, mut predicate: impl FnMut(&Gid) -> bool) -> Option<u8> {
+        port.gids
+            .iter()
+            .find(|gid| predicate(gid))
+            .and_then(|gid| u8::try_from(gid.index).ok())
+    }
+
+    /// Constructs an Endpoint from a QueuePair and selected local port/GID.
+    fn make_endpoint(
+        &self,
+        qp: &QueuePair,
+        device: &RdmaDevice,
+        port_num: u8,
+        gid_index: u8,
+    ) -> Result<Endpoint> {
+        let info = device.info();
+        let port = Self::find_port(&info, port_num)?;
+        if !Self::port_is_usable(port) {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!("RDMA port {}:{} is not active", info.name, port_num),
+            ));
+        }
+
+        let gid = port
+            .gids
+            .iter()
+            .find(|gid| u8::try_from(gid.index).ok() == Some(gid_index))
+            .map(|gid| gid.gid);
+        if port.port_attr.link_layer.is_ethernet() && gid.is_none() {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "RDMA port {}:{} does not have GID index {}",
+                    info.name, port_num, gid_index
+                ),
+            ));
+        }
+
+        Ok(Endpoint {
+            qp_num: qp.qp_num(),
+            port_num,
+            gid_index,
+            lid: port.port_attr.lid,
+            gid: gid.unwrap_or_default(),
+            link_layer: port.port_attr.link_layer,
+            active_mtu: port.port_attr.active_mtu,
+        })
+    }
+
+    fn find_port(info: &DeviceInfo, port_num: u8) -> Result<&Port> {
+        info.ports
+            .iter()
+            .find(|port| port.port_num == port_num)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidArgument,
+                    format!("RDMA port {}:{} not found", info.name, port_num),
+                )
+            })
+    }
+
+    fn connect_queue_pair(
+        &self,
+        qp: &QueuePair,
+        local: &Endpoint,
+        remote: &Endpoint,
+    ) -> Result<()> {
+        if local.link_layer != remote.link_layer {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "RDMA link layer mismatch: local {} remote {}",
+                    local.link_layer, remote.link_layer
+                ),
+            ));
+        }
+
+        let path_mtu = Self::min_mtu(local.active_mtu, remote.active_mtu);
+        qp.connect(
+            local.port_num,
+            local.gid_index,
+            local.link_layer,
+            path_mtu,
+            remote.qp_num,
+            remote.gid,
+            remote.lid,
+        )
+        .map_err(|e| Error::new(ErrorKind::RdmaSendFailed, e.to_string()))
+    }
+
+    fn min_mtu(a: ibv_mtu, b: ibv_mtu) -> ibv_mtu {
+        if (a as u32) <= (b as u32) { a } else { b }
     }
 
     /// Starts the event loop for handling RDMA events on a socket.
@@ -276,6 +527,7 @@ impl RdmaSocketPool {
 impl Drop for RdmaSocketPool {
     fn drop(&mut self) {
         self.task_supervisor.stop();
+        self.port_refresher.stop();
         self.socket_map.get_mut().clear();
     }
 }
@@ -284,4 +536,12 @@ impl std::fmt::Debug for RdmaSocketPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RdmaSocketPool").finish()
     }
+}
+
+#[derive(Clone)]
+struct SelectedDevice {
+    local_device_index: usize,
+    local_port_num: u8,
+    local_gid_index: u8,
+    remote: DeviceSelection,
 }

--- a/ruapc/src/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/rdma/rdma_socket_pool.rs
@@ -3,6 +3,7 @@ use std::{
     net::SocketAddr,
     sync::Arc,
     sync::atomic::{AtomicUsize, Ordering},
+    time::{Duration, Instant},
 };
 
 use foldhash::fast::RandomState;
@@ -42,7 +43,11 @@ pub struct RdmaSocketPool {
     /// all spawned EventLoop tasks finish and release their `Arc<RdmaSocket>`.
     pub task_supervisor: TaskSupervisor,
     /// Background port/GID cache refresher. Dropped before RDMA devices.
-    pub(crate) port_refresher: RdmaDeviceRefresher,
+    port_refresher: RdmaDeviceRefresher,
+    /// Per-peer connection locks prevent duplicate in-flight RDMA handshakes.
+    connect_locks: dashmap::DashMap<SocketAddr, Arc<tokio::sync::Mutex<()>>, RandomState>,
+    /// Short-lived cache for the first-stage server RDMA device query.
+    query_cache: RwLock<HashMap<SocketAddr, CachedRdmaInfo, RandomState>>,
     /// Thread-safe map of active RDMA sockets indexed by their addresses.
     /// Dropped after tasks stop → destroys QPs.
     pub socket_map: RwLock<HashMap<SocketAddr, Arc<RdmaSocket>, RandomState>>,
@@ -132,49 +137,18 @@ impl SocketPoolTrait for RdmaSocketPool {
             return Ok(socket.into());
         }
 
-        // If not, create a new socket and insert it into the socket map.
-        let mut socket_map = self.socket_map.write().await;
-        if let Some(socket) = socket_map.get(addr) {
-            return Ok(socket.into());
-        }
-
-        let acquire_ctx = Context::create_with_state_and_addr(state, addr);
-        let remote_info = Box::pin(self.acquire_client.info(&acquire_ctx, &())).await?;
-        let selection = self.select_device(&remote_info)?;
-
-        let device = self
-            .devices
-            .rdma_devices()
-            .get(selection.local_device_index)
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::InvalidArgument,
-                    "selected RDMA device disappeared".into(),
-                )
-            })?;
-        let (queue_pair, comp_channel, cq) = self.create_queue_pair(device)?;
-        let local_endpoint = self.make_endpoint(
-            &queue_pair,
-            device,
-            selection.local_port_num,
-            selection.local_gid_index,
-        )?;
-
-        let connect_request = ConnectRequest {
-            endpoint: local_endpoint,
-            target: selection.remote,
-        };
-        let remote_endpoint =
-            Box::pin(self.acquire_client.connect(&acquire_ctx, &connect_request)).await?;
-        self.connect_queue_pair(&queue_pair, &local_endpoint, &remote_endpoint)?;
-        tracing::info!("acquired socket: {:?}", queue_pair);
-
-        let (tx, rx) = tokio::sync::mpsc::channel::<SendMsg>(1024);
-        let socket = RdmaSocket::new(queue_pair, self.buffer_pool.clone(), tx);
-        let socket = Arc::new(socket);
-        socket_map.insert(*addr, socket.clone());
-        self.start_event_loop(socket.clone(), state.clone(), comp_channel, cq, rx)?;
-        Ok(socket.into())
+        let connect_lock = self
+            .connect_locks
+            .entry(*addr)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let guard = connect_lock.lock().await;
+        let result = self.acquire_with_connect_lock(addr, state).await;
+        self.connect_locks.remove_if(addr, |_, value| {
+            Arc::ptr_eq(value, &connect_lock) && Arc::strong_count(value) == 2
+        });
+        drop(guard);
+        result
     }
 
     async fn handle_new_stream(
@@ -191,6 +165,8 @@ impl SocketPoolTrait for RdmaSocketPool {
 }
 
 impl RdmaSocketPool {
+    const QUERY_CACHE_TTL: Duration = Duration::from_secs(5);
+
     /// Creates a new pool using the shared devices and buffer pool.
     pub fn new(devices: Arc<Devices>, buffer_pool: Arc<BufferPool>) -> Result<Self> {
         Ok(Self {
@@ -201,6 +177,8 @@ impl RdmaSocketPool {
             },
             task_supervisor: TaskSupervisor::create(),
             port_refresher: RdmaDeviceRefresher::start(devices.clone())?,
+            connect_locks: dashmap::DashMap::default(),
+            query_cache: RwLock::default(),
             socket_map: RwLock::default(),
             buffer_pool,
             devices,
@@ -255,6 +233,108 @@ impl RdmaSocketPool {
             .map_err(|e| Error::new(ErrorKind::RdmaSendFailed, e.to_string()))?;
 
         Ok((queue_pair, comp_channel, cq))
+    }
+
+    async fn acquire_with_connect_lock(
+        &self,
+        addr: &SocketAddr,
+        state: &Arc<State>,
+    ) -> Result<Socket> {
+        if let Some(socket) = self.socket_map.read().await.get(addr).cloned() {
+            return Ok(socket.into());
+        }
+
+        let acquire_ctx = Context::create_with_state_and_addr(state, addr);
+        let remote_info = self.query_remote_info(addr, &acquire_ctx).await?;
+        let selection = match self.select_device(&remote_info) {
+            Ok(selection) => selection,
+            Err(err) => {
+                self.invalidate_query_cache(addr).await;
+                return Err(err);
+            }
+        };
+
+        let device = self
+            .devices
+            .rdma_devices()
+            .get(selection.local_device_index)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidArgument,
+                    "selected RDMA device disappeared".into(),
+                )
+            })?;
+        let (queue_pair, comp_channel, cq) = self.create_queue_pair(device)?;
+        let local_endpoint = self.make_endpoint(
+            &queue_pair,
+            device,
+            selection.local_port_num,
+            selection.local_gid_index,
+        )?;
+
+        let connect_request = ConnectRequest {
+            endpoint: local_endpoint,
+            target: selection.remote.clone(),
+        };
+        let remote_endpoint =
+            match Box::pin(self.acquire_client.connect(&acquire_ctx, &connect_request)).await {
+                Ok(endpoint) => endpoint,
+                Err(err) => {
+                    self.invalidate_query_cache(addr).await;
+                    return Err(err);
+                }
+            };
+        self.connect_queue_pair(&queue_pair, &local_endpoint, &remote_endpoint)?;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<SendMsg>(1024);
+        let socket = RdmaSocket::new(queue_pair, self.buffer_pool.clone(), tx);
+        let socket = Arc::new(socket);
+        self.start_event_loop(socket.clone(), state.clone(), comp_channel, cq, rx)?;
+        {
+            let mut socket_map = self.socket_map.write().await;
+            socket_map.insert(*addr, socket.clone());
+        }
+        let local_info = device.info();
+        tracing::info!(
+            local_device = %local_info.name,
+            local_port = selection.local_port_num,
+            local_gid_index = selection.local_gid_index,
+            remote_device = %selection.remote.device_name,
+            remote_port = selection.remote.port_num,
+            remote_gid_index = selection.remote.gid_index,
+            "acquired RDMA socket"
+        );
+        Ok(socket.into())
+    }
+
+    async fn query_remote_info(&self, addr: &SocketAddr, ctx: &Context) -> Result<RdmaInfo> {
+        if let Some(info) = self.cached_remote_info(addr).await {
+            return Ok(info);
+        }
+
+        let info = Box::pin(self.acquire_client.info(ctx, &())).await?;
+        self.query_cache.write().await.insert(
+            *addr,
+            CachedRdmaInfo {
+                info: info.clone(),
+                cached_at: Instant::now(),
+            },
+        );
+        Ok(info)
+    }
+
+    async fn cached_remote_info(&self, addr: &SocketAddr) -> Option<RdmaInfo> {
+        let cache = self.query_cache.read().await;
+        let cached = cache.get(addr)?;
+        if cached.cached_at.elapsed() < Self::QUERY_CACHE_TTL {
+            Some(cached.info.clone())
+        } else {
+            None
+        }
+    }
+
+    async fn invalidate_query_cache(&self, addr: &SocketAddr) {
+        self.query_cache.write().await.remove(addr);
     }
 
     fn select_device(&self, remote_info: &RdmaInfo) -> Result<SelectedDevice> {
@@ -544,4 +624,9 @@ struct SelectedDevice {
     local_port_num: u8,
     local_gid_index: u8,
     remote: DeviceSelection,
+}
+
+struct CachedRdmaInfo {
+    info: RdmaInfo,
+    cached_at: Instant,
 }

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -9,7 +9,7 @@ use tokio_tungstenite::WebSocketStream;
 use tokio_util::sync::DropGuard;
 
 #[cfg(feature = "rdma")]
-use crate::rdma::{Endpoint, RdmaSocketPool};
+use crate::rdma::{ConnectRequest, Endpoint, RdmaSocketPool};
 #[cfg(feature = "rdma")]
 use crate::{Error, ErrorKind};
 use crate::{
@@ -74,6 +74,7 @@ impl Default for SocketPoolConfig {
 }
 
 /// Socket pool managing connections for different transport protocols.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SocketPool {
     /// TCP socket pool.
@@ -138,7 +139,7 @@ pub trait SocketPoolTrait: Sized {
 
     #[cfg(feature = "rdma")]
     #[allow(unused_variables)]
-    fn rdma_connect(&self, endpoint: &Endpoint, state: &Arc<State>) -> Result<Endpoint> {
+    fn rdma_connect(&self, request: &ConnectRequest, state: &Arc<State>) -> Result<Endpoint> {
         Err(Error::new(
             ErrorKind::InvalidArgument,
             "RDMA is not supported: invalid socket type".into(),
@@ -246,10 +247,10 @@ impl SocketPool {
     }
 
     #[cfg(feature = "rdma")]
-    pub fn rdma_connect(&self, endpoint: &Endpoint, state: &Arc<State>) -> Result<Endpoint> {
+    pub fn rdma_connect(&self, request: &ConnectRequest, state: &Arc<State>) -> Result<Endpoint> {
         match self {
-            SocketPool::RDMA(p) => p.rdma_connect(endpoint, state),
-            SocketPool::UNIFIED(p) => p.rdma_connect(endpoint, state),
+            SocketPool::RDMA(p) => p.rdma_connect(request, state),
+            SocketPool::UNIFIED(p) => p.rdma_connect(request, state),
             _ => Err(Error::new(
                 ErrorKind::InvalidArgument,
                 "RDMA is not supported: invalid socket type".into(),
@@ -439,12 +440,23 @@ mod tests {
         let buffer_pool = ruapc_bufpool::BufferPoolBuilder::new(devices.clone()).build();
         let pool = SocketPool::create(&config, &devices, &buffer_pool).unwrap();
         let (state, _guard) = crate::State::create(crate::Router::default(), &config).unwrap();
-        let endpoint = crate::rdma::Endpoint {
-            qp_num: 0,
-            gid: ruapc_rdma::ibv_gid::default(),
-            lid: 0,
+        let request = crate::rdma::ConnectRequest {
+            target: crate::rdma::DeviceSelection {
+                device_name: "missing".into(),
+                port_num: 1,
+                gid_index: 0,
+            },
+            endpoint: crate::rdma::Endpoint {
+                qp_num: 0,
+                port_num: 1,
+                gid_index: 0,
+                gid: ruapc_rdma::ibv_gid::default(),
+                lid: 0,
+                link_layer: ruapc_rdma::LinkLayer::Ethernet,
+                active_mtu: ruapc_rdma::ibv_mtu::IBV_MTU_512,
+            },
         };
-        assert!(pool.rdma_connect(&endpoint, &state).is_err());
+        assert!(pool.rdma_connect(&request, &state).is_err());
         pool.stop();
         pool.join().await;
     }

--- a/ruapc/src/sockets/unified/unified_socket_pool.rs
+++ b/ruapc/src/sockets/unified/unified_socket_pool.rs
@@ -4,7 +4,7 @@ use futures_util::TryFutureExt;
 use tokio_util::sync::DropGuard;
 
 #[cfg(feature = "rdma")]
-use crate::rdma::{Endpoint, RdmaInfo, RdmaSocketPool};
+use crate::rdma::{ConnectRequest, Endpoint, RdmaInfo, RdmaSocketPool};
 use crate::{
     BufferPool, Devices, Error, ErrorKind, RawStream, Result, Socket, SocketPoolConfig,
     SocketPoolTrait, SocketType, State, TaskSupervisor,
@@ -125,8 +125,8 @@ impl SocketPoolTrait for UnifiedSocketPool {
     }
 
     #[cfg(feature = "rdma")]
-    fn rdma_connect(&self, endpoint: &Endpoint, state: &Arc<State>) -> Result<Endpoint> {
-        self.rdma_socket_pool.rdma_connect(endpoint, state)
+    fn rdma_connect(&self, request: &ConnectRequest, state: &Arc<State>) -> Result<Endpoint> {
+        self.rdma_socket_pool.rdma_connect(request, state)
     }
 
     fn stop(&self) {
@@ -211,12 +211,23 @@ mod tests {
         let buffer_pool = ruapc_bufpool::BufferPoolBuilder::new(devices.clone()).build();
         let pool = UnifiedSocketPool::create(&config, &devices, &buffer_pool).unwrap();
         let (state, _guard) = crate::State::create(crate::Router::default(), &config).unwrap();
-        let endpoint = crate::rdma::Endpoint {
-            qp_num: 0,
-            gid: ruapc_rdma::ibv_gid::default(),
-            lid: 0,
+        let request = crate::rdma::ConnectRequest {
+            target: crate::rdma::DeviceSelection {
+                device_name: "missing".into(),
+                port_num: 1,
+                gid_index: 0,
+            },
+            endpoint: crate::rdma::Endpoint {
+                qp_num: 0,
+                port_num: 1,
+                gid_index: 0,
+                gid: ruapc_rdma::ibv_gid::default(),
+                lid: 0,
+                link_layer: ruapc_rdma::LinkLayer::Ethernet,
+                active_mtu: ruapc_rdma::ibv_mtu::IBV_MTU_512,
+            },
         };
-        assert!(pool.rdma_connect(&endpoint, &state).is_err());
+        assert!(pool.rdma_connect(&request, &state).is_err());
         pool.stop();
         pool.join().await;
     }


### PR DESCRIPTION
## Summary
- add ArcSwap-backed RDMA device info cache with a background port/GID refresh worker
- change RDMA connect flow so the client queries server devices first, selects a compatible NIC/GID, then sends a targeted connect request
- honor selected port, GID index, link layer, and MTU in QP setup; fix Ethernet link-layer raw value

## Tests
- cargo fmt
- cargo check --all-features
- cargo clippy --all-features
- cargo test --all-features