### PR TITLE
feat(bufpool): buddy memory allocator with slab layer, lazy merging, async waiters, and subtree reservation

### DIFF
--- a/ruapc-bufpool/Cargo.toml
+++ b/ruapc-bufpool/Cargo.toml
@@ -13,12 +13,21 @@ license.workspace = true
 [dependencies]
 aliasable.workspace = true
 dashmap.workspace = true
+foldhash.workspace = true
 schemars.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "macros", "time"] }
+
+[[bench]]
+name = "lazy_merge"
+harness = false
+
+[[bench]]
+name = "contention"
+harness = false
 
 [lints]
 workspace = true

--- a/ruapc-bufpool/README.md
+++ b/ruapc-bufpool/README.md
@@ -6,11 +6,21 @@ fixed-size buffer management. This crate is part of the [ruapc](../ruapc/) proje
 ## Features
 
 - **Buddy Memory Allocation**: Supports allocation of 1MiB, 4MiB, 16MiB, and 64MiB buffers
+- **Slab Layer for Small Buffers**: 64KiB and 256KiB allocations are served from slabs
+  (1MiB buddy leaves carved into fixed-size chunks) behind per-class mutexes, keeping
+  small-buffer traffic off the buddy pool's global mutex; empty slabs are cached up to a
+  watermark and returned to the buddy pool on demand
 - **Both Sync and Async APIs**: Designed for tokio environments with async-first design
 - **Automatic Memory Reclamation**: Buffers are automatically returned to the pool on drop
 - **Memory Limits**: Configurable maximum memory usage with async waiting when limits are reached
 - **Custom Allocators**: Pluggable allocator trait for memory allocation backend
 - **O(1) Buddy Merging**: Intrusive doubly-linked list with O(1) free/merge operations
+- **Lazy Buddy Merging**: Per-level watermarks defer merging on free to avoid split/merge
+  thrashing; complete-but-unmerged quads are tracked on intrusive pending-merge lists and
+  coalesced on demand in O(merges performed), independent of pool size
+- **Starvation Protection**: Async waiters are served smallest-request-first; a large
+  waiter queued past a configurable timeout gets a reserved subtree whose capacity is
+  drained toward it and protected from smaller allocations until it is satisfied
 - **Device Registration**: Optional device registration support for RDMA and TCP transports
 
 ## Architecture
@@ -30,6 +40,7 @@ fixed-size buffer management. This crate is part of the [ruapc](../ruapc/) proje
 │  └─────────────────────────────────────────────────────┘    │
 │                                                             │
 │  free_lists: [IntrusiveList; 4]  (one per level)            │
+│  pending_lists: [IntrusiveList; 4]  (deferred merge quads)  │
 │  waiting_lists: [VecDeque<Sender>; 4]  (async waiters)      │
 └─────────────────────────────────────────────────────────────┘
          │

--- a/ruapc-bufpool/benches/contention.rs
+++ b/ruapc-bufpool/benches/contention.rs
@@ -1,0 +1,104 @@
+//! Multi-threaded contention benchmark for the buffer pool's global mutex.
+//!
+//! Run with: `cargo bench -p ruapc-bufpool --bench contention`
+//!
+//! Every thread churns buffers (allocate + free) on a shared pool, which is
+//! the worst case for lock contention: each operation takes the pool mutex
+//! once. Reported numbers show how per-op latency and aggregate throughput
+//! scale with thread count.
+
+use std::hint::black_box;
+use std::sync::{Arc, Barrier};
+use std::time::Instant;
+
+use ruapc_bufpool::{BufferPool, BufferPoolBuilder, EmptyDevices};
+
+const MIB: usize = 1024 * 1024;
+
+fn new_pool() -> Arc<BufferPool> {
+    BufferPoolBuilder::new(Arc::new(EmptyDevices))
+        .max_memory(1024 * MIB)
+        .build()
+}
+
+/// Runs `threads` workers, each performing `iters` alloc+free pairs of
+/// `size`-byte buffers on the shared pool. Returns elapsed wall time in
+/// seconds.
+fn run_churn(pool: &Arc<BufferPool>, threads: usize, iters: u64, size: usize) -> f64 {
+    let barrier = Arc::new(Barrier::new(threads + 1));
+
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let pool = Arc::clone(pool);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                // Warm up: fault in this thread's working set and pre-split.
+                for _ in 0..1_000 {
+                    black_box(pool.allocate(size).unwrap());
+                }
+                barrier.wait();
+                for _ in 0..iters {
+                    black_box(pool.allocate(size).unwrap());
+                }
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    let start = Instant::now();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    start.elapsed().as_secs_f64()
+}
+
+fn scenario(name: &str, size: usize, hold: usize, iters: u64) {
+    println!("{name}");
+    let mut baseline_ns = 0.0;
+
+    for threads in [1usize, 2, 4, 8, 16] {
+        let pool = new_pool();
+        // Hold a few buffers so the pool stays pre-grown and quads stay
+        // broken, keeping the scenario steady-state.
+        let _held: Vec<_> = (0..threads * hold)
+            .map(|_| pool.allocate(size).unwrap())
+            .collect();
+
+        let secs = run_churn(&pool, threads, iters, size);
+
+        #[allow(clippy::cast_precision_loss)]
+        let total_ops = (iters * threads as u64 * 2) as f64; // alloc + free
+        let mops = total_ops / secs / 1e6;
+        #[allow(clippy::cast_precision_loss)]
+        let ns_per_pair = secs * 1e9 / (iters as f64); // latency per alloc+free pair per thread
+        if threads == 1 {
+            baseline_ns = ns_per_pair;
+        }
+
+        println!(
+            "threads {threads:>2}: {mops:>7.2} M lock-ops/s | {ns_per_pair:>8.1} ns per alloc+free \
+             | scaling vs 1 thread: {:>5.2}x latency",
+            ns_per_pair / baseline_ns
+        );
+    }
+    println!();
+}
+
+fn main() {
+    println!("ruapc-bufpool: multi-threaded churn on a shared pool");
+    println!("(each op = allocate + free = one lock acquisition each)");
+    println!();
+
+    scenario(
+        "1MiB churn (buddy path, global pool mutex)",
+        MIB,
+        1,
+        1_000_000,
+    );
+    scenario(
+        "64KiB churn (slab path, per-class mutex)",
+        64 * 1024,
+        1,
+        1_000_000,
+    );
+}

--- a/ruapc-bufpool/benches/lazy_merge.rs
+++ b/ruapc-bufpool/benches/lazy_merge.rs
@@ -1,0 +1,210 @@
+//! Benchmark comparing eager vs lazy buddy merging.
+//!
+//! Run with: `cargo bench -p ruapc-bufpool`
+//!
+//! Each scenario runs the exact same operation sequence against two pools:
+//! - **eager**: `merge_watermarks([0, 0, 0, 0])`, the pre-lazy-merge behavior
+//!   (every free immediately merges complete quads upward)
+//! - **lazy**: default watermarks, deferring merges and coalescing on demand
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ruapc_bufpool::{Buffer, BufferPool, BufferPoolBuilder, EmptyDevices};
+
+const MIB: usize = 1024 * 1024;
+const LEVEL_SIZES: [usize; 4] = [MIB, 4 * MIB, 16 * MIB, 64 * MIB];
+
+const EAGER: [usize; 4] = [0, 0, 0, 0];
+const LAZY: [usize; 4] = [16, 8, 2, 0];
+
+fn new_pool(watermarks: [usize; 4]) -> Arc<BufferPool> {
+    BufferPoolBuilder::new(Arc::new(EmptyDevices))
+        .max_memory(256 * MIB)
+        .merge_watermarks(watermarks)
+        .build()
+}
+
+/// Simple deterministic RNG (splitmix-style) so both pools see identical
+/// operation sequences.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (self.0 >> 33) as usize
+    }
+}
+
+fn report(name: &str, ops: u64, eager: Duration, lazy: Duration) {
+    #[allow(clippy::cast_precision_loss)]
+    let per_op = |d: Duration| d.as_nanos() as f64 / ops as f64;
+    let (e, l) = (per_op(eager), per_op(lazy));
+    println!(
+        "{name:<44} eager {e:>9.1} ns/op | lazy {l:>9.1} ns/op | speedup {:>5.2}x",
+        e / l
+    );
+}
+
+/// Worst case for eager merging: repeatedly allocate and free a single
+/// buffer while the pool is otherwise empty. Eager merging pays a full
+/// split + merge chain on every iteration.
+fn bench_same_size_churn(level: usize, iters: u64) {
+    let run = |watermarks| {
+        let pool = new_pool(watermarks);
+        for _ in 0..1_000 {
+            black_box(pool.allocate(LEVEL_SIZES[level]).unwrap());
+        }
+        let start = Instant::now();
+        for _ in 0..iters {
+            black_box(pool.allocate(LEVEL_SIZES[level]).unwrap());
+        }
+        start.elapsed()
+    };
+    report(
+        &format!(
+            "same-size churn ({}MiB alloc+free)",
+            LEVEL_SIZES[level] / MIB
+        ),
+        iters,
+        run(EAGER),
+        run(LAZY),
+    );
+}
+
+/// Concurrency oscillating around a quad boundary: one full quad (4 x 1MiB)
+/// is held, and a 5th buffer is repeatedly allocated and freed. The churn
+/// buffer sits alone in the next quad, so under eager merging every free
+/// completes that quad and merges it up, and every allocation splits again.
+fn bench_quad_boundary(iters: u64) {
+    let run = |watermarks| {
+        let pool = new_pool(watermarks);
+        let _held: Vec<Buffer> = (0..4).map(|_| pool.allocate(MIB).unwrap()).collect();
+        for _ in 0..1_000 {
+            black_box(pool.allocate(MIB).unwrap());
+        }
+        let start = Instant::now();
+        for _ in 0..iters {
+            black_box(pool.allocate(MIB).unwrap());
+        }
+        start.elapsed()
+    };
+    report(
+        "quad boundary oscillation (1MiB)",
+        iters,
+        run(EAGER),
+        run(LAZY),
+    );
+}
+
+/// Bursty RPC pattern: allocate a batch of small buffers, then drop the
+/// whole batch, repeatedly.
+fn bench_burst(iters: u64) {
+    const BATCH: u64 = 16;
+    let run = |watermarks| {
+        let pool = new_pool(watermarks);
+        let mut batch = Vec::with_capacity(BATCH as usize);
+        for _ in 0..100 {
+            for _ in 0..BATCH {
+                batch.push(pool.allocate(MIB).unwrap());
+            }
+            batch.clear();
+        }
+        let start = Instant::now();
+        for _ in 0..iters {
+            for _ in 0..BATCH {
+                batch.push(pool.allocate(MIB).unwrap());
+            }
+            batch.clear();
+        }
+        start.elapsed()
+    };
+    report(
+        "burst alloc/free (16 x 1MiB per batch)",
+        iters * BATCH,
+        run(EAGER),
+        run(LAZY),
+    );
+}
+
+/// Random mix of sizes with a steady working set, biased toward small
+/// buffers as in typical RPC workloads.
+fn bench_mixed(iters: u64) {
+    let run = |watermarks| {
+        let pool = new_pool(watermarks);
+        let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+        let mut held: Vec<Buffer> = Vec::new();
+        let op = |pool: &Arc<BufferPool>, rng: &mut Rng, held: &mut Vec<Buffer>| {
+            if rng.next() % 100 < 55 || held.is_empty() {
+                let level = [0, 0, 0, 0, 1, 1, 2][rng.next() % 7];
+                if let Ok(buffer) = pool.allocate(LEVEL_SIZES[level]) {
+                    held.push(buffer);
+                }
+            } else {
+                let idx = rng.next() % held.len();
+                held.swap_remove(idx);
+            }
+        };
+        for _ in 0..10_000 {
+            op(&pool, &mut rng, &mut held);
+        }
+        let start = Instant::now();
+        for _ in 0..iters {
+            op(&pool, &mut rng, &mut held);
+        }
+        start.elapsed()
+    };
+    report(
+        "mixed random sizes (55% alloc)",
+        iters,
+        run(EAGER),
+        run(LAZY),
+    );
+}
+
+/// Demand path: small-buffer churn interleaved with an occasional 64MiB
+/// allocation. The lazy pool must pay for on-demand coalescing here, so this
+/// checks that the deferred work does not make large allocations regress.
+fn bench_small_churn_with_large(iters: u64) {
+    const SMALL_PER_LARGE: u64 = 64;
+    let run = |watermarks| {
+        let pool = new_pool(watermarks);
+        let round = |pool: &Arc<BufferPool>| {
+            for _ in 0..SMALL_PER_LARGE {
+                black_box(pool.allocate(MIB).unwrap());
+            }
+            black_box(pool.allocate(64 * MIB).unwrap());
+        };
+        for _ in 0..100 {
+            round(&pool);
+        }
+        let start = Instant::now();
+        for _ in 0..iters {
+            round(&pool);
+        }
+        start.elapsed()
+    };
+    report(
+        "64x 1MiB churn + one 64MiB alloc",
+        iters * (SMALL_PER_LARGE + 1),
+        run(EAGER),
+        run(LAZY),
+    );
+}
+
+fn main() {
+    println!("ruapc-bufpool: eager vs lazy buddy merging");
+    println!("(eager = merge_watermarks [0,0,0,0], lazy = default watermarks)");
+    println!();
+
+    bench_same_size_churn(0, 2_000_000);
+    bench_same_size_churn(1, 2_000_000);
+    bench_quad_boundary(2_000_000);
+    bench_burst(200_000);
+    bench_mixed(2_000_000);
+    bench_small_churn_with_large(50_000);
+}

--- a/ruapc-bufpool/src/buddy.rs
+++ b/ruapc-bufpool/src/buddy.rs
@@ -39,7 +39,7 @@ pub const LEVEL_STATE_OFFSETS: [usize; NUM_LEVELS] = [0, 64, 80, 84];
 
 /// State of a node in the buddy tree.
 ///
-/// Each node uses 2 bits (00=Allocated, 01=Free, 10=Split).
+/// Each node uses 2 bits (00=Allocated, 01=Free, 10=Split, 11=SplitPending).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 #[derive(Default)]
@@ -51,6 +51,10 @@ pub enum NodeState {
     Free = 1,
     /// The node has been split into smaller children.
     Split = 2,
+    /// The node is split and all 4 children are free, but merging has been
+    /// deferred (lazy buddy). The node's intrusive list node is linked into
+    /// the pool's pending-merge list for its level.
+    SplitPending = 3,
 }
 
 impl NodeState {
@@ -63,6 +67,7 @@ impl NodeState {
             0 => Self::Allocated,
             1 => Self::Free,
             2 => Self::Split,
+            3 => Self::SplitPending,
             _ => panic!("invalid bits"),
         }
     }

--- a/ruapc-bufpool/src/buffer.rs
+++ b/ruapc-bufpool/src/buffer.rs
@@ -29,10 +29,12 @@ pub struct Buffer {
     /// Logical length of data in the buffer (may be less than capacity).
     len: usize,
 
-    /// The allocation level (0-3).
+    /// The allocation kind: buddy level (0-3) for buddy buffers, or
+    /// `NUM_LEVELS + class` for slab chunks (64 KiB / 256 KiB).
     level: u8,
 
-    /// Index within the level in the buddy block.
+    /// Index within the level in the buddy block (buddy buffers), or the
+    /// chunk index within the slab (slab chunks).
     index: u8,
 }
 
@@ -80,6 +82,42 @@ impl Buffer {
         }
     }
 
+    /// Creates a new buffer for a slab chunk.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure:
+    /// - `ptr` points to a valid chunk of `SLAB_CLASS_SIZES[class]` bytes
+    ///   inside a slab owned by the pool's slab layer
+    /// - `block` points to the `BuddyBlock` containing the chunk
+    /// - `class` is a valid slab class and `index` a valid chunk index
+    pub(crate) unsafe fn new_chunk(
+        ptr: NonNull<u8>,
+        class: usize,
+        index: usize,
+        block: NonNull<BuddyBlock>,
+        pool: Arc<BufferPool>,
+    ) -> Self {
+        debug_assert!(class < crate::slab::NUM_SLAB_CLASSES);
+        let capacity = crate::slab::SLAB_CLASS_SIZES[class];
+        debug_assert!(index < crate::slab::SLAB_BACKING_SIZE / capacity);
+        Self {
+            ptr,
+            pool,
+            block,
+            len: capacity,
+            #[allow(clippy::cast_possible_truncation)]
+            level: (crate::buddy::NUM_LEVELS + class) as u8,
+            #[allow(clippy::cast_possible_truncation)]
+            index: index as u8,
+        }
+    }
+
+    /// Returns the buddy block containing this buffer.
+    pub(crate) const fn block_ptr(&self) -> NonNull<BuddyBlock> {
+        self.block
+    }
+
     /// Returns the logical length of the buffer in bytes.
     ///
     /// Initially set to the full capacity. Use `set_len` to adjust.
@@ -88,15 +126,17 @@ impl Buffer {
         self.len
     }
 
-    /// Returns the capacity of the buffer in bytes (determined by allocation level).
-    ///
-    /// - Level 0: 1 MiB
-    /// - Level 1: 4 MiB
-    /// - Level 2: 16 MiB
-    /// - Level 3: 64 MiB
+    /// Returns the capacity of the buffer in bytes (determined by the
+    /// allocation size class): 64 KiB, 256 KiB, 1 MiB, 4 MiB, 16 MiB or
+    /// 64 MiB.
     #[must_use]
     pub const fn capacity(&self) -> usize {
-        crate::buddy::LEVEL_SIZES[self.level as usize]
+        let level = self.level as usize;
+        if level < crate::buddy::NUM_LEVELS {
+            crate::buddy::LEVEL_SIZES[level]
+        } else {
+            crate::slab::SLAB_CLASS_SIZES[level - crate::buddy::NUM_LEVELS]
+        }
     }
 
     /// Returns `true` if the buffer's logical length is 0.
@@ -191,6 +231,29 @@ impl Buffer {
             })
     }
 
+    /// Decomposes the buffer into its raw parts without running `Drop`.
+    ///
+    /// Used by the pool to reclaim a buffer while already holding the pool
+    /// mutex (e.g. when a waiter cancelled before receiving a handed-off
+    /// buffer): running `Drop` would re-enter the non-reentrant mutex.
+    ///
+    /// The internal `Arc<BufferPool>` reference is released here. This is
+    /// safe to call while holding the pool mutex as long as the caller owns
+    /// another reference to the pool (always true inside pool methods), so
+    /// the decrement can never be the final one.
+    pub(crate) fn into_raw_parts(self) -> (usize, usize, NonNull<BuddyBlock>) {
+        debug_assert!(
+            (self.level as usize) < crate::buddy::NUM_LEVELS,
+            "into_raw_parts is only valid for buddy buffers"
+        );
+        let this = std::mem::ManuallyDrop::new(self);
+        // SAFETY: `this` is never accessed as a whole again; we move the Arc
+        // out to release the pool reference without running Buffer::drop.
+        let pool = unsafe { std::ptr::read(&this.pool) };
+        drop(pool);
+        (this.level as usize, this.index as usize, this.block)
+    }
+
     /// Returns the remote buffer info for RDMA-style operations.
     ///
     /// Note: uses the buffer's capacity (not logical length) for the remote info.
@@ -213,8 +276,17 @@ impl Buffer {
 
 impl Drop for Buffer {
     fn drop(&mut self) {
-        self.pool
-            .return_buffer(self.level as usize, self.index as usize, self.block);
+        let level = self.level as usize;
+        if level < crate::buddy::NUM_LEVELS {
+            self.pool
+                .return_buffer(level, self.index as usize, self.block);
+        } else {
+            self.pool.return_chunk(
+                level - crate::buddy::NUM_LEVELS,
+                self.ptr,
+                self.index as usize,
+            );
+        }
     }
 }
 

--- a/ruapc-bufpool/src/lib.rs
+++ b/ruapc-bufpool/src/lib.rs
@@ -40,6 +40,7 @@ mod buddy;
 mod buffer;
 mod intrusive_list;
 mod pool;
+mod slab;
 
 pub use aligned::AlignedMemory;
 pub use buffer::Buffer;

--- a/ruapc-bufpool/src/pool.rs
+++ b/ruapc-bufpool/src/pool.rs
@@ -3,19 +3,50 @@
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind, Result};
 use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use aliasable::boxed::AliasableBox;
 use tokio::sync::oneshot;
 
 use crate::AlignedMemory;
-use crate::buddy::{BuddyBlock, NUM_LEVELS, NodeState, SIZE_64MIB, size_to_level};
+use crate::buddy::{
+    BuddyBlock, FreeNode, LEVEL_SIZES, NODES_PER_LEVEL, NUM_LEVELS, NodeState, SIZE_64MIB,
+    size_to_level,
+};
 use crate::buffer::Buffer;
 use crate::devices::Devices;
 use crate::intrusive_list::IntrusiveList;
+use crate::slab::{NUM_SLAB_CLASSES, SlabClass, size_to_class};
 
 /// Default maximum memory limit (256 MiB).
 const DEFAULT_MAX_MEMORY: usize = 256 * 1024 * 1024;
+
+/// Default merge watermarks for each level (lazy buddy merging).
+///
+/// When a buffer is freed at level `L`, its buddy quad is only merged upward
+/// if the free list at level `L` already holds at least `watermark[L]` nodes
+/// (or a larger allocation is waiting). This avoids split/merge thrashing for
+/// workloads that repeatedly allocate and free buffers of the same size.
+///
+/// The level-3 (64 MiB, root) entry is unused since roots are never merged.
+const DEFAULT_MERGE_WATERMARKS: [usize; NUM_LEVELS] = [16, 8, 2, 0];
+
+/// Default starvation timeout for large async waiters.
+///
+/// A waiter for a 4 MiB or larger buffer that has been queued longer than
+/// this triggers a subtree reservation, protecting capacity from being
+/// consumed by smaller allocations until the waiter can be satisfied.
+const DEFAULT_STARVATION_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// Default number of empty slabs cached per slab size class.
+///
+/// Caching avoids refill/release thrashing for small-buffer churn; each
+/// cached slab holds 1 MiB. Empty slabs beyond the watermark — or all of
+/// them when the buddy pool has pending demand — are returned to the buddy
+/// pool.
+const DEFAULT_SLAB_EMPTY_WATERMARK: usize = 1;
 
 /// Builder for creating a [`BufferPool`] with custom configuration.
 ///
@@ -32,6 +63,9 @@ const DEFAULT_MAX_MEMORY: usize = 256 * 1024 * 1024;
 pub struct BufferPoolBuilder {
     max_memory: usize,
     devices: Arc<dyn Devices>,
+    merge_watermarks: [usize; NUM_LEVELS],
+    starvation_timeout: Duration,
+    slab_empty_watermark: usize,
 }
 
 impl BufferPoolBuilder {
@@ -43,7 +77,41 @@ impl BufferPoolBuilder {
         Self {
             max_memory: DEFAULT_MAX_MEMORY,
             devices,
+            merge_watermarks: DEFAULT_MERGE_WATERMARKS,
+            starvation_timeout: DEFAULT_STARVATION_TIMEOUT,
+            slab_empty_watermark: DEFAULT_SLAB_EMPTY_WATERMARK,
         }
+    }
+
+    /// Sets the number of empty slabs cached per slab size class.
+    ///
+    /// Small allocations (up to 256 KiB) are served from slabs: 1 MiB buddy
+    /// leaves carved into fixed-size chunks. When all chunks of a slab are
+    /// free, the slab is cached for reuse; empty slabs beyond this watermark
+    /// are returned to the buddy pool. When the buddy pool has pending
+    /// demand (async waiters or an anti-starvation reservation), empty slabs
+    /// are always returned immediately, regardless of the watermark.
+    #[must_use]
+    pub const fn slab_empty_watermark(mut self, watermark: usize) -> Self {
+        self.slab_empty_watermark = watermark;
+        self
+    }
+
+    /// Sets the starvation timeout for large async waiters.
+    ///
+    /// Waiters are normally served smallest-request-first, so under
+    /// sustained small-allocation pressure a large waiter could starve.
+    /// When a waiter for a 4 MiB or larger buffer has been queued longer
+    /// than this timeout, the pool reserves a 64 MiB-aligned subtree for it:
+    /// free capacity inside the subtree is drained toward the waiter and
+    /// protected from other allocations until the request is satisfied.
+    /// At most one reservation is active at a time.
+    ///
+    /// Use `Duration::MAX` to disable starvation protection.
+    #[must_use]
+    pub const fn starvation_timeout(mut self, timeout: Duration) -> Self {
+        self.starvation_timeout = timeout;
+        self
     }
 
     /// Sets the maximum memory limit for the pool.
@@ -55,20 +123,43 @@ impl BufferPoolBuilder {
         self
     }
 
+    /// Sets the merge watermarks for lazy buddy merging (one per level).
+    ///
+    /// When a buffer is freed at level `L`, its buddy quad is merged upward
+    /// only if the free list at level `L` already holds at least
+    /// `watermarks[L]` nodes, or a larger allocation is currently waiting.
+    /// Deferred merges are performed on demand when an allocation cannot be
+    /// satisfied from the free lists (before growing the pool).
+    ///
+    /// Setting all watermarks to 0 restores eager merging.
+    /// The level-3 entry is unused since root nodes are never merged.
+    #[must_use]
+    pub const fn merge_watermarks(mut self, watermarks: [usize; NUM_LEVELS]) -> Self {
+        self.merge_watermarks = watermarks;
+        self
+    }
+
     /// Builds the buffer pool with the configured settings.
     #[must_use]
     pub fn build(self) -> Arc<BufferPool> {
         let inner = PoolInner {
-            max_memory: self.max_memory,
             allocated_memory: 0,
+            merge_watermarks: self.merge_watermarks,
             blocks: Vec::new(),
             free_lists: std::array::from_fn(|_| IntrusiveList::new()),
+            pending_lists: std::array::from_fn(|_| IntrusiveList::new()),
             waiting_lists: std::array::from_fn(|_| VecDeque::new()),
             min_waiting_level: None,
+            reservation: None,
         };
 
         Arc::new(BufferPool {
             devices: self.devices,
+            max_memory: self.max_memory,
+            starvation_timeout: self.starvation_timeout,
+            slab_empty_watermark: self.slab_empty_watermark,
+            has_demand: AtomicBool::new(false),
+            slab_classes: std::array::from_fn(|class| Mutex::new(SlabClass::new(class))),
             inner: Mutex::new(inner),
         })
     }
@@ -80,6 +171,19 @@ impl BufferPoolBuilder {
 /// at four size levels: 1 MiB, 4 MiB, 16 MiB, and 64 MiB.
 pub struct BufferPool {
     devices: Arc<dyn Devices>,
+    max_memory: usize,
+    starvation_timeout: Duration,
+    slab_empty_watermark: usize,
+    /// Hint that the buddy pool has pending demand (async waiters or an
+    /// active reservation). Read lock-free by the slab layer to bypass the
+    /// empty-slab watermark, so that cached slabs cannot stall waiters or
+    /// the anti-starvation drain. Conservatively-true is harmless.
+    has_demand: AtomicBool,
+    /// Slab size classes for small allocations, each behind its own mutex
+    /// so small-buffer traffic does not contend on the buddy pool's mutex.
+    /// Lock ordering: a slab class lock may be taken before `inner`, never
+    /// after.
+    slab_classes: [Mutex<SlabClass>; NUM_SLAB_CLASSES],
     inner: Mutex<PoolInner>,
 }
 
@@ -100,13 +204,19 @@ impl BufferPool {
         block: NonNull<BuddyBlock>,
     ) {
         let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
-        inner.deallocate_buffer(level, index, block);
+        inner.deallocate_buffer(self, level, index, block);
     }
 
     /// Allocates a buffer of at least the specified size.
     ///
     /// The returned buffer may be larger than requested, rounded up to the
-    /// nearest allocation level (1 MiB, 4 MiB, 16 MiB, or 64 MiB).
+    /// nearest size class (64 KiB, 256 KiB, 1 MiB, 4 MiB, 16 MiB, or
+    /// 64 MiB). Sizes up to 256 KiB are served by the slab layer; larger
+    /// sizes by the buddy allocator.
+    ///
+    /// If the pool needs to grow, the 64 MiB block creation and device
+    /// registration (potentially milliseconds for RDMA) happen *outside*
+    /// the pool mutex, so concurrent allocations and frees are not stalled.
     ///
     /// # Errors
     ///
@@ -115,13 +225,69 @@ impl BufferPool {
     /// - Memory limit has been reached
     /// - Underlying allocator fails
     pub fn allocate(self: &Arc<Self>, size: usize) -> Result<Buffer> {
+        if let Some(class) = size_to_class(size) {
+            if let Some(buffer) = self.try_take_chunk(class) {
+                return Ok(buffer);
+            }
+            let backing = self.allocate_buddy(0)?;
+            return Ok(self.install_backing_and_take(class, backing));
+        }
+
+        let level = size_to_level(size).ok_or_else(|| invalid_size_error(size))?;
+        self.allocate_buddy(level)
+    }
+
+    /// Allocates a buddy buffer at the given level (synchronous).
+    fn allocate_buddy(self: &Arc<Self>, level: usize) -> Result<Buffer> {
+        {
+            let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
+            if let Some(buffer) = inner.try_allocate_local(level, self) {
+                return Ok(buffer);
+            }
+        }
+
+        // The slab layer may be caching empty slabs; releasing them can
+        // satisfy this allocation without growing the pool.
+        self.reclaim_empty_slabs();
+
+        {
+            let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
+            if let Some(buffer) = inner.try_allocate_local(level, self) {
+                return Ok(buffer);
+            }
+            // Grow the pool: reserve budget under the lock, then create and
+            // register the block without holding the pool mutex.
+            inner.try_reserve_block(self.max_memory)?;
+        }
+
+        let block = self.create_block_or_release()?;
+
         let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
-        inner.allocate_sync(size, self)
+        inner.install_block(block);
+        // Cannot fail: the freshly installed block is allocated under the
+        // same lock acquisition that installed it. The grower is served
+        // before any waiters: it paid the budget reservation for this block.
+        let buffer = inner
+            .try_allocate_local(level, self)
+            .ok_or_else(|| Error::other("allocation failed unexpectedly"));
+        // Hand any remaining capacity of the new block to queued waiters
+        // (they registered while the block was being created and registered).
+        inner.serve_waiters(self);
+        buffer
     }
 
     /// Allocates a buffer asynchronously.
     ///
-    /// If the memory limit has been reached, waits for other buffers to be freed.
+    /// If the memory limit has been reached, waits for other buffers to be
+    /// freed. Freed capacity is handed off directly: the freeing task
+    /// allocates on behalf of the waiter and sends the buffer through the
+    /// waiter's channel, so waiters cannot lose races against concurrent
+    /// [`Self::allocate`] calls.
+    ///
+    /// Like [`Self::allocate`], pool growth (block creation and device
+    /// registration) happens outside the pool mutex. Note that it still runs
+    /// on the current thread and may block it for the duration of the device
+    /// registration; this only happens when the pool actually grows.
     ///
     /// # Errors
     ///
@@ -129,38 +295,111 @@ impl BufferPool {
     /// - `size` is 0 or exceeds 64 MiB
     /// - Underlying allocator fails
     pub async fn async_allocate(self: &Arc<Self>, size: usize) -> Result<Buffer> {
-        let level = size_to_level(size).ok_or_else(|| {
-            Error::new(
-                ErrorKind::InvalidInput,
-                format!("invalid size: {size} (must be 1-67108864 bytes)"),
-            )
-        })?;
+        if let Some(class) = size_to_class(size) {
+            if let Some(buffer) = self.try_take_chunk(class) {
+                return Ok(buffer);
+            }
+            let backing = self.async_allocate_buddy(0).await?;
+            return Ok(self.install_backing_and_take(class, backing));
+        }
 
+        let level = size_to_level(size).ok_or_else(|| invalid_size_error(size))?;
+        self.async_allocate_buddy(level).await
+    }
+
+    /// Allocates a buddy buffer at the given level, waiting for capacity if
+    /// the memory limit has been reached.
+    async fn async_allocate_buddy(self: &Arc<Self>, level: usize) -> Result<Buffer> {
         loop {
-            let receiver = {
+            enum Step {
+                Grow,
+                Wait(oneshot::Receiver<Buffer>),
+            }
+
+            {
+                let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
+                if let Some(buffer) = inner.try_allocate_local(level, self) {
+                    return Ok(buffer);
+                }
+            }
+
+            // The slab layer may be caching empty slabs; releasing them can
+            // satisfy this allocation without growing or waiting.
+            self.reclaim_empty_slabs();
+
+            let step = {
                 let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
 
-                match inner.try_allocate(level, self) {
-                    Ok(buffer) => return Ok(buffer),
-                    Err(e) if e.kind() == ErrorKind::OutOfMemory => {
-                        let (sender, receiver) = oneshot::channel();
-                        inner.waiting_lists[level].push_back(sender);
-                        inner.update_min_waiting_level_on_add(level);
-                        receiver
-                    }
-                    Err(e) => return Err(e),
+                if let Some(buffer) = inner.try_allocate_local(level, self) {
+                    return Ok(buffer);
+                }
+
+                if inner.try_reserve_block(self.max_memory).is_ok() {
+                    Step::Grow
+                } else {
+                    let (sender, receiver) = oneshot::channel();
+                    inner.waiting_lists[level].push_back(Waiter {
+                        since: Instant::now(),
+                        sender,
+                    });
+                    inner.update_min_waiting_level_on_add(level);
+                    // Hint the slab layer that cached empty slabs must be
+                    // released as soon as they appear.
+                    self.has_demand.store(true, Ordering::Relaxed);
+                    Step::Wait(receiver)
                 }
             };
 
-            // Wait for buffer to be available (lock is released)
-            if let Ok(buffer) = receiver.await {
-                return Ok(buffer);
+            match step {
+                Step::Grow => {
+                    let block = self.create_block_or_release()?;
+                    let mut inner = self.inner.lock().expect("BufferPool mutex poisoned");
+                    inner.install_block(block);
+                    let buffer = inner.try_allocate_local(level, self);
+                    inner.serve_waiters(self);
+                    if let Some(buffer) = buffer {
+                        return Ok(buffer);
+                    }
+                    // Unreachable in practice (install + allocate happen under
+                    // one lock acquisition); retry defensively.
+                }
+                Step::Wait(receiver) => {
+                    // Wait for a handed-off buffer (the lock is released
+                    // while waiting).
+                    if let Ok(buffer) = receiver.await {
+                        return Ok(buffer);
+                    }
+                    // Sender was dropped without sending (e.g. pool
+                    // teardown); retry allocation defensively.
+                }
             }
-            // Sender was dropped without sending, retry allocation
         }
     }
 
-    /// Returns the current amount of allocated memory in bytes.
+    /// Creates and registers a new 64 MiB block. Requires a prior successful
+    /// [`PoolInner::try_reserve_block`]; releases the reservation on failure.
+    ///
+    /// This is deliberately *not* called with the pool mutex held: memory
+    /// allocation and device registration (e.g. `ibv_reg_mr`) can take
+    /// milliseconds and must not stall concurrent allocations and frees.
+    fn create_block_or_release(&self) -> Result<Box<BuddyBlock>> {
+        let create = || -> Result<Box<BuddyBlock>> {
+            let aligned = Arc::new(AlignedMemory::new(SIZE_64MIB)?);
+            let regs = self.devices.register(&aligned)?;
+            Ok(BuddyBlock::new(aligned, regs))
+        };
+        create().inspect_err(|_| {
+            self.inner
+                .lock()
+                .expect("BufferPool mutex poisoned")
+                .allocated_memory -= SIZE_64MIB;
+        })
+    }
+
+    /// Returns the current amount of budgeted memory in bytes.
+    ///
+    /// This includes installed 64 MiB blocks plus any reservations for
+    /// blocks that are currently being created and registered.
     pub fn allocated_memory(&self) -> usize {
         self.inner
             .lock()
@@ -169,17 +408,98 @@ impl BufferPool {
     }
 
     /// Returns the maximum memory limit in bytes.
-    pub fn max_memory(&self) -> usize {
-        self.inner
-            .lock()
-            .expect("BufferPool mutex poisoned")
-            .max_memory
+    pub const fn max_memory(&self) -> usize {
+        self.max_memory
     }
 
     /// Returns the number of free buffers at each level.
     pub fn free_counts(&self) -> [usize; NUM_LEVELS] {
         let inner = self.inner.lock().expect("BufferPool mutex poisoned");
         std::array::from_fn(|i| inner.free_lists[i].len())
+    }
+
+    /// Returns the number of deferred (pending-merge) buddy quads at each level.
+    ///
+    /// `pending_counts()[L]` is the number of split parents at level `L` whose
+    /// 4 children are all free but whose merge has been deferred (lazy buddy).
+    /// Level 0 is always 0.
+    pub fn pending_counts(&self) -> [usize; NUM_LEVELS] {
+        let inner = self.inner.lock().expect("BufferPool mutex poisoned");
+        std::array::from_fn(|i| inner.pending_lists[i].len())
+    }
+
+    /// Returns the number of free chunks in each slab size class
+    /// (64 KiB, 256 KiB).
+    pub fn slab_free_counts(&self) -> [usize; NUM_SLAB_CLASSES] {
+        std::array::from_fn(|class| {
+            self.slab_classes[class]
+                .lock()
+                .expect("SlabClass mutex poisoned")
+                .free_chunks()
+        })
+    }
+
+    /// Takes a chunk from an existing slab of the given class, if available.
+    fn try_take_chunk(self: &Arc<Self>, class: usize) -> Option<Buffer> {
+        let (ptr, index, block) = self.slab_classes[class]
+            .lock()
+            .expect("SlabClass mutex poisoned")
+            .alloc()?;
+        Some(unsafe { Buffer::new_chunk(ptr, class, index, block, Arc::clone(self)) })
+    }
+
+    /// Installs a fresh 1 MiB backing buffer as a slab of the given class
+    /// and takes the first chunk from it.
+    fn install_backing_and_take(self: &Arc<Self>, class: usize, backing: Buffer) -> Buffer {
+        let (ptr, index, block) = {
+            let mut slab_class = self.slab_classes[class]
+                .lock()
+                .expect("SlabClass mutex poisoned");
+            slab_class.insert_backing(backing);
+            slab_class
+                .alloc()
+                .expect("fresh slab must have free chunks")
+        };
+        unsafe { Buffer::new_chunk(ptr, class, index, block, Arc::clone(self)) }
+    }
+
+    /// Returns a chunk to its slab.
+    ///
+    /// Called automatically when a slab-chunk [`Buffer`] is dropped. If the
+    /// slab becomes fully free and exceeds the empty-slab watermark — or the
+    /// buddy pool has pending demand — the slab's backing buffer is released
+    /// to the buddy pool (outside the class lock; its `Drop` re-enters the
+    /// pool through the regular buddy free path).
+    pub(crate) fn return_chunk(self: &Arc<Self>, class: usize, ptr: NonNull<u8>, index: usize) {
+        let released = {
+            let max_empty = if self.has_demand.load(Ordering::Relaxed) {
+                0
+            } else {
+                self.slab_empty_watermark
+            };
+            self.slab_classes[class]
+                .lock()
+                .expect("SlabClass mutex poisoned")
+                .free(ptr.as_ptr() as usize, index, max_empty)
+        };
+        drop(released);
+    }
+
+    /// Releases all cached empty slabs back to the buddy pool.
+    /// Returns `true` if any slab was released.
+    fn reclaim_empty_slabs(&self) -> bool {
+        let mut any = false;
+        for class in &self.slab_classes {
+            let empties = class
+                .lock()
+                .expect("SlabClass mutex poisoned")
+                .drain_empty();
+            any |= !empties.is_empty();
+            // Dropping the backing buffers takes the buddy pool mutex; the
+            // class lock has already been released.
+            drop(empties);
+        }
+        any
     }
 
     /// Returns the devices associated with this pool.
@@ -190,22 +510,86 @@ impl BufferPool {
 
 impl std::fmt::Debug for BufferPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let inner = self.inner.lock().expect("BufferPool mutex poisoned");
+        let blocks = self
+            .inner
+            .lock()
+            .expect("BufferPool mutex poisoned")
+            .blocks
+            .len();
         f.debug_struct("BufferPool")
-            .field("allocated_memory", &inner.allocated_memory)
-            .field("max_memory", &inner.max_memory)
-            .field("blocks", &inner.blocks.len())
+            .field("allocated_memory", &self.allocated_memory())
+            .field("max_memory", &self.max_memory)
+            .field("blocks", &blocks)
             .finish_non_exhaustive()
     }
 }
 
-/// Sender type for waiting list entries.
-type WaitingSender = oneshot::Sender<Buffer>;
+fn invalid_size_error(size: usize) -> Error {
+    Error::new(
+        ErrorKind::InvalidInput,
+        format!("invalid size: {size} (must be 1-67108864 bytes)"),
+    )
+}
+
+/// A queued asynchronous allocation waiting for capacity.
+struct Waiter {
+    /// When the waiter was queued; used for starvation detection.
+    since: Instant,
+    /// Channel used to hand a buffer directly to the waiter.
+    sender: oneshot::Sender<Buffer>,
+}
+
+/// An anti-starvation reservation for a large waiter.
+///
+/// Created when a waiter for level >= 1 has been queued longer than the
+/// configured starvation timeout. At most one reservation exists at a time.
+/// The reserved waiter is removed from the waiting lists (its buffer arrives
+/// through this reservation, or through the priority claim in
+/// [`PoolInner::serve_waiters`]).
+struct Reservation {
+    /// Channel of the starving waiter.
+    sender: oneshot::Sender<Buffer>,
+    /// Requested allocation level.
+    level: usize,
+    /// The subtree being drained for this waiter, if one has been chosen.
+    /// `None` ("floating") when no drainable subtree exists yet; the waiter
+    /// is then served through the priority claim on public capacity, and an
+    /// upgrade to a subtree is retried on subsequent frees.
+    subtree: Option<ReservedSubtree>,
+}
+
+/// A buddy subtree reserved for a starving waiter.
+///
+/// Free nodes inside the subtree are *absorbed*: unlinked from the free
+/// lists (invisible to regular allocation) while keeping their `Free` state
+/// as an "absorbed" marker. Frees inside the subtree are intercepted before
+/// the regular merge path. Since live buffers inside are eventually dropped
+/// and absorbed capacity can never be re-allocated, `collected` grows
+/// monotonically until the subtree is whole — this is the progress
+/// guarantee that makes starvation impossible.
+struct ReservedSubtree {
+    /// The block containing the reserved subtree.
+    block: NonNull<BuddyBlock>,
+    /// Index of the subtree root within the reservation level.
+    root_index: usize,
+    /// Bytes absorbed so far; the reservation completes when this reaches
+    /// `LEVEL_SIZES[level]`.
+    collected: usize,
+}
+
+// SAFETY: the NonNull<BuddyBlock> is only dereferenced while holding the
+// pool mutex, and the block is owned by (and outlives) the pool.
+unsafe impl Send for ReservedSubtree {}
 
 /// Internal pool state protected by the mutex.
 struct PoolInner {
-    max_memory: usize,
+    /// Total memory budgeted, in bytes: installed blocks plus any 64 MiB
+    /// reservations for blocks currently being created and registered
+    /// outside the lock.
     allocated_memory: usize,
+    /// Per-level merge watermarks for lazy buddy merging.
+    /// See [`BufferPoolBuilder::merge_watermarks`].
+    merge_watermarks: [usize; NUM_LEVELS],
     /// All allocated buddy blocks. Each entry is wrapped in `AliasableBox` to
     /// opt out of the `noalias` guarantee that `Box` carries. This is required
     /// because `Buffer` and intrusive free-list nodes hold `NonNull<BuddyBlock>`
@@ -214,39 +598,108 @@ struct PoolInner {
     /// accesses through the raw pointers.
     blocks: Vec<AliasableBox<BuddyBlock>>,
     free_lists: [IntrusiveList<crate::buddy::FreeNodeData>; NUM_LEVELS],
-    waiting_lists: [VecDeque<WaitingSender>; NUM_LEVELS],
+    /// Pending-merge lists for lazy buddy merging, one per level.
+    ///
+    /// `pending_lists[L]` links parent nodes at level `L` that are in the
+    /// [`NodeState::SplitPending`] state: split, with all 4 children free,
+    /// but whose merge has been deferred. A `Split` parent's intrusive node
+    /// is otherwise unused, so it is reused here at no extra memory cost.
+    ///
+    /// Invariant: a parent is on `pending_lists[L]` (state `SplitPending`)
+    /// if and only if all 4 of its children are free. This makes on-demand
+    /// coalescing O(number of merges performed), independent of block count.
+    /// Level 0 is unused (leaf nodes have no children).
+    pending_lists: [IntrusiveList<crate::buddy::FreeNodeData>; NUM_LEVELS],
+    waiting_lists: [VecDeque<Waiter>; NUM_LEVELS],
     min_waiting_level: Option<usize>,
+    /// Active anti-starvation reservation, if any. See [`Reservation`].
+    reservation: Option<Reservation>,
 }
 
 impl PoolInner {
-    fn allocate_sync(&mut self, size: usize, pool: &Arc<BufferPool>) -> Result<Buffer> {
-        let level = size_to_level(size).ok_or_else(|| {
-            Error::new(
-                ErrorKind::InvalidInput,
-                format!("invalid size: {size} (must be 1-67108864 bytes)"),
-            )
-        })?;
-
-        self.try_allocate(level, pool)
+    /// Pushes a node onto the free list at `level`.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`IntrusiveList::push_front`].
+    unsafe fn push_free(&mut self, level: usize, node: NonNull<FreeNode>) {
+        unsafe {
+            self.free_lists[level].push_front(node);
+        }
     }
 
-    fn try_allocate(&mut self, level: usize, pool: &Arc<BufferPool>) -> Result<Buffer> {
-        if let Some(buffer) = self.try_allocate_from_free_lists(level, Arc::clone(pool)) {
-            return Ok(buffer);
+    /// Pops a node from the free list at `level`.
+    fn pop_free(&mut self, level: usize) -> Option<NonNull<FreeNode>> {
+        self.free_lists[level].pop_front()
+    }
+
+    /// Removes a node from the free list at `level`.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`IntrusiveList::remove`].
+    unsafe fn remove_free(&mut self, level: usize, node: NonNull<FreeNode>) {
+        unsafe {
+            self.free_lists[level].remove(node);
+        }
+    }
+
+    /// Reserves a 64 MiB slot of the memory budget for a new block.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OutOfMemory` if the reservation would exceed the limit.
+    fn try_reserve_block(&mut self, max_memory: usize) -> Result<()> {
+        if self.allocated_memory + SIZE_64MIB > max_memory {
+            return Err(Error::new(ErrorKind::OutOfMemory, "memory limit reached"));
+        }
+        self.allocated_memory += SIZE_64MIB;
+        Ok(())
+    }
+
+    /// Attempts to allocate from local state: free lists first, then
+    /// demand-driven coalescing of deferred quads. Does not grow the pool.
+    fn try_allocate_local(&mut self, level: usize, pool: &Arc<BufferPool>) -> Option<Buffer> {
+        if let Some(buffer) = self.try_allocate_from_free_lists(level, pool) {
+            return Some(buffer);
         }
 
-        // Need to allocate a new 64 MiB block
-        self.allocate_new_block(&pool.devices)?;
+        // Demand-driven coalescing: merging is deferred on free (lazy buddy),
+        // so free quads at lower levels may satisfy this allocation once merged.
+        if self.coalesce_pending(level) {
+            return self.try_allocate_from_free_lists(level, pool);
+        }
 
-        // Try again - should succeed now
-        self.try_allocate_from_free_lists(level, Arc::clone(pool))
-            .ok_or_else(|| Error::other("allocation failed unexpectedly"))
+        // A cancelled reserved waiter may be sitting on absorbed capacity
+        // with no future free to notice the cancellation; reclaim it here so
+        // allocation misses cannot strand memory indefinitely.
+        if self.reclaim_cancelled_reservation() {
+            return self.try_allocate_from_free_lists(level, pool);
+        }
+
+        None
+    }
+
+    /// Releases the reservation if its waiter has been cancelled.
+    /// Returns `true` if a reservation was reclaimed.
+    fn reclaim_cancelled_reservation(&mut self) -> bool {
+        let Some(res) = &self.reservation else {
+            return false;
+        };
+        if !res.sender.is_closed() {
+            return false;
+        }
+        let res = self.reservation.take().unwrap();
+        if let Some(sub) = &res.subtree {
+            self.release_reservation_subtree(res.level, sub);
+        }
+        true
     }
 
     fn try_allocate_from_free_lists(
         &mut self,
         level: usize,
-        pool: Arc<BufferPool>,
+        pool: &Arc<BufferPool>,
     ) -> Option<Buffer> {
         for search_level in level..NUM_LEVELS {
             if !self.free_lists[search_level].is_empty() {
@@ -260,14 +713,18 @@ impl PoolInner {
         &mut self,
         from_level: usize,
         target_level: usize,
-        pool: Arc<BufferPool>,
+        pool: &Arc<BufferPool>,
     ) -> Buffer {
-        let node = self.free_lists[from_level].pop_front().unwrap();
+        let node = self.pop_free(from_level).unwrap();
 
         let block = unsafe { (*node.as_ptr()).data.block };
         let index_in_level = unsafe { (*block.as_ptr()).node_index_in_level(node, from_level) };
 
         let block_ref = unsafe { &mut *block.as_ptr() };
+
+        // Taking this node breaks its (previously complete) buddy quad, so
+        // its parent must leave the pending-merge list, if it was on it.
+        self.demote_pending_parent(block_ref, from_level, index_in_level);
 
         if from_level == target_level {
             block_ref.set_state(from_level, index_in_level, NodeState::Allocated);
@@ -279,7 +736,7 @@ impl PoolInner {
                     from_level,
                     index_in_level,
                     block,
-                    pool,
+                    Arc::clone(pool),
                 )
             }
         } else {
@@ -293,7 +750,7 @@ impl PoolInner {
         from_level: usize,
         from_index: usize,
         target_level: usize,
-        pool: Arc<BufferPool>,
+        pool: &Arc<BufferPool>,
     ) -> Buffer {
         let block_ref = unsafe { &mut *block.as_ptr() };
 
@@ -313,7 +770,7 @@ impl PoolInner {
 
                 let node = block_ref.get_free_node_mut(child_level, child_index);
                 unsafe {
-                    self.free_lists[child_level].push_front(node);
+                    self.push_free(child_level, node);
                 }
             }
 
@@ -330,25 +787,18 @@ impl PoolInner {
                 current_level,
                 current_index,
                 block,
-                pool,
+                Arc::clone(pool),
             )
         }
     }
 
-    fn allocate_new_block(&mut self, devices: &Arc<dyn Devices>) -> Result<()> {
-        if self.allocated_memory + SIZE_64MIB > self.max_memory {
-            return Err(Error::new(ErrorKind::OutOfMemory, "memory limit reached"));
-        }
-
-        // Allocate 64 MiB aligned memory.
-        let aligned = Arc::new(AlignedMemory::new(SIZE_64MIB)?);
-
-        // Register with all devices.
-        let regs = devices.register(&aligned)?;
-
-        // Create buddy block with memory and registrations.
-        let block = BuddyBlock::new(aligned, regs);
-
+    /// Installs a freshly created block into the pool.
+    ///
+    /// The memory budget was already reserved by
+    /// [`PoolInner::try_reserve_block`] before the block was created; the
+    /// caller is expected to allocate its own buffer and then call
+    /// [`PoolInner::serve_waiters`] under the same lock acquisition.
+    fn install_block(&mut self, block: Box<BuddyBlock>) {
         // Wrap in AliasableBox to allow aliasing via NonNull<BuddyBlock> in
         // Buffer and free-list nodes without violating noalias semantics.
         let block = AliasableBox::from_unique(block);
@@ -358,40 +808,368 @@ impl PoolInner {
         // Add root node to level 3 free list.
         unsafe {
             let node = (*block_ptr.as_ptr()).get_free_node_mut(3, 0);
-            self.free_lists[3].push_front(node);
+            self.push_free(3, node);
         }
 
         self.blocks.push(block);
-        self.allocated_memory += SIZE_64MIB;
-
-        Ok(())
     }
 
     pub(crate) fn deallocate_buffer(
         &mut self,
+        pool: &Arc<BufferPool>,
         level: usize,
         index: usize,
         block: NonNull<BuddyBlock>,
     ) {
-        let block_ref = unsafe { &mut *block.as_ptr() };
+        if !self.try_absorb_into_reservation(pool, level, index, block) {
+            let block_ref = unsafe { &mut *block.as_ptr() };
+            self.try_merge(block_ref, level, index);
+            // Starvation check runs before serving so that a freshly
+            // activated reservation can claim this free ahead of smaller
+            // waiters.
+            self.check_starvation(pool);
+        }
+        self.serve_waiters(pool);
+    }
 
-        let (final_level, _final_index) = self.try_merge(block_ref, level, index);
+    /// Hands freed capacity directly to queued waiters.
+    ///
+    /// A starving reserved waiter (if any) gets first claim on public
+    /// capacity at its level. Then, for each waiter (smallest requested size
+    /// first), allocates a buffer on its behalf and sends it through the
+    /// waiter's channel. This eliminates the wake-then-retry race where
+    /// concurrent `allocate()` callers could steal the capacity from a woken
+    /// waiter, and satisfies as many waiters as the freed capacity allows in
+    /// a single pass (no under-notification).
+    ///
+    /// Smallest-first is a deliberate policy: it maximizes the number of
+    /// satisfied waiters. Large waiters are protected from starvation by the
+    /// reservation mechanism (see [`Reservation`]).
+    fn serve_waiters(&mut self, pool: &Arc<BufferPool>) {
+        self.try_complete_reservation_from_lists(pool);
 
-        // Check if we should notify a waiting allocation
-        if let Some(min_waiting) = self.min_waiting_level
-            && final_level >= min_waiting
-        {
-            for wait_level in min_waiting..=final_level {
-                if self.waiting_lists[wait_level].pop_front().is_some() {
-                    // Sender is dropped here, signaling the waiter to retry
-                    self.update_min_waiting_level_on_remove(wait_level);
-                    return;
-                }
+        while let Some(wait_level) = self.min_waiting_level {
+            let Some(buffer) = self.try_allocate_local(wait_level, pool) else {
+                break;
+            };
+
+            let waiter = self.waiting_lists[wait_level]
+                .pop_front()
+                .expect("waiting list at min_waiting_level must be non-empty");
+            self.update_min_waiting_level_on_remove(wait_level);
+
+            if let Err(buffer) = waiter.sender.send(buffer) {
+                // The receiver was dropped (waiter cancelled). Reclaim the
+                // buffer without running Buffer::drop, which would deadlock
+                // by re-locking the pool mutex we are already holding.
+                let (level, index, block) = buffer.into_raw_parts();
+                let block_ref = unsafe { &mut *block.as_ptr() };
+                self.try_merge(block_ref, level, index);
+                // Keep serving: the reclaimed capacity may satisfy the next
+                // waiter in line.
             }
+        }
+
+        // Refresh the demand hint for the slab layer.
+        pool.has_demand.store(
+            self.min_waiting_level.is_some() || self.reservation.is_some(),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Returns `true` if `(level, index)` lies strictly inside the subtree
+    /// rooted at `root_index` of `res_level`.
+    const fn subtree_contains(
+        res_level: usize,
+        root_index: usize,
+        level: usize,
+        index: usize,
+    ) -> bool {
+        level < res_level && (index >> (2 * (res_level - level))) == root_index
+    }
+
+    /// Intercepts a free that falls inside the reserved subtree.
+    ///
+    /// The freed node is absorbed: its state is set to `Free` but it is NOT
+    /// pushed onto the free lists, making it invisible to regular allocation.
+    /// Returns `false` if there is no matching reservation (the caller then
+    /// runs the regular merge path).
+    fn try_absorb_into_reservation(
+        &mut self,
+        pool: &Arc<BufferPool>,
+        level: usize,
+        index: usize,
+        block: NonNull<BuddyBlock>,
+    ) -> bool {
+        let Some(res) = &mut self.reservation else {
+            return false;
+        };
+        let Some(sub) = &mut res.subtree else {
+            return false;
+        };
+        if sub.block != block || !Self::subtree_contains(res.level, sub.root_index, level, index) {
+            return false;
+        }
+
+        if res.sender.is_closed() {
+            // The reserved waiter was cancelled: mark this node absorbed as
+            // well, then release the whole subtree in one pass. (Freeing the
+            // node separately first would double-process it during release.)
+            let res = self.reservation.take().unwrap();
+            let block_ref = unsafe { &mut *block.as_ptr() };
+            block_ref.set_state(level, index, NodeState::Free);
+            self.release_reservation_subtree(res.level, &res.subtree.unwrap());
+            return true;
+        }
+
+        let block_ref = unsafe { &mut *block.as_ptr() };
+        debug_assert_eq!(block_ref.get_state(level, index), NodeState::Allocated);
+        block_ref.set_state(level, index, NodeState::Free); // absorbed marker
+        sub.collected += LEVEL_SIZES[level];
+        self.try_finalize_reservation(pool);
+        true
+    }
+
+    /// Checks for starving large waiters and manages reservation activation.
+    ///
+    /// If a reservation is already active but floating (no subtree), retries
+    /// the subtree upgrade. Otherwise, if the oldest waiter at some level of
+    /// at least 1 (largest level first) has been queued longer than the
+    /// starvation timeout, removes it from the waiting lists and activates a
+    /// reservation for it.
+    fn check_starvation(&mut self, pool: &Arc<BufferPool>) {
+        if let Some(res) = &self.reservation {
+            if res.subtree.is_some() {
+                return;
+            }
+            // Try to upgrade a floating reservation to a drainable subtree.
+            let level = res.level;
+            if let Some(subtree) = self.reserve_subtree(level) {
+                self.reservation.as_mut().unwrap().subtree = Some(subtree);
+                self.try_finalize_reservation(pool);
+            }
+            return;
+        }
+
+        if self.min_waiting_level.is_none() {
+            return;
+        }
+        let now = Instant::now();
+        // Largest level first: big requests are the starvation victims.
+        for level in (1..NUM_LEVELS).rev() {
+            let Some(waiter) = self.waiting_lists[level].front() else {
+                continue;
+            };
+            if now.duration_since(waiter.since) < pool.starvation_timeout {
+                continue;
+            }
+
+            let waiter = self.waiting_lists[level].pop_front().unwrap();
+            self.update_min_waiting_level_on_remove(level);
+            let subtree = self.reserve_subtree(level);
+            self.reservation = Some(Reservation {
+                sender: waiter.sender,
+                level,
+                subtree,
+            });
+            self.try_finalize_reservation(pool);
+            return;
         }
     }
 
-    fn try_merge(&mut self, block: &mut BuddyBlock, level: usize, index: usize) -> (usize, usize) {
+    /// Chooses and claims the best subtree for a reservation at `level`:
+    /// the `Split` node at that level with the most free bytes inside
+    /// (maximum head start). Absorbs its current free nodes.
+    ///
+    /// Returns `None` if no `Split` node exists at that level, in which case
+    /// capacity can only arrive as whole nodes of >= `level`, which the
+    /// priority claim in [`Self::serve_waiters`] picks up directly.
+    fn reserve_subtree(&mut self, level: usize) -> Option<ReservedSubtree> {
+        let mut best: Option<(NonNull<BuddyBlock>, usize, usize)> = None;
+
+        for i in 0..self.blocks.len() {
+            let block_ptr =
+                NonNull::new(std::ptr::from_ref::<BuddyBlock>(&self.blocks[i]).cast_mut()).unwrap();
+            let block_ref = unsafe { &*block_ptr.as_ptr() };
+
+            for root_index in 0..NODES_PER_LEVEL[level] {
+                if block_ref.get_state(level, root_index) != NodeState::Split {
+                    continue;
+                }
+                let mut free_bytes = 0;
+                for (child_level, &child_size) in LEVEL_SIZES.iter().enumerate().take(level) {
+                    let first = root_index << (2 * (level - child_level));
+                    let count = 1usize << (2 * (level - child_level));
+                    for index in first..first + count {
+                        if block_ref.get_state(child_level, index) == NodeState::Free {
+                            free_bytes += child_size;
+                        }
+                    }
+                }
+                if best.is_none_or(|(_, _, bytes)| free_bytes > bytes) {
+                    best = Some((block_ptr, root_index, free_bytes));
+                }
+            }
+        }
+
+        let (block, root_index, _) = best?;
+        let collected = self.absorb_subtree_free_nodes(block, level, root_index);
+        Some(ReservedSubtree {
+            block,
+            root_index,
+            collected,
+        })
+    }
+
+    /// Absorbs all currently free nodes inside the subtree: they are removed
+    /// from the free lists (and their parents from the pending lists) but
+    /// keep their `Free` state as the "absorbed" marker. Returns the number
+    /// of bytes absorbed.
+    fn absorb_subtree_free_nodes(
+        &mut self,
+        block: NonNull<BuddyBlock>,
+        res_level: usize,
+        root_index: usize,
+    ) -> usize {
+        let block_ref = unsafe { &mut *block.as_ptr() };
+        let mut collected = 0;
+
+        for (level, &size) in LEVEL_SIZES.iter().enumerate().take(res_level) {
+            let first = root_index << (2 * (res_level - level));
+            let count = 1usize << (2 * (res_level - level));
+            for index in first..first + count {
+                if block_ref.get_state(level, index) == NodeState::Free {
+                    self.demote_pending_parent(block_ref, level, index);
+                    let node = block_ref.get_free_node_mut(level, index);
+                    unsafe {
+                        self.remove_free(level, node);
+                    }
+                    collected += size;
+                }
+            }
+        }
+
+        collected
+    }
+
+    /// Completes the reservation if its subtree has been fully collected:
+    /// the whole subtree is handed to the waiter as a single buffer.
+    fn try_finalize_reservation(&mut self, pool: &Arc<BufferPool>) {
+        let Some(res) = &self.reservation else {
+            return;
+        };
+        let Some(sub) = &res.subtree else {
+            return;
+        };
+        debug_assert!(sub.collected <= LEVEL_SIZES[res.level]);
+        if sub.collected < LEVEL_SIZES[res.level] {
+            return;
+        }
+
+        let res = self.reservation.take().unwrap();
+        let sub = res.subtree.unwrap();
+        let block_ref = unsafe { &mut *sub.block.as_ptr() };
+
+        // Restore the state invariant for an allocated node: all strict
+        // descendants must read Allocated (clears absorbed markers and stale
+        // Split states alike).
+        for level in 0..res.level {
+            let first = sub.root_index << (2 * (res.level - level));
+            let count = 1usize << (2 * (res.level - level));
+            for index in first..first + count {
+                block_ref.set_state(level, index, NodeState::Allocated);
+            }
+        }
+        block_ref.set_state(res.level, sub.root_index, NodeState::Allocated);
+
+        let ptr = block_ref.get_memory_addr(res.level, sub.root_index);
+        let buffer = unsafe {
+            Buffer::new(
+                NonNull::new(ptr).unwrap(),
+                res.level,
+                sub.root_index,
+                sub.block,
+                Arc::clone(pool),
+            )
+        };
+        if let Err(buffer) = res.sender.send(buffer) {
+            // Cancelled at the finish line: reclaim the whole node.
+            let (level, index, block) = buffer.into_raw_parts();
+            let block_ref = unsafe { &mut *block.as_ptr() };
+            self.try_merge(block_ref, level, index);
+        }
+    }
+
+    /// Priority claim for the reserved waiter: if public capacity at its
+    /// level exists (or can be coalesced), complete the reservation from it
+    /// and release any partially drained subtree back to the pool.
+    ///
+    /// Also detects a cancelled reserved waiter and releases its subtree.
+    fn try_complete_reservation_from_lists(&mut self, pool: &Arc<BufferPool>) {
+        if self.reclaim_cancelled_reservation() {
+            return;
+        }
+        let Some(res) = &self.reservation else {
+            return;
+        };
+
+        let level = res.level;
+        let Some(buffer) = self.try_allocate_local(level, pool) else {
+            return;
+        };
+
+        let res = self.reservation.take().unwrap();
+        if let Some(sub) = &res.subtree {
+            self.release_reservation_subtree(res.level, sub);
+        }
+        if let Err(buffer) = res.sender.send(buffer) {
+            let (level, index, block) = buffer.into_raw_parts();
+            let block_ref = unsafe { &mut *block.as_ptr() };
+            self.try_merge(block_ref, level, index);
+        }
+    }
+
+    /// Returns all absorbed capacity of a released reservation to the pool.
+    ///
+    /// Absorbed markers must all be cleared to `Allocated` *before* any node
+    /// is re-freed: `try_merge` inspects sibling states, and an absorbed
+    /// sibling still marked `Free` is not on any list, so merging with it
+    /// would corrupt the free lists.
+    fn release_reservation_subtree(&mut self, res_level: usize, sub: &ReservedSubtree) {
+        let block_ref = unsafe { &mut *sub.block.as_ptr() };
+
+        let mut absorbed = Vec::new();
+        for level in 0..res_level {
+            let first = sub.root_index << (2 * (res_level - level));
+            let count = 1usize << (2 * (res_level - level));
+            for index in first..first + count {
+                if block_ref.get_state(level, index) == NodeState::Free {
+                    block_ref.set_state(level, index, NodeState::Allocated);
+                    absorbed.push((level, index));
+                }
+            }
+        }
+
+        for (level, index) in absorbed {
+            let block_ref = unsafe { &mut *sub.block.as_ptr() };
+            self.try_merge(block_ref, level, index);
+        }
+    }
+
+    /// Returns `true` if a node freed at `level` should be merged upward.
+    ///
+    /// Lazy buddy policy: merge only if the free list at this level already
+    /// holds enough nodes (watermark reached), or a larger allocation is
+    /// currently waiting (demand-driven). Otherwise keep the node at its
+    /// level so that same-size reallocation avoids a split/merge round trip.
+    fn should_merge(&self, level: usize) -> bool {
+        if self.free_lists[level].len() >= self.merge_watermarks[level] {
+            return true;
+        }
+        ((level + 1)..NUM_LEVELS).any(|l| !self.waiting_lists[l].is_empty())
+    }
+
+    fn try_merge(&mut self, block: &mut BuddyBlock, level: usize, index: usize) {
         let mut current_level = level;
         let mut current_index = index;
 
@@ -400,43 +1178,159 @@ impl PoolInner {
                 block.set_state(current_level, current_index, NodeState::Free);
                 let node = block.get_free_node_mut(current_level, current_index);
                 unsafe {
-                    self.free_lists[current_level].push_front(node);
+                    self.push_free(current_level, node);
                 }
-                return (current_level, current_index);
+                return;
             }
 
             let siblings = BuddyBlock::get_siblings(current_index);
 
-            let all_free = siblings.iter().all(|&idx| {
+            // Note: `current_index` itself is not yet marked Free, so its
+            // parent cannot already be SplitPending at this point.
+            let quad_complete = siblings.iter().all(|&idx| {
                 idx == current_index || block.get_state(current_level, idx) == NodeState::Free
             });
 
-            if !all_free {
-                block.set_state(current_level, current_index, NodeState::Free);
-                let node = block.get_free_node_mut(current_level, current_index);
-                unsafe {
-                    self.free_lists[current_level].push_front(node);
+            if quad_complete && self.should_merge(current_level) {
+                // Eager merge: remove siblings from free list and ascend.
+                for &sibling_idx in &siblings {
+                    if sibling_idx != current_index {
+                        let node = block.get_free_node_mut(current_level, sibling_idx);
+                        unsafe {
+                            self.remove_free(current_level, node);
+                        }
+                    }
+                    block.set_state(current_level, sibling_idx, NodeState::Allocated);
                 }
-                return (current_level, current_index);
+
+                let (parent_level, parent_index) =
+                    BuddyBlock::get_parent(current_level, current_index).unwrap();
+                current_level = parent_level;
+                current_index = parent_index;
+                continue;
             }
 
-            // All siblings are free, remove them from free list and merge
-            for &sibling_idx in &siblings {
-                if sibling_idx != current_index {
-                    let node = block.get_free_node_mut(current_level, sibling_idx);
+            // Stop here: the freed node stays at this level.
+            block.set_state(current_level, current_index, NodeState::Free);
+            let node = block.get_free_node_mut(current_level, current_index);
+            unsafe {
+                self.push_free(current_level, node);
+            }
+
+            if quad_complete {
+                // Deferred merge (lazy buddy): record the parent on the
+                // pending-merge list so coalescing later is O(1) per quad.
+                let (parent_level, parent_index) =
+                    BuddyBlock::get_parent(current_level, current_index).unwrap();
+                debug_assert_eq!(
+                    block.get_state(parent_level, parent_index),
+                    NodeState::Split
+                );
+                block.set_state(parent_level, parent_index, NodeState::SplitPending);
+                let parent_node = block.get_free_node_mut(parent_level, parent_index);
+                unsafe {
+                    self.pending_lists[parent_level].push_front(parent_node);
+                }
+            }
+
+            return;
+        }
+    }
+
+    /// Removes the parent of `(level, index)` from the pending-merge list if
+    /// it was there. Must be called whenever a free node is taken out of its
+    /// free list for allocation, since that breaks the complete buddy quad.
+    fn demote_pending_parent(&mut self, block: &mut BuddyBlock, level: usize, index: usize) {
+        if let Some((parent_level, parent_index)) = BuddyBlock::get_parent(level, index)
+            && block.get_state(parent_level, parent_index) == NodeState::SplitPending
+        {
+            let parent_node = block.get_free_node_mut(parent_level, parent_index);
+            unsafe {
+                self.pending_lists[parent_level].remove(parent_node);
+            }
+            block.set_state(parent_level, parent_index, NodeState::Split);
+        }
+    }
+
+    /// Merges deferred buddy quads from the pending-merge lists, bottom-up,
+    /// until a free node at `target_level` is produced (or nothing is left).
+    ///
+    /// This is the demand-driven counterpart of lazy merging in [`Self::try_merge`]:
+    /// it is invoked when an allocation cannot be satisfied from the free
+    /// lists, before growing the pool with a new 64 MiB block.
+    ///
+    /// Complexity is O(number of merges actually performed) — independent of
+    /// the number of blocks — since complete quads are tracked incrementally
+    /// on the pending lists. Each merge is amortized against the O(1) work
+    /// that deferred it, and the loop exits as soon as the target level gains
+    /// a free node. Returns `true` if at least one merge was performed.
+    fn coalesce_pending(&mut self, target_level: usize) -> bool {
+        let mut merged_any = false;
+
+        // Bottom-up: a merge at level L may complete a quad at level L + 1,
+        // which is then picked up by a later iteration. Merging above
+        // `target_level` cannot help the current allocation, so skip it.
+        'levels: for parent_level in 1..=target_level {
+            loop {
+                if !self.free_lists[target_level].is_empty() {
+                    break 'levels; // Target satisfied, keep the rest deferred.
+                }
+                let Some(parent_node) = self.pending_lists[parent_level].pop_front() else {
+                    break;
+                };
+
+                let block = unsafe { (*parent_node.as_ptr()).data.block };
+                // SAFETY: the block outlives its nodes and we hold the pool mutex.
+                let block_ref = unsafe { &mut *block.as_ptr() };
+                let parent_index = block_ref.node_index_in_level(parent_node, parent_level);
+                debug_assert_eq!(
+                    block_ref.get_state(parent_level, parent_index),
+                    NodeState::SplitPending
+                );
+
+                // Merge the quad: all 4 children are free by invariant.
+                let (child_level, first_child) =
+                    BuddyBlock::get_first_child(parent_level, parent_index).unwrap();
+                for k in 0..4 {
+                    debug_assert_eq!(
+                        block_ref.get_state(child_level, first_child + k),
+                        NodeState::Free
+                    );
+                    let node = block_ref.get_free_node_mut(child_level, first_child + k);
                     unsafe {
-                        self.free_lists[current_level].remove(node);
+                        self.remove_free(child_level, node);
+                    }
+                    block_ref.set_state(child_level, first_child + k, NodeState::Allocated);
+                }
+
+                block_ref.set_state(parent_level, parent_index, NodeState::Free);
+                let node = block_ref.get_free_node_mut(parent_level, parent_index);
+                unsafe {
+                    self.push_free(parent_level, node);
+                }
+                merged_any = true;
+
+                // Cascade: the merged node may complete its own quad.
+                if parent_level < 3 {
+                    let siblings = BuddyBlock::get_siblings(parent_index);
+                    let quad_complete = siblings
+                        .iter()
+                        .all(|&idx| block_ref.get_state(parent_level, idx) == NodeState::Free);
+                    if quad_complete {
+                        let (gp_level, gp_index) =
+                            BuddyBlock::get_parent(parent_level, parent_index).unwrap();
+                        debug_assert_eq!(block_ref.get_state(gp_level, gp_index), NodeState::Split);
+                        block_ref.set_state(gp_level, gp_index, NodeState::SplitPending);
+                        let gp_node = block_ref.get_free_node_mut(gp_level, gp_index);
+                        unsafe {
+                            self.pending_lists[gp_level].push_front(gp_node);
+                        }
                     }
                 }
-                block.set_state(current_level, sibling_idx, NodeState::Allocated);
             }
-
-            // Move up to parent
-            let (parent_level, parent_index) =
-                BuddyBlock::get_parent(current_level, current_index).unwrap();
-            current_level = parent_level;
-            current_index = parent_index;
         }
+
+        merged_any
     }
 
     #[allow(clippy::missing_const_for_fn)]
@@ -503,7 +1397,21 @@ mod tests {
     fn test_allocation_sizes() {
         let pool = test_pool();
 
-        let b1 = pool.allocate(1).unwrap();
+        // Small sizes are served by the slab layer.
+        let s1 = pool.allocate(1).unwrap();
+        assert_eq!(s1.len(), 64 * 1024);
+
+        let s2 = pool.allocate(64 * 1024).unwrap();
+        assert_eq!(s2.len(), 64 * 1024);
+
+        let s3 = pool.allocate(64 * 1024 + 1).unwrap();
+        assert_eq!(s3.len(), 256 * 1024);
+
+        let s4 = pool.allocate(256 * 1024).unwrap();
+        assert_eq!(s4.len(), 256 * 1024);
+
+        // Larger sizes go to the buddy allocator.
+        let b1 = pool.allocate(256 * 1024 + 1).unwrap();
         assert_eq!(b1.len(), SIZE_1MIB);
 
         let b2 = pool.allocate(SIZE_1MIB + 1).unwrap();
@@ -655,6 +1563,674 @@ mod tests {
 
         assert_eq!(b1.len(), SIZE_64MIB);
         assert_eq!(b2.len(), SIZE_64MIB);
+    }
+
+    #[test]
+    fn test_lazy_merge_keeps_nodes_below_watermark() {
+        // High watermarks: merging on free is always deferred.
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .merge_watermarks([64, 16, 4, 0])
+            .build();
+
+        let buffer = pool.allocate(SIZE_1MIB).unwrap();
+        // Splitting 64MiB down to 1MiB leaves 3 free nodes at each level.
+        assert_eq!(pool.free_counts(), [3, 3, 3, 0]);
+        assert_eq!(pool.pending_counts(), [0, 0, 0, 0]);
+
+        drop(buffer);
+        // Lazy merge: the freed node stays at level 0 instead of merging
+        // back up to the root; its parent is tracked as a pending quad.
+        assert_eq!(pool.free_counts(), [4, 3, 3, 0]);
+        assert_eq!(pool.pending_counts(), [0, 1, 0, 0]);
+
+        // Same-size reallocation is served without any split, and the
+        // broken quad leaves the pending list.
+        let _buffer = pool.allocate(SIZE_1MIB).unwrap();
+        assert_eq!(pool.free_counts(), [3, 3, 3, 0]);
+        assert_eq!(pool.pending_counts(), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_zero_watermarks_restore_eager_merge() {
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .merge_watermarks([0, 0, 0, 0])
+            .build();
+
+        let buffer = pool.allocate(SIZE_1MIB).unwrap();
+        assert_eq!(pool.free_counts(), [3, 3, 3, 0]);
+
+        drop(buffer);
+        // Eager merge: everything coalesces back to the 64MiB root.
+        assert_eq!(pool.free_counts(), [0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn test_demand_driven_coalescing_on_alloc() {
+        // Max memory allows two blocks, so this also verifies that deferred
+        // quads are coalesced and reused instead of growing the pool.
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB * 2)
+            .merge_watermarks([64, 16, 4, 0])
+            .build();
+
+        let buffer = pool.allocate(SIZE_1MIB).unwrap();
+        drop(buffer);
+        assert_eq!(pool.free_counts(), [4, 3, 3, 0]);
+        assert_eq!(pool.pending_counts(), [0, 1, 0, 0]);
+        assert_eq!(pool.allocated_memory(), SIZE_64MIB);
+
+        // No free 64MiB node exists; demand-driven coalescing must rebuild
+        // the root from the pending quads (cascading up all three levels)
+        // rather than allocating a second block.
+        let big = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(big.len(), SIZE_64MIB);
+        assert_eq!(pool.allocated_memory(), SIZE_64MIB);
+        assert_eq!(pool.free_counts(), [0, 0, 0, 0]);
+        assert_eq!(pool.pending_counts(), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_coalescing_is_minimal_and_on_demand() {
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .merge_watermarks([64, 16, 4, 0])
+            .build();
+
+        // Occupy four full level-1 quads with 1MiB buffers and drain level 2,
+        // so that only deferred level-0 nodes remain after dropping.
+        let small: Vec<_> = (0..16).map(|_| pool.allocate(SIZE_1MIB).unwrap()).collect();
+        let _large: Vec<_> = (0..3)
+            .map(|_| pool.allocate(LEVEL_SIZES[2]).unwrap())
+            .collect();
+        assert_eq!(pool.free_counts(), [0, 0, 0, 0]);
+
+        drop(small);
+        // Lazy merge keeps all 16 freed nodes at level 0; the 4 complete
+        // quads are tracked on the pending list.
+        assert_eq!(pool.free_counts(), [16, 0, 0, 0]);
+        assert_eq!(pool.pending_counts(), [0, 4, 0, 0]);
+
+        // A 4MiB allocation cannot be served directly; demand-driven
+        // coalescing merges exactly ONE pending quad (early exit) and keeps
+        // the rest deferred at level 0 for future small allocations.
+        let b = pool.allocate(LEVEL_SIZES[1]).unwrap();
+        assert_eq!(b.len(), LEVEL_SIZES[1]);
+        assert_eq!(pool.free_counts(), [12, 0, 0, 0]);
+        assert_eq!(pool.pending_counts(), [0, 3, 0, 0]);
+        assert_eq!(pool.allocated_memory(), SIZE_64MIB);
+
+        // Each further 4MiB demand consumes exactly one more pending quad.
+        let b2 = pool.allocate(LEVEL_SIZES[1]).unwrap();
+        assert_eq!(b2.len(), LEVEL_SIZES[1]);
+        assert_eq!(pool.free_counts(), [8, 0, 0, 0]);
+        assert_eq!(pool.pending_counts(), [0, 2, 0, 0]);
+    }
+
+    #[tokio::test]
+    async fn test_waiter_triggers_merge_on_free() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .merge_watermarks([64, 16, 4, 0])
+            .build();
+
+        let buffers: Vec<_> = (0..4)
+            .map(|_| pool.allocate(LEVEL_SIZES[2]).unwrap())
+            .collect();
+
+        let pool_clone = pool.clone();
+        let handle = tokio::spawn(async move { pool_clone.async_allocate(SIZE_64MIB).await });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Freeing with a 64MiB waiter present must force merging despite the
+        // high watermarks (demand-driven path in should_merge).
+        drop(buffers);
+
+        let result = timeout(Duration::from_secs(1), handle).await;
+        let buffer = result.unwrap().unwrap().unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[test]
+    fn test_lazy_merge_randomized_stress() {
+        // Random alloc/free mix across all levels; debug_asserts in
+        // try_merge/coalesce_pending/demote_pending_parent verify the
+        // pending-list invariant on every transition.
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB * 4)
+            .merge_watermarks([4, 2, 1, 0])
+            .build();
+
+        let mut held: Vec<Buffer> = Vec::new();
+        let mut rng: u64 = 0x9E37_79B9_7F4A_7C15;
+        let mut next = || {
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (rng >> 33) as usize
+        };
+
+        for _ in 0..10_000 {
+            let r = next();
+            if r % 100 < 60 || held.is_empty() {
+                let level = [0, 0, 0, 1, 1, 2, 3][next() % 7];
+                if let Ok(buffer) = pool.allocate(LEVEL_SIZES[level]) {
+                    held.push(buffer);
+                }
+            } else {
+                held.swap_remove(next() % held.len());
+            }
+        }
+
+        drop(held);
+        // Full drain: everything must be reachable again via coalescing.
+        let all: Vec<_> = (0..4).map(|_| pool.allocate(SIZE_64MIB).unwrap()).collect();
+        assert_eq!(all.len(), 4);
+        assert_eq!(pool.free_counts(), [0, 0, 0, 0]);
+        assert_eq!(pool.pending_counts(), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_concurrent_allocation_and_growth() {
+        // Many threads allocate and free concurrently, forcing concurrent
+        // pool growth (block creation happens outside the pool mutex).
+        let pool = test_pool_with_max(SIZE_64MIB * 16);
+        let threads: Vec<_> = (0..8)
+            .map(|t| {
+                let pool = pool.clone();
+                std::thread::spawn(move || {
+                    let mut held = Vec::new();
+                    for i in 0..500 {
+                        let level = (t + i) % 3;
+                        match pool.allocate(LEVEL_SIZES[level]) {
+                            Ok(buffer) => held.push(buffer),
+                            Err(e) => assert_eq!(e.kind(), ErrorKind::OutOfMemory),
+                        }
+                        if i % 3 == 0 {
+                            held.clear();
+                        }
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        // Budget must never be exceeded, even with racing growers.
+        assert!(pool.allocated_memory() <= pool.max_memory());
+
+        // With everything freed, the pool must be fully recoverable.
+        let blocks = pool.allocated_memory() / SIZE_64MIB;
+        let all: Vec<_> = (0..blocks)
+            .map(|_| pool.allocate(SIZE_64MIB).unwrap())
+            .collect();
+        assert_eq!(all.len(), blocks);
+    }
+
+    #[tokio::test]
+    async fn test_handoff_serves_multiple_waiters_from_one_free() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = test_pool_with_max(SIZE_64MIB);
+        let held = pool.allocate(SIZE_64MIB).unwrap();
+
+        // Queue 4 waiters for 16MiB each; the pool is exhausted.
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let pool = pool.clone();
+                tokio::spawn(async move { pool.async_allocate(LEVEL_SIZES[2]).await })
+            })
+            .collect();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // A single free must hand capacity to ALL of them (the old
+        // notify-one design would wake only one and strand the rest).
+        drop(held);
+
+        for handle in handles {
+            let buffer = timeout(Duration::from_secs(1), handle)
+                .await
+                .expect("waiter starved: free did not serve all waiters")
+                .unwrap()
+                .unwrap();
+            assert_eq!(buffer.len(), LEVEL_SIZES[2]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handoff_cancelled_waiter_returns_buffer() {
+        use std::time::Duration;
+
+        let pool = test_pool_with_max(SIZE_64MIB);
+        let held = pool.allocate(SIZE_64MIB).unwrap();
+
+        // Register a waiter, then cancel it before capacity arrives.
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(SIZE_1MIB).await })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waiter.abort();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // The free hands a buffer to the cancelled waiter; the failed send
+        // must reclaim it into the pool instead of leaking it.
+        drop(held);
+
+        // The full 64MiB must be recoverable again.
+        let buffer = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[tokio::test]
+    async fn test_handoff_mixed_sizes_smallest_first() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = test_pool_with_max(SIZE_64MIB);
+        let held = pool.allocate(SIZE_64MIB).unwrap();
+
+        // One large and several small waiters; one 64MiB free fits them all.
+        let big = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(LEVEL_SIZES[2]).await })
+        };
+        let smalls: Vec<_> = (0..3)
+            .map(|_| {
+                let pool = pool.clone();
+                tokio::spawn(async move { pool.async_allocate(SIZE_1MIB).await })
+            })
+            .collect();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        drop(held);
+
+        for handle in smalls.into_iter().chain(std::iter::once(big)) {
+            let buffer = timeout(Duration::from_secs(1), handle)
+                .await
+                .expect("waiter starved")
+                .unwrap()
+                .unwrap();
+            assert!(!buffer.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_starving_waiter_reservation_drains_and_blocks_theft() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .starvation_timeout(Duration::from_millis(10))
+            .build();
+
+        // Fill the pool with 64 small buffers, then queue a 64MiB waiter.
+        let mut held: Vec<_> = (0..64).map(|_| pool.allocate(SIZE_1MIB).unwrap()).collect();
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(SIZE_64MIB).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // The first free after the timeout activates the reservation.
+        held.pop();
+        // From now on, freed capacity is absorbed by the reservation:
+        // fast-path allocations must NOT be able to steal it. (Without the
+        // reservation this allocate would succeed and the waiter would
+        // starve for as long as the churn continues.)
+        assert!(pool.allocate(SIZE_1MIB).is_err());
+
+        // Drain the rest; every free flows to the reserved waiter.
+        held.clear();
+        let buffer = timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("64MiB waiter starved despite reservation")
+            .unwrap()
+            .unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[tokio::test]
+    async fn test_starving_waiter_priority_over_later_small_waiters() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .starvation_timeout(Duration::from_millis(10))
+            .build();
+
+        let held = pool.allocate(SIZE_64MIB).unwrap();
+
+        // A large waiter queues first and ages past the timeout...
+        let big = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(SIZE_64MIB).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // ...then small waiters arrive. Under plain smallest-first they
+        // would carve up the freed 64MiB and strand the large waiter.
+        let smalls: Vec<_> = (0..3)
+            .map(|_| {
+                let pool = pool.clone();
+                tokio::spawn(async move { pool.async_allocate(SIZE_1MIB).await })
+            })
+            .collect();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        drop(held);
+
+        // The aged large waiter must win the freed 64MiB.
+        let big_buffer = timeout(Duration::from_secs(1), big)
+            .await
+            .expect("aged 64MiB waiter lost to later small waiters")
+            .unwrap()
+            .unwrap();
+        assert_eq!(big_buffer.len(), SIZE_64MIB);
+
+        // Releasing it then serves the small waiters normally.
+        drop(big_buffer);
+        for handle in smalls {
+            let buffer = timeout(Duration::from_secs(1), handle)
+                .await
+                .expect("small waiter starved")
+                .unwrap()
+                .unwrap();
+            assert_eq!(buffer.len(), SIZE_1MIB);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_reserved_waiter_releases_absorbed_capacity() {
+        use std::time::Duration;
+
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .starvation_timeout(Duration::from_millis(10))
+            .build();
+
+        let mut held: Vec<_> = (0..64).map(|_| pool.allocate(SIZE_1MIB).unwrap()).collect();
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(SIZE_64MIB).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Activate the reservation and drain part of the pool into it.
+        for _ in 0..16 {
+            held.pop();
+        }
+        assert!(pool.allocate(SIZE_1MIB).is_err());
+
+        // Cancel the reserved waiter; the next free detects the cancellation
+        // and releases all absorbed capacity back to the pool.
+        waiter.abort();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        held.pop();
+
+        let reclaimed = pool.allocate(SIZE_1MIB);
+        assert!(
+            reclaimed.is_ok(),
+            "absorbed capacity leaked after waiter cancellation"
+        );
+        drop(reclaimed);
+
+        // Full recovery: everything must merge back into one 64MiB node.
+        held.clear();
+        let buffer = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_starvation_reservation_randomized_stress() {
+        use std::time::Duration;
+
+        // Small pool + tiny starvation timeout + aggressive request timeouts:
+        // exercises reservation activation, drain, priority completion and
+        // cancellation-release concurrently. The debug_asserts in the merge,
+        // pending and reservation paths check the invariants throughout.
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB * 2)
+            .starvation_timeout(Duration::from_millis(5))
+            .build();
+
+        let tasks: Vec<_> = (0..8u64)
+            .map(|t| {
+                let pool = pool.clone();
+                tokio::spawn(async move {
+                    let mut rng: u64 = t * 7919 + 12345;
+                    let mut next = move || {
+                        rng = rng
+                            .wrapping_mul(6364136223846793005)
+                            .wrapping_add(1442695040888963407);
+                        (rng >> 33) as usize
+                    };
+                    const SIZES: [usize; 9] = [
+                        64 * 1024,
+                        64 * 1024,
+                        256 * 1024,
+                        LEVEL_SIZES[0],
+                        LEVEL_SIZES[0],
+                        LEVEL_SIZES[1],
+                        LEVEL_SIZES[1],
+                        LEVEL_SIZES[2],
+                        LEVEL_SIZES[3],
+                    ];
+                    for _ in 0..200 {
+                        let size = SIZES[next() % SIZES.len()];
+                        let wait_ms = (next() % 25) as u64;
+                        let result = tokio::time::timeout(
+                            Duration::from_millis(wait_ms),
+                            pool.async_allocate(size),
+                        )
+                        .await;
+                        if let Ok(Ok(buffer)) = result {
+                            if next() % 3 == 0 {
+                                tokio::task::yield_now().await;
+                            }
+                            drop(buffer);
+                        }
+                        // Timed-out requests exercise waiter/reservation
+                        // cancellation.
+                    }
+                })
+            })
+            .collect();
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        // Full drain: no capacity may be stranded in reservations or lists.
+        let a = pool.allocate(SIZE_64MIB).unwrap();
+        let b = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(a.len() + b.len(), 2 * SIZE_64MIB);
+    }
+
+    #[test]
+    fn test_chunks_share_slab() {
+        const KIB64: usize = 64 * 1024;
+        let pool = test_pool_with_max(SIZE_64MIB);
+
+        // 16 x 64KiB fit in one slab (one 1MiB buddy leaf).
+        let chunks: Vec<_> = (0..16).map(|_| pool.allocate(KIB64).unwrap()).collect();
+        assert_eq!(pool.allocated_memory(), SIZE_64MIB);
+
+        let base = chunks[0].as_ptr() as usize & !(SIZE_1MIB - 1);
+        let mut addrs: Vec<usize> = chunks.iter().map(|c| c.as_ptr() as usize).collect();
+        addrs.sort_unstable();
+        addrs.dedup();
+        assert_eq!(addrs.len(), 16, "chunks must not overlap");
+        for &addr in &addrs {
+            assert_eq!(addr & !(SIZE_1MIB - 1), base, "chunks must share one slab");
+            assert_eq!(addr % KIB64, 0, "chunks must be 64KiB-aligned");
+        }
+        assert_eq!(pool.slab_free_counts(), [0, 0]);
+
+        // The 17th chunk opens a second slab.
+        let extra = pool.allocate(KIB64).unwrap();
+        assert_ne!(extra.as_ptr() as usize & !(SIZE_1MIB - 1), base);
+        assert_eq!(pool.slab_free_counts(), [15, 0]);
+    }
+
+    #[test]
+    fn test_slab_release_beyond_watermark() {
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .slab_empty_watermark(0)
+            .build();
+
+        let chunk = pool.allocate(64 * 1024).unwrap();
+        drop(chunk);
+
+        // Watermark 0: the empty slab returns to the buddy pool at once,
+        // and the whole 64MiB is recoverable.
+        assert_eq!(pool.slab_free_counts(), [0, 0]);
+        let buffer = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[test]
+    fn test_slab_watermark_caches_empty_slab() {
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .slab_empty_watermark(1)
+            .build();
+
+        let chunk = pool.allocate(64 * 1024).unwrap();
+        let buddy_free = pool.free_counts();
+        drop(chunk);
+
+        // The empty slab stays cached: buddy free lists are untouched and
+        // all 16 chunks are available for reuse without a refill.
+        assert_eq!(pool.slab_free_counts(), [16, 0]);
+        assert_eq!(pool.free_counts(), buddy_free);
+
+        let chunk = pool.allocate(64 * 1024).unwrap();
+        assert_eq!(pool.slab_free_counts(), [15, 0]);
+        assert_eq!(pool.free_counts(), buddy_free);
+        drop(chunk);
+    }
+
+    #[test]
+    fn test_buddy_miss_reclaims_cached_slabs() {
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .slab_empty_watermark(8)
+            .build();
+
+        let chunk = pool.allocate(64 * 1024).unwrap();
+        drop(chunk);
+        assert_eq!(pool.slab_free_counts(), [16, 0]);
+
+        // The 64MiB allocation misses the buddy free lists; the reclaim
+        // hook must release the cached empty slab instead of failing.
+        let buffer = pool.allocate(SIZE_64MIB).unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+        assert_eq!(pool.slab_free_counts(), [0, 0]);
+    }
+
+    #[tokio::test]
+    async fn test_demand_releases_cached_slab_for_waiter() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = BufferPoolBuilder::new(Arc::new(EmptyDevices))
+            .max_memory(SIZE_64MIB)
+            .slab_empty_watermark(8)
+            .build();
+
+        // 63 x 1MiB + one slab (16 x 64KiB) fill the whole pool.
+        let bufs: Vec<_> = (0..63).map(|_| pool.allocate(SIZE_1MIB).unwrap()).collect();
+        let chunks: Vec<_> = (0..16).map(|_| pool.allocate(64 * 1024).unwrap()).collect();
+
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(SIZE_64MIB).await })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        drop(bufs);
+        // The last MiB is held by the slab. Freeing its chunks must release
+        // the (now empty) slab immediately — demand overrides the watermark —
+        // so the waiter can complete.
+        drop(chunks);
+
+        let buffer = timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter starved: cached empty slab was not released")
+            .unwrap()
+            .unwrap();
+        assert_eq!(buffer.len(), SIZE_64MIB);
+    }
+
+    #[tokio::test]
+    async fn test_async_small_allocation_waits_and_completes() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let pool = test_pool_with_max(SIZE_64MIB);
+        let held = pool.allocate(SIZE_64MIB).unwrap();
+
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.async_allocate(64 * 1024).await })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        drop(held);
+
+        let buffer = timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("small waiter starved")
+            .unwrap()
+            .unwrap();
+        assert_eq!(buffer.len(), 64 * 1024);
+    }
+
+    #[test]
+    fn test_chunk_write_read_and_drop() {
+        let pool = test_pool();
+        let mut chunk = pool.allocate(100).unwrap();
+        assert_eq!(chunk.capacity(), 64 * 1024);
+
+        chunk.set_len(0);
+        chunk.extend_from_slice(&[0xAB; 128]).unwrap();
+        assert_eq!(chunk.len(), 128);
+        assert!(chunk.iter().all(|&b| b == 0xAB));
+
+        // Overflowing the (now smaller) capacity must fail cleanly.
+        chunk.set_len(64 * 1024);
+        assert!(chunk.extend_from_slice(&[0u8; 1]).is_err());
+    }
+
+    #[test]
+    fn test_stats_consistency() {
+        let pool = test_pool_with_max(SIZE_64MIB);
+        assert_eq!(pool.allocated_memory(), 0);
+        assert_eq!(pool.free_counts(), [0, 0, 0, 0]);
+
+        let buffer = pool.allocate(SIZE_1MIB).unwrap();
+        assert_eq!(pool.allocated_memory(), SIZE_64MIB);
+        // Atomic counts must mirror the free lists exactly when quiescent.
+        assert_eq!(pool.free_counts(), [3, 3, 3, 0]);
+
+        drop(buffer);
+        let counts = pool.free_counts();
+        let free_bytes: usize = counts
+            .iter()
+            .zip(LEVEL_SIZES.iter())
+            .map(|(c, s)| c * s)
+            .sum();
+        assert_eq!(free_bytes, SIZE_64MIB);
     }
 
     #[test]

--- a/ruapc-bufpool/src/slab.rs
+++ b/ruapc-bufpool/src/slab.rs
@@ -1,0 +1,213 @@
+//! Slab layer for small buffer classes (64 KiB and 256 KiB).
+//!
+//! Small allocations are served from *slabs*: 1 MiB leaves taken from the
+//! buddy pool and carved into fixed-size chunks. Each size class keeps its
+//! own slabs, free-chunk bitmaps and an availability stack, protected by a
+//! per-class mutex at the [`crate::BufferPool`] facade — small-allocation
+//! traffic therefore does not contend on the buddy pool's global mutex.
+//!
+//! Empty slabs (all chunks free) are cached up to a configurable watermark
+//! and returned to the buddy pool beyond it, immediately when the buddy pool
+//! has pending demand (async waiters or an anti-starvation reservation), or
+//! in bulk when a buddy allocation misses. Returning a slab is simply
+//! dropping its backing [`Buffer`], which flows through the regular buddy
+//! free path (merging, waiter handoff and reservation absorption included).
+
+use std::collections::HashMap;
+use std::ptr::NonNull;
+
+use crate::buddy::{BuddyBlock, SIZE_1MIB};
+use crate::buffer::Buffer;
+
+/// Fast non-cryptographic hasher for the slab map: keys are trusted
+/// 1 MiB-aligned addresses, so SipHash's DoS resistance is unnecessary.
+type SlabMap = HashMap<usize, Slab, foldhash::fast::FixedState>;
+
+/// Size of the buddy leaf backing one slab.
+pub(crate) const SLAB_BACKING_SIZE: usize = SIZE_1MIB;
+
+/// Number of slab size classes.
+pub(crate) const NUM_SLAB_CLASSES: usize = 2;
+
+/// Chunk sizes for each slab class.
+pub(crate) const SLAB_CLASS_SIZES: [usize; NUM_SLAB_CLASSES] = [64 * 1024, 256 * 1024];
+
+/// Returns the slab class for a request size, or `None` if the size is 0 or
+/// belongs to the buddy allocator (> 256 KiB).
+pub(crate) fn size_to_class(size: usize) -> Option<usize> {
+    if size == 0 {
+        return None;
+    }
+    SLAB_CLASS_SIZES.iter().position(|&s| size <= s)
+}
+
+/// A single slab: a 1 MiB buddy leaf carved into equal chunks.
+struct Slab {
+    /// Backing buffer from the buddy pool. Dropping it returns the memory
+    /// through the regular buddy free path.
+    backing: Buffer,
+    /// Bitmask of free chunks (bit `i` set = chunk `i` is free).
+    free_mask: u32,
+    /// Whether this slab's address is currently on the `available` stack.
+    in_available: bool,
+}
+
+/// State of one slab size class. Locking is done by the caller.
+pub(crate) struct SlabClass {
+    chunk_size: usize,
+    /// Mask with one bit set per chunk (the "fully free" pattern).
+    full_mask: u32,
+    /// All slabs of this class, keyed by the 1 MiB-aligned base address.
+    slabs: SlabMap,
+    /// LIFO stack of slab base addresses that may have free chunks.
+    /// Entries can be stale (slab became full or was released); they are
+    /// validated and skipped lazily on allocation. Each slab transition
+    /// pushes at most one entry, so staleness is bounded.
+    available: Vec<usize>,
+    /// Number of fully-free slabs currently cached.
+    empty_count: usize,
+}
+
+impl SlabClass {
+    pub(crate) fn new(class: usize) -> Self {
+        let chunk_size = SLAB_CLASS_SIZES[class];
+        let chunks = SLAB_BACKING_SIZE / chunk_size;
+        debug_assert!(chunks <= 32);
+        Self {
+            chunk_size,
+            full_mask: ((1u64 << chunks) - 1) as u32,
+            slabs: SlabMap::default(),
+            available: Vec::new(),
+            empty_count: 0,
+        }
+    }
+
+    /// Takes a free chunk from any available slab.
+    ///
+    /// Returns the chunk pointer, its index within the slab, and the
+    /// `BuddyBlock` containing it (for device registration lookups).
+    pub(crate) fn alloc(&mut self) -> Option<(NonNull<u8>, usize, NonNull<BuddyBlock>)> {
+        loop {
+            let &addr = self.available.last()?;
+            let Some(slab) = self.slabs.get_mut(&addr) else {
+                // Stale entry: the slab was released.
+                self.available.pop();
+                continue;
+            };
+            if slab.free_mask == 0 {
+                // Stale entry: the slab became full.
+                slab.in_available = false;
+                self.available.pop();
+                continue;
+            }
+
+            if slab.free_mask == self.full_mask {
+                self.empty_count -= 1;
+            }
+            let index = slab.free_mask.trailing_zeros() as usize;
+            slab.free_mask &= !(1u32 << index);
+            if slab.free_mask == 0 {
+                slab.in_available = false;
+                self.available.pop();
+            }
+
+            let ptr = unsafe {
+                NonNull::new_unchecked(
+                    slab.backing
+                        .as_ptr()
+                        .cast_mut()
+                        .add(index * self.chunk_size),
+                )
+            };
+            return Some((ptr, index, slab.backing.block_ptr()));
+        }
+    }
+
+    /// Adds a fresh slab backed by a 1 MiB buddy buffer.
+    pub(crate) fn insert_backing(&mut self, backing: Buffer) {
+        let addr = backing.as_ptr() as usize;
+        debug_assert_eq!(
+            addr & (SLAB_BACKING_SIZE - 1),
+            0,
+            "slab backing must be 1MiB-aligned"
+        );
+        debug_assert_eq!(backing.capacity(), SLAB_BACKING_SIZE);
+        let prev = self.slabs.insert(
+            addr,
+            Slab {
+                backing,
+                free_mask: self.full_mask,
+                in_available: true,
+            },
+        );
+        debug_assert!(prev.is_none(), "duplicate slab backing");
+        self.available.push(addr);
+        self.empty_count += 1;
+    }
+
+    /// Returns a chunk to its slab (located via address masking).
+    ///
+    /// If this makes the slab fully free and more than `max_empty` empty
+    /// slabs would be cached, the slab is removed and its backing buffer is
+    /// returned so the caller can release it to the buddy pool (outside the
+    /// class lock).
+    pub(crate) fn free(
+        &mut self,
+        chunk_addr: usize,
+        index: usize,
+        max_empty: usize,
+    ) -> Option<Buffer> {
+        let base = chunk_addr & !(SLAB_BACKING_SIZE - 1);
+        let slab = self
+            .slabs
+            .get_mut(&base)
+            .expect("chunk freed into unknown slab");
+        debug_assert_eq!((chunk_addr - base) / self.chunk_size, index);
+        debug_assert_eq!(slab.free_mask & (1u32 << index), 0, "double free of chunk");
+
+        slab.free_mask |= 1u32 << index;
+        if !slab.in_available {
+            slab.in_available = true;
+            self.available.push(base);
+        }
+
+        if slab.free_mask == self.full_mask {
+            if self.empty_count >= max_empty {
+                let slab = self.slabs.remove(&base).unwrap();
+                return Some(slab.backing);
+            }
+            self.empty_count += 1;
+        }
+        None
+    }
+
+    /// Removes all cached empty slabs, returning their backing buffers so
+    /// the caller can release them to the buddy pool (outside the class
+    /// lock).
+    pub(crate) fn drain_empty(&mut self) -> Vec<Buffer> {
+        if self.empty_count == 0 {
+            return Vec::new();
+        }
+        let full = self.full_mask;
+        let empties: Vec<usize> = self
+            .slabs
+            .iter()
+            .filter(|(_, slab)| slab.free_mask == full)
+            .map(|(&addr, _)| addr)
+            .collect();
+        debug_assert_eq!(empties.len(), self.empty_count);
+        self.empty_count = 0;
+        empties
+            .into_iter()
+            .map(|addr| self.slabs.remove(&addr).unwrap().backing)
+            .collect()
+    }
+
+    /// Total number of free chunks across all slabs of this class.
+    pub(crate) fn free_chunks(&self) -> usize {
+        self.slabs
+            .values()
+            .map(|slab| slab.free_mask.count_ones() as usize)
+            .sum()
+    }
+}


### PR DESCRIPTION
- Buddy-based memory allocation with configurable page sizes (64KiB, 256KiB, etc.)
- Slab layer for 64KiB and 256KiB allocations, amortizing buddy overhead
- Lazy buddy merging with pending-merge lists for reduced contention
- Subtree reservation to prevent large-waiter starvation
- Async waiters receive freed buffers directly, avoiding polling overhead
- Pool growth outside the mutex; lock-free statistics tracking
- Benchmarks for multi-threaded contention and eager vs lazy merging