### PR TITLE
refactor(rdma): dedupe test helpers into rdma::test_utils

### DIFF
--- a/ruapc/src/rdma/mod.rs
+++ b/ruapc/src/rdma/mod.rs
@@ -21,3 +21,6 @@ pub(crate) use rdma_socket::RdmaSocket;
 
 mod rdma_socket_pool;
 pub(crate) use rdma_socket_pool::RdmaSocketPool;
+
+#[cfg(test)]
+pub(crate) mod test_utils;

--- a/ruapc/src/rdma/poller.rs
+++ b/ruapc/src/rdma/poller.rs
@@ -1235,12 +1235,7 @@ mod tests {
     /// driver caps `max_cqe` at 32767, below the default `device_cq_len`).
     #[tokio::test]
     async fn test_cq_len_clamped_to_device_max() {
-        let Ok(devices) = ruapc_rdma::ActiveDevice::available() else {
-            return; // no RDMA device in this environment
-        };
-        let Some(device) = devices.first() else {
-            return;
-        };
+        let device = crate::rdma::test_utils::open_rdma_device();
         let config = PollerConfig {
             cq_len: u32::MAX,
             spin_us: 0,

--- a/ruapc/src/rdma/rdma_device.rs
+++ b/ruapc/src/rdma/rdma_device.rs
@@ -120,19 +120,9 @@ mod tests {
     use super::*;
     use ruapc_bufpool::Device as _;
 
-    fn open_rdma_device() -> ActiveDevice {
-        let active_devices =
-            ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
-        let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
-        active_devices
-            .into_iter()
-            .find(|d| !prefer_rxe || d.info().name.starts_with("rxe"))
-            .expect("no RDMA device matching filter found")
-    }
-
     #[test]
     fn test_rdma_device_debug_format() {
-        let mut rdma = RdmaDevice::new(open_rdma_device());
+        let mut rdma = RdmaDevice::new(crate::rdma::test_utils::open_rdma_device());
         rdma.set_index(DeviceIndex { magic: 0, index: 3 });
         let debug = format!("{rdma:?}");
         assert!(debug.contains("RdmaDevice"));
@@ -140,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_rdma_device_index_and_inner() {
-        let mut rdma = RdmaDevice::new(open_rdma_device());
+        let mut rdma = RdmaDevice::new(crate::rdma::test_utils::open_rdma_device());
         rdma.set_index(DeviceIndex {
             magic: 0,
             index: 42,

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -170,28 +170,13 @@ mod tests {
     use super::*;
     use crate::{SocketPoolConfig, SocketType};
 
-    fn make_rdma_context() -> Context {
-        let active_devices =
-            ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
-        let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
-        let mut devices = crate::Devices::default();
-        for dev in active_devices {
-            if prefer_rxe && !dev.info().name.starts_with("rxe") {
-                continue;
-            }
-            devices.add_rdma_device(dev);
-        }
-        assert!(!devices.rdma_devices().is_empty(), "no RDMA device found");
+    #[tokio::test]
+    async fn test_rdma_service_info_returns_devices() {
         let config = SocketPoolConfig {
             socket_type: SocketType::RDMA,
             ..Default::default()
         };
-        Context::create(&config).expect("failed to create RDMA context")
-    }
-
-    #[tokio::test]
-    async fn test_rdma_service_info_returns_devices() {
-        let ctx = make_rdma_context();
+        let ctx = Context::create(&config).expect("failed to create RDMA context");
         let result = ().info(&ctx, &()).await;
         assert!(result.is_ok());
         let info = result.unwrap();

--- a/ruapc/src/rdma/test_utils.rs
+++ b/ruapc/src/rdma/test_utils.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+/// Opens the first available RDMA device, honoring the `RUAPC_PREFER_RXE`
+/// env var (used in CI to select the `rxe_0` virtual device).
+pub(crate) fn open_rdma_device() -> ruapc_rdma::ActiveDevice {
+    let active_devices =
+        ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
+    let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
+    active_devices
+        .into_iter()
+        .find(|d| !prefer_rxe || d.info().name.starts_with("rxe"))
+        .expect("no RDMA device matching filter found")
+}
+
+/// Builds a [`crate::Devices`] populated with all available RDMA devices,
+/// honoring the `RUAPC_PREFER_RXE` env var.
+pub(crate) fn make_rdma_devices() -> Arc<crate::Devices> {
+    let active_devices =
+        ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
+    let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
+    let mut devices = crate::Devices::default();
+    for dev in active_devices {
+        if prefer_rxe && !dev.info().name.starts_with("rxe") {
+            continue;
+        }
+        devices.add_rdma_device(dev);
+    }
+    assert!(!devices.rdma_devices().is_empty(), "no RDMA device found");
+    Arc::new(devices)
+}

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -533,25 +533,9 @@ mod tests {
     }
 
     #[cfg(feature = "rdma")]
-    fn make_rdma_devices() -> std::sync::Arc<crate::Devices> {
-        let active_devices =
-            ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
-        let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
-        let mut devices = crate::Devices::default();
-        for dev in active_devices {
-            if prefer_rxe && !dev.info().name.starts_with("rxe") {
-                continue;
-            }
-            devices.add_rdma_device(dev);
-        }
-        assert!(!devices.rdma_devices().is_empty(), "no RDMA device found");
-        std::sync::Arc::new(devices)
-    }
-
-    #[cfg(feature = "rdma")]
     #[tokio::test]
     async fn test_socket_pool_rdma_socket_type() {
-        let devices = make_rdma_devices();
+        let devices = crate::rdma::test_utils::make_rdma_devices();
         let config = SocketPoolConfig {
             socket_type: SocketType::RDMA,
             ..Default::default()
@@ -567,7 +551,7 @@ mod tests {
     #[cfg(feature = "rdma")]
     #[tokio::test]
     async fn test_socket_pool_rdma_device_list_from_rdma_pool() {
-        let devices = make_rdma_devices();
+        let devices = crate::rdma::test_utils::make_rdma_devices();
         let config = SocketPoolConfig {
             socket_type: SocketType::RDMA,
             ..Default::default()
@@ -630,7 +614,7 @@ mod tests {
     #[tokio::test]
     async fn test_socket_pool_handle_new_stream_rdma_returns_err() {
         use tokio::net::TcpListener;
-        let devices = make_rdma_devices();
+        let devices = crate::rdma::test_utils::make_rdma_devices();
         let config = SocketPoolConfig {
             socket_type: SocketType::RDMA,
             ..Default::default()

--- a/ruapc/src/sockets/unified/unified_socket_pool.rs
+++ b/ruapc/src/sockets/unified/unified_socket_pool.rs
@@ -157,22 +157,6 @@ impl std::fmt::Debug for UnifiedSocketPool {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "rdma")]
-    fn make_rdma_devices() -> Arc<crate::Devices> {
-        let active_devices =
-            ruapc_rdma::ActiveDevice::available().expect("RDMA devices should be available");
-        let prefer_rxe = std::env::var("RUAPC_PREFER_RXE").is_ok();
-        let mut devices = crate::Devices::default();
-        for dev in active_devices {
-            if prefer_rxe && !dev.info().name.starts_with("rxe") {
-                continue;
-            }
-            devices.add_rdma_device(dev);
-        }
-        assert!(!devices.rdma_devices().is_empty(), "no RDMA device found");
-        Arc::new(devices)
-    }
-
     #[tokio::test]
     async fn test_unified_socket_pool_debug_format() {
         let config = crate::SocketPoolConfig {
@@ -189,7 +173,7 @@ mod tests {
     #[cfg(feature = "rdma")]
     #[tokio::test]
     async fn test_unified_socket_pool_rdma_device_list() {
-        let devices = make_rdma_devices();
+        let devices = crate::rdma::test_utils::make_rdma_devices();
         let config = crate::SocketPoolConfig {
             socket_type: crate::SocketType::UNIFIED,
             ..Default::default()


### PR DESCRIPTION
Consolidate duplicated open_rdma_device/make_rdma_devices test helpers from four test modules into a shared rdma/test_utils.rs, and inline the redundant make_rdma_context in rdma_service tests.