### PR TITLE
feat(rdma): multi-NIC path awareness with load-balanced placement and rebalancing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ RuaPC ("Rua! Procedure Call") is a high-performance Rust RPC library supporting 
 
 - **Enum dispatch over `dyn Trait`**: All runtime polymorphism uses enum variants (e.g. `Socket`, `SocketPool`, `HttpSocket`) instead of trait objects. Two reasons: (1) we don't need open-ended extensibility and won't sacrifice performance for it; (2) `async`-compatible `dyn Trait` has high runtime cost and is not mature enough. When adding new transport types or socket variants, add enum variants rather than trait objects.
 
+### RDMA Multi-NIC Path Awareness
+
+- **Peer identity vs path**: peers are identified by their bootstrap TCP address (the socket_map key); the *path* — the (local NIC, remote NIC) pair, `RdmaPathInfo` — is a per-connection property carried on every `RdmaSocket`. Each stripe of a peer picks its own path.
+- **Placement**: local NIC by least-connections over live per-device counters (`ConnCountGuard`, outbound + inbound); remote NIC by power-of-two-choices over the peer's advertised per-NIC load (`RdmaDeviceInfo.active_connections` in the `info` RPC) — P2C avoids client herding on stale snapshots.
+- **Reachability**: device matching cannot verify routability; QP setup failures (e.g. no route between subnets) blacklist the NIC pair per peer for 30s and placement falls over to the next candidate (`connect_with_failover`).
+- **Maintenance task** (per pool, jittered `rdma.maintenance_interval_ms`, default 5s): fails connections on downed local ports (via the 15s device refresher), prunes dead stripes, replenishes peers up to `connections_per_peer`, and migrates at most one connection per tick to a less-loaded pair (make-before-break with a `drain_timeout_ms` grace; `rebalance_threshold` gives hysteresis, scores exclude the victim's own contribution). Rate-limited migration is what makes traffic return gradually to recovered NICs.
+- **Explicit control**: `Context::with_rdma_path(RdmaPathSelector)` pins requests to matching paths (creating pinned, rebalance-exempt connections on demand); `rdma.device_filter` / `rdma.remote_device_filter` for config-level constraints; `State::rdma_path_report()` / `Server::state()` for introspection (paths, direction, health, per-device load).
+
 ### Wire Format
 - TCP / HTTP-2 stream: `[4B magic "RUA!"][4B total_len][4B meta_len][meta bytes][payload bytes]`
 - RDMA send: a sequence of self-delimiting frames `[4B frame_len][4B meta_len][meta][payload]` (usually one). Window-blocked sends are aggregated by plain frame concatenation; one RDMA send consumes one flow-control credit (= one peer receive buffer) regardless of frame count. The poll thread never parses messages — received buffers are batched per CQ drain and routed (sticky, spilling on pressure) to a fixed pool of dispatch worker tasks (`rdma.dispatch_workers`, default 32), each owning one SPSC queue, that walk and parse the frames; when every worker is saturated the poll thread falls back to a one-shot `tokio::spawn` per batch.

--- a/ruapc-rdma/src/types/device_info.rs
+++ b/ruapc-rdma/src/types/device_info.rs
@@ -16,7 +16,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::{Guid, ibv_device_attr, ibv_gid, ibv_port_attr, ibv_transport_type};
+use crate::{Guid, LinkLayer, ibv_device_attr, ibv_gid, ibv_port_attr, ibv_transport_type};
 
 /// Information about an RDMA device.
 ///
@@ -64,11 +64,39 @@ pub enum GidType {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Gid {
     /// GID index on the port.
-    pub index: u16,
+    pub index: u8,
     /// The GID value.
     pub gid: ibv_gid,
     /// The type of this GID.
     pub gid_type: GidType,
+}
+
+impl Gid {
+    /// Builds a `Gid` entry, returning `None` if the GID cannot be used to
+    /// communicate with remote peers.
+    ///
+    /// RoCE v2 GIDs are derived from the IP addresses assigned to the
+    /// associated net device. GIDs derived from loopback or IPv6 link-local
+    /// (`fe80::/10`) addresses are not routable and cannot be used to reach
+    /// remote hosts, so they are rejected.
+    ///
+    /// IB and RoCE v1 GIDs always use the link-local `fe80::/64` subnet
+    /// prefix by design (IB default subnet prefix / MAC-derived EUI-64), so
+    /// the link-local filter must not be applied to them.
+    pub fn usable(index: u8, gid: ibv_gid, gid_type: GidType) -> Option<Self> {
+        let usable = match gid_type {
+            GidType::RoCEv2 => {
+                let addr = gid.as_ipv6();
+                !addr.is_loopback() && !addr.is_unicast_link_local()
+            }
+            GidType::IB | GidType::RoCEv1 | GidType::Other(_) => true,
+        };
+        usable.then_some(Self {
+            index,
+            gid,
+            gid_type,
+        })
+    }
 }
 
 /// RDMA device port information.
@@ -83,4 +111,112 @@ pub struct Port {
     pub port_attr: ibv_port_attr,
     /// The GID (Global Identifier) list of the port.
     pub gids: Vec<Gid>,
+}
+
+impl Port {
+    /// Looks up a GID entry by its index in the port GID table.
+    pub fn find_gid(&self, gid_index: u8) -> Option<&Gid> {
+        self.gids.iter().find(|gid| gid.index == gid_index)
+    }
+
+    /// Returns `true` if the port can carry RDMA traffic: it is active and
+    /// uses a supported link layer (InfiniBand or Ethernet).
+    pub fn is_usable(&self) -> bool {
+        matches!(
+            self.port_attr.state,
+            crate::ibv_port_state::IBV_PORT_ACTIVE | crate::ibv_port_state::IBV_PORT_ACTIVE_DEFER
+        ) && matches!(
+            self.port_attr.link_layer,
+            LinkLayer::InfiniBand | LinkLayer::Ethernet
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_gid(addr: &str) -> ibv_gid {
+        let bits = addr.parse::<std::net::Ipv6Addr>().unwrap().to_bits();
+        let mut gid = ibv_gid::default();
+        gid.global.subnet_prefix = ((bits >> 64) as u64).to_be();
+        gid.global.interface_id = (bits as u64).to_be();
+        gid
+    }
+
+    fn usable(addr: &str, gid_type: GidType) -> bool {
+        Gid::usable(0, make_gid(addr), gid_type).is_some()
+    }
+
+    #[test]
+    fn test_rocev2_link_local_gid_not_usable() {
+        assert!(!usable("fe80::a288:c2ff:fe32:1a74", GidType::RoCEv2));
+    }
+
+    #[test]
+    fn test_rocev2_loopback_gid_not_usable() {
+        assert!(!usable("::1", GidType::RoCEv2));
+    }
+
+    #[test]
+    fn test_rocev2_routable_gids_usable() {
+        // IPv4-mapped GID (RoCE v2 over IPv4).
+        assert!(usable("::ffff:10.0.0.1", GidType::RoCEv2));
+
+        // Global unicast IPv6 GID.
+        assert!(usable("2001:db8::1", GidType::RoCEv2));
+    }
+
+    #[test]
+    fn test_link_local_prefix_usable_for_ib_and_rocev1() {
+        // IB and RoCE v1 GIDs always live in fe80::/64 by design; the
+        // link-local filter must not remove them.
+        assert!(usable("fe80::a288:c2ff:fe32:1a74", GidType::IB));
+        assert!(usable("fe80::a288:c2ff:fe32:1a74", GidType::RoCEv1));
+        assert!(usable(
+            "fe80::a288:c2ff:fe32:1a74",
+            GidType::Other("custom".into())
+        ));
+    }
+
+    #[test]
+    fn test_usable_keeps_index_and_type() {
+        let gid = Gid::usable(3, make_gid("::ffff:192.168.1.10"), GidType::RoCEv2).unwrap();
+        assert_eq!(gid.index, 3);
+        assert_eq!(gid.gid_type, GidType::RoCEv2);
+    }
+
+    #[test]
+    fn test_port_is_usable() {
+        let mut port = Port {
+            port_num: 1,
+            port_attr: ibv_port_attr::default(),
+            gids: Vec::new(),
+        };
+        // Zeroed attrs: NOP state, unspecified link layer.
+        assert!(!port.is_usable());
+
+        port.port_attr.state = crate::ibv_port_state::IBV_PORT_ACTIVE;
+        port.port_attr.link_layer = LinkLayer::Ethernet;
+        assert!(port.is_usable());
+
+        port.port_attr.state = crate::ibv_port_state::IBV_PORT_DOWN;
+        assert!(!port.is_usable());
+
+        port.port_attr.state = crate::ibv_port_state::IBV_PORT_ACTIVE;
+        port.port_attr.link_layer = LinkLayer::Unspecified;
+        assert!(!port.is_usable());
+    }
+
+    #[test]
+    fn test_port_find_gid() {
+        let gid = Gid::usable(5, make_gid("::ffff:10.0.0.1"), GidType::RoCEv2).unwrap();
+        let port = Port {
+            port_num: 1,
+            port_attr: ibv_port_attr::default(),
+            gids: vec![gid],
+        };
+        assert_eq!(port.find_gid(5).map(|g| g.index), Some(5));
+        assert!(port.find_gid(0).is_none());
+    }
 }

--- a/ruapc-rdma/src/types/gid.rs
+++ b/ruapc-rdma/src/types/gid.rs
@@ -47,6 +47,11 @@ impl ibv_gid {
     pub fn is_null(&self) -> bool {
         self.interface_id() == 0
     }
+
+    /// Checks if the GID is an IPv6 unicast link-local address (`fe80::/10`).
+    pub fn is_unicast_link_local(&self) -> bool {
+        self.as_ipv6().is_unicast_link_local()
+    }
 }
 
 impl std::fmt::Debug for ibv_gid {

--- a/ruapc-rdma/src/verbs/context.rs
+++ b/ruapc-rdma/src/verbs/context.rs
@@ -60,7 +60,7 @@ impl Context {
     }
 
     /// Queries a GID for the specified port and index.
-    pub fn query_gid(&self, port_num: u8, gid_index: u16) -> Result<crate::ibv_gid> {
+    pub fn query_gid(&self, port_num: u8, gid_index: u8) -> Result<crate::ibv_gid> {
         let mut gid = crate::ibv_gid::default();
         let ret =
             unsafe { crate::ibv_query_gid(self.ptr, port_num as _, gid_index as _, &mut gid) };
@@ -75,7 +75,7 @@ impl Context {
     pub fn query_gid_type(
         &self,
         port_num: u8,
-        gid_index: u16,
+        gid_index: u8,
         ibdev_path: &Path,
         port_attr: &crate::ibv_port_attr,
     ) -> Result<GidType> {

--- a/ruapc-rdma/src/verbs/device.rs
+++ b/ruapc-rdma/src/verbs/device.rs
@@ -160,8 +160,13 @@ impl ActiveDevice {
         MemoryRegion::register(&self.pd, memory, access as _)
     }
 
-    /// Updates device attributes by querying the hardware.
-    pub fn update_attr(&mut self) -> Result<()> {
+    /// Queries the hardware and returns a fresh snapshot of the device
+    /// information (attributes, ports, and usable GIDs).
+    ///
+    /// Unusable GIDs (e.g. RoCE v2 GIDs derived from loopback or link-local
+    /// addresses, see [`crate::is_gid_usable`]) are filtered out at
+    /// collection time and never appear in the returned snapshot.
+    pub fn query_device_info(&self) -> Result<DeviceInfo> {
         let device_attr = self.context.query_device()?;
 
         let mut ports = Vec::with_capacity(device_attr.phys_port_cnt as usize);
@@ -176,27 +181,35 @@ impl ActiveDevice {
             });
         }
 
-        self.info.device_attr = device_attr;
-        self.info.ports = ports;
+        Ok(DeviceInfo {
+            device_attr,
+            ports,
+            ..self.info.clone()
+        })
+    }
 
+    /// Updates the cached device attributes by querying the hardware.
+    pub fn update_attr(&mut self) -> Result<()> {
+        self.info = self.query_device_info()?;
         Ok(())
     }
 
     fn collect_port_gids(&self, port_num: u8, port_attr: &crate::ibv_port_attr) -> Vec<Gid> {
-        let mut gids = Vec::with_capacity(port_attr.gid_tbl_len as usize);
-        for gid_index in 0..port_attr.gid_tbl_len as u16 {
+        // GID indices are exchanged as `u8` during connection negotiation,
+        // so entries beyond index 255 are unusable and not collected.
+        let gid_tbl_len = port_attr.gid_tbl_len.clamp(0, 1 + u8::MAX as i32);
+        let mut gids = Vec::with_capacity(gid_tbl_len as usize);
+        for gid_index in 0..gid_tbl_len {
+            let gid_index = gid_index as u8;
             let Ok(gid) = self.context.query_gid(port_num, gid_index) else {
                 continue;
             };
             if let Ok(gid_type) =
                 self.context
                     .query_gid_type(port_num, gid_index, &self.info.ibdev_path, port_attr)
+                && let Some(gid) = Gid::usable(gid_index, gid, gid_type)
             {
-                gids.push(Gid {
-                    index: gid_index,
-                    gid,
-                    gid_type,
-                })
+                gids.push(gid);
             }
         }
         gids

--- a/ruapc/src/core/client.rs
+++ b/ruapc/src/core/client.rs
@@ -113,10 +113,28 @@ impl Client {
                 let socket_type = self
                     .socket_type
                     .unwrap_or(ctx.state.socket_pool.socket_type());
-                ctx.state
+                #[cfg(feature = "rdma")]
+                let socket = match &ctx.rdma_path {
+                    Some(selector) if socket_type == SocketType::RDMA => {
+                        ctx.state
+                            .socket_pool
+                            .acquire_rdma_path(socket_addr, selector, &ctx.state)
+                            .await?
+                    }
+                    _ => {
+                        ctx.state
+                            .socket_pool
+                            .acquire(socket_addr, socket_type, &ctx.state)
+                            .await?
+                    }
+                };
+                #[cfg(not(feature = "rdma"))]
+                let socket = ctx
+                    .state
                     .socket_pool
                     .acquire(socket_addr, socket_type, &ctx.state)
-                    .await?
+                    .await?;
+                socket
             }
         };
 

--- a/ruapc/src/core/context.rs
+++ b/ruapc/src/core/context.rs
@@ -53,6 +53,10 @@ pub struct Context {
     pub(crate) endpoint: SocketEndpoint,
     /// Message metadata for the current RPC operation.
     pub msg_meta: MsgMeta,
+    /// Optional constraint on the RDMA path (NIC pair) used by requests
+    /// issued through this context. See [`Context::with_rdma_path`].
+    #[cfg(feature = "rdma")]
+    pub(crate) rdma_path: Option<crate::rdma::RdmaPathSelector>,
 }
 
 impl Context {
@@ -69,6 +73,8 @@ impl Context {
             endpoint: SocketEndpoint::Invalid,
             drop_guard: Some(Arc::new(drop_guard)),
             msg_meta: MsgMeta::default(),
+            #[cfg(feature = "rdma")]
+            rdma_path: None,
         })
     }
 
@@ -82,6 +88,7 @@ impl Context {
             endpoint: SocketEndpoint::Address(*addr),
             drop_guard: None,
             msg_meta: MsgMeta::default(),
+            rdma_path: None,
         }
     }
 
@@ -93,7 +100,34 @@ impl Context {
             endpoint: SocketEndpoint::Address(addr),
             drop_guard: self.drop_guard.clone(),
             msg_meta: MsgMeta::default(),
+            #[cfg(feature = "rdma")]
+            rdma_path: self.rdma_path.clone(),
         }
+    }
+
+    /// Constrains RDMA requests issued through this context to
+    /// connections whose path (local NIC, remote NIC) matches `selector`;
+    /// a matching connection is established on demand (and kept pinned:
+    /// it is exempt from automatic rebalancing).
+    ///
+    /// Only affects requests using [`SocketType::RDMA`](crate::SocketType);
+    /// other transports ignore the selector.
+    ///
+    /// ```rust,no_run
+    /// # use ruapc::{Context, RdmaPathSelector, SocketPoolConfig};
+    /// # use std::{net::SocketAddr, str::FromStr};
+    /// let ctx = Context::create(&SocketPoolConfig::default()).unwrap();
+    /// let addr = SocketAddr::from_str("127.0.0.1:8000").unwrap();
+    /// let ctx = ctx
+    ///     .with_addr(addr)
+    ///     .with_rdma_path(RdmaPathSelector::local_device("mlx5_0"));
+    /// ```
+    #[cfg(feature = "rdma")]
+    #[must_use]
+    pub fn with_rdma_path(&self, selector: crate::rdma::RdmaPathSelector) -> Self {
+        let mut ctx = self.clone();
+        ctx.rdma_path = Some(selector);
+        ctx
     }
 
     /// Creates a server-side context with an established socket connection.
@@ -104,6 +138,8 @@ impl Context {
             endpoint: SocketEndpoint::Connected(socket),
             drop_guard: None,
             msg_meta,
+            #[cfg(feature = "rdma")]
+            rdma_path: None,
         }
     }
 

--- a/ruapc/src/core/server.rs
+++ b/ruapc/src/core/server.rs
@@ -62,6 +62,13 @@ impl Server {
         })
     }
 
+    /// The server's shared state (router, socket pool, buffer pool);
+    /// useful for introspection such as
+    /// [`State::rdma_path_report`](crate::State::rdma_path_report).
+    pub fn state(&self) -> &Arc<State> {
+        &self.state
+    }
+
     /// Stops the server, closing all listeners and connections.
     ///
     /// This method initiates a graceful shutdown by:

--- a/ruapc/src/core/state.rs
+++ b/ruapc/src/core/state.rs
@@ -137,6 +137,24 @@ impl State {
     pub(crate) fn drop_guard(&self) -> DropGuard {
         self.socket_pool.drop_guard()
     }
+
+    /// Snapshot of every live RDMA connection with its path (local NIC,
+    /// remote NIC) and the per-device connection counts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorKind::InvalidArgument`](crate::ErrorKind::InvalidArgument)
+    /// when the socket pool has no RDMA support (not an RDMA/UNIFIED pool).
+    #[cfg(feature = "rdma")]
+    pub async fn rdma_path_report(&self) -> Result<crate::RdmaPathReport> {
+        match self.socket_pool.rdma_pool() {
+            Some(pool) => Ok(pool.path_report().await),
+            None => Err(crate::Error::new(
+                crate::ErrorKind::InvalidArgument,
+                "RDMA is not supported: invalid socket type".into(),
+            )),
+        }
+    }
 }
 
 impl std::fmt::Debug for State {

--- a/ruapc/src/lib.rs
+++ b/ruapc/src/lib.rs
@@ -34,3 +34,8 @@ pub use ruapc_bufpool::Devices as _;
 
 #[cfg(feature = "rdma")]
 mod rdma;
+#[cfg(feature = "rdma")]
+pub use rdma::{
+    NicSelector, RdmaConnDirection, RdmaDeviceLoad, RdmaNicInfo, RdmaPathEntry, RdmaPathInfo,
+    RdmaPathReport, RdmaPathSelector,
+};

--- a/ruapc/src/rdma/endpoint.rs
+++ b/ruapc/src/rdma/endpoint.rs
@@ -63,6 +63,9 @@ pub struct RdmaConnectionConfig {
 pub struct ConnectRequest {
     /// Client endpoint to connect with.
     pub endpoint: Endpoint,
+    /// Name of the client-side RDMA device this connection originates
+    /// from; gives the server full path (NIC pair) visibility.
+    pub source_device: String,
     /// Server device/port/GID that should accept this connection.
     pub target: DeviceSelection,
     /// Queue Pair settings negotiated by the client for this connection.

--- a/ruapc/src/rdma/mod.rs
+++ b/ruapc/src/rdma/mod.rs
@@ -1,6 +1,12 @@
 mod endpoint;
 pub(crate) use endpoint::{ConnectRequest, DeviceSelection, Endpoint, RdmaConnectionConfig};
 
+mod path;
+pub use path::{
+    NicSelector, RdmaConnDirection, RdmaDeviceLoad, RdmaNicInfo, RdmaPathEntry, RdmaPathInfo,
+    RdmaPathReport, RdmaPathSelector,
+};
+
 mod rdma_device;
 pub(crate) use rdma_device::RdmaDevice;
 
@@ -20,7 +26,7 @@ mod rdma_socket;
 pub(crate) use rdma_socket::RdmaSocket;
 
 mod rdma_socket_pool;
-pub(crate) use rdma_socket_pool::RdmaSocketPool;
+pub(crate) use rdma_socket_pool::{ConnCountGuard, RdmaSocketPool};
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/ruapc/src/rdma/path.rs
+++ b/ruapc/src/rdma/path.rs
@@ -1,0 +1,262 @@
+//! RDMA path awareness: NIC identities, path selectors and path reports.
+//!
+//! A *path* is the pair of NICs an RDMA connection runs on. Peers are still
+//! identified by their bootstrap TCP address; the path is a property of
+//! each individual connection (stripe), giving full NIC visibility and
+//! control without changing the peer identity.
+
+use std::net::{IpAddr, SocketAddr};
+
+use ruapc_rdma::ibv_gid;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Best-effort IP address carried by a GID.
+///
+/// RoCE v2 GIDs embed the IP address of the associated net device
+/// (IPv4-mapped for RoCE v2 over IPv4). IB and RoCE v1 GIDs are link-local
+/// EUI-64 values that do not correspond to an IP, so they yield `None`.
+pub(crate) fn gid_ip(gid: &ibv_gid) -> Option<IpAddr> {
+    if gid.is_null() {
+        return None;
+    }
+    let v6 = gid.as_ipv6();
+    if v6.is_unicast_link_local() {
+        return None;
+    }
+    Some(v6.to_ipv4_mapped().map_or(IpAddr::V6(v6), IpAddr::V4))
+}
+
+/// Identity of one NIC endpoint (device + port + GID) of an RDMA path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaNicInfo {
+    /// RDMA device name (e.g. `mlx5_0`).
+    pub device: String,
+    /// Port number on the device (1-based).
+    pub port_num: u8,
+    /// GID index used on that port.
+    pub gid_index: u8,
+    /// IP address carried by the GID (RoCE v2 only; `None` for IB/RoCE v1).
+    pub ip: Option<IpAddr>,
+}
+
+/// The pair of NICs an RDMA connection runs on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaPathInfo {
+    /// NIC on this side of the connection.
+    pub local: RdmaNicInfo,
+    /// NIC on the peer side of the connection.
+    pub remote: RdmaNicInfo,
+}
+
+/// Selects a NIC either by device name or by the IP its GID is derived
+/// from (RoCE v2). IP selectors never match IB / RoCE v1 NICs, whose GIDs
+/// carry no IP.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum NicSelector {
+    /// Match by RDMA device name (e.g. `mlx5_0`).
+    Device(String),
+    /// Match by the IP address embedded in the NIC's RoCE v2 GID.
+    Ip(IpAddr),
+}
+
+impl NicSelector {
+    /// Whether `nic` satisfies this selector.
+    #[must_use]
+    pub fn matches(&self, nic: &RdmaNicInfo) -> bool {
+        match self {
+            NicSelector::Device(name) => nic.device == *name,
+            NicSelector::Ip(ip) => nic.ip == Some(*ip),
+        }
+    }
+}
+
+/// Constrains which (local NIC, remote NIC) pair an RDMA connection may
+/// use. `None` on a side leaves that side unconstrained.
+///
+/// Attached to a [`Context`](crate::Context) via
+/// [`with_rdma_path`](crate::Context::with_rdma_path): the request then
+/// only uses (or establishes) connections whose path matches.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaPathSelector {
+    /// Constraint on the local NIC.
+    pub local: Option<NicSelector>,
+    /// Constraint on the remote NIC.
+    pub remote: Option<NicSelector>,
+}
+
+impl RdmaPathSelector {
+    /// Selects a specific local NIC by device name.
+    #[must_use]
+    pub fn local_device(name: impl Into<String>) -> Self {
+        Self {
+            local: Some(NicSelector::Device(name.into())),
+            remote: None,
+        }
+    }
+
+    /// Selects a specific remote NIC by device name.
+    #[must_use]
+    pub fn remote_device(name: impl Into<String>) -> Self {
+        Self {
+            local: None,
+            remote: Some(NicSelector::Device(name.into())),
+        }
+    }
+
+    /// Selects a specific local NIC by GID-embedded IP (RoCE v2).
+    #[must_use]
+    pub fn local_ip(ip: IpAddr) -> Self {
+        Self {
+            local: Some(NicSelector::Ip(ip)),
+            remote: None,
+        }
+    }
+
+    /// Selects a specific remote NIC by GID-embedded IP (RoCE v2).
+    #[must_use]
+    pub fn remote_ip(ip: IpAddr) -> Self {
+        Self {
+            local: None,
+            remote: Some(NicSelector::Ip(ip)),
+        }
+    }
+
+    /// Whether `path` satisfies both sides of this selector.
+    #[must_use]
+    pub fn matches(&self, path: &RdmaPathInfo) -> bool {
+        self.local.as_ref().is_none_or(|s| s.matches(&path.local))
+            && self.remote.as_ref().is_none_or(|s| s.matches(&path.remote))
+    }
+}
+
+/// Direction of an RDMA connection relative to this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum RdmaConnDirection {
+    /// Established by this side (client role).
+    Outbound,
+    /// Accepted from a peer (server role).
+    Inbound,
+}
+
+/// One RDMA connection and the path it runs on.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaPathEntry {
+    /// Bootstrap TCP address of the peer (outbound connections only).
+    pub peer: Option<SocketAddr>,
+    /// Whether this side established or accepted the connection.
+    pub direction: RdmaConnDirection,
+    /// The NIC pair the connection runs on.
+    pub path: RdmaPathInfo,
+    /// Local queue pair number.
+    pub qp_num: u32,
+    /// Whether the connection is usable (not in the error state).
+    pub healthy: bool,
+    /// Whether the connection was created for an explicit path selector;
+    /// pinned connections are exempt from rebalancing.
+    pub pinned: bool,
+}
+
+/// Live connection count of one local RDMA device.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaDeviceLoad {
+    /// RDMA device name.
+    pub device: String,
+    /// Live connections (outbound + inbound) on this device.
+    pub connections: usize,
+}
+
+/// Snapshot of all live RDMA connections and per-device load.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaPathReport {
+    /// Per-device live connection counts.
+    pub devices: Vec<RdmaDeviceLoad>,
+    /// Every live connection with its path.
+    pub paths: Vec<RdmaPathEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_gid(addr: &str) -> ibv_gid {
+        let bits = addr.parse::<std::net::Ipv6Addr>().unwrap().to_bits();
+        let mut gid = ibv_gid::default();
+        gid.global.subnet_prefix = ((bits >> 64) as u64).to_be();
+        gid.global.interface_id = (bits as u64).to_be();
+        gid
+    }
+
+    fn nic(device: &str, ip: Option<&str>) -> RdmaNicInfo {
+        RdmaNicInfo {
+            device: device.into(),
+            port_num: 1,
+            gid_index: 0,
+            ip: ip.map(|s| s.parse().unwrap()),
+        }
+    }
+
+    #[test]
+    fn test_gid_ip_v4_mapped() {
+        assert_eq!(
+            gid_ip(&make_gid("::ffff:10.1.2.3")),
+            Some("10.1.2.3".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_gid_ip_v6_global() {
+        assert_eq!(
+            gid_ip(&make_gid("2001:db8::1")),
+            Some("2001:db8::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_gid_ip_link_local_and_null() {
+        // IB / RoCE v1 style link-local GIDs carry no IP.
+        assert_eq!(gid_ip(&make_gid("fe80::a288:c2ff:fe32:1a74")), None);
+        assert_eq!(gid_ip(&ibv_gid::default()), None);
+    }
+
+    #[test]
+    fn test_nic_selector_matches() {
+        let n = nic("mlx5_0", Some("10.0.0.1"));
+        assert!(NicSelector::Device("mlx5_0".into()).matches(&n));
+        assert!(!NicSelector::Device("mlx5_1".into()).matches(&n));
+        assert!(NicSelector::Ip("10.0.0.1".parse().unwrap()).matches(&n));
+        assert!(!NicSelector::Ip("10.0.0.2".parse().unwrap()).matches(&n));
+        // IP selectors never match NICs without a GID-embedded IP.
+        assert!(!NicSelector::Ip("10.0.0.1".parse().unwrap()).matches(&nic("mlx5_0", None)));
+    }
+
+    #[test]
+    fn test_path_selector_matches() {
+        let path = RdmaPathInfo {
+            local: nic("mlx5_0", Some("10.0.0.1")),
+            remote: nic("mlx5_1", Some("10.0.0.2")),
+        };
+        assert!(RdmaPathSelector::default().matches(&path));
+        assert!(RdmaPathSelector::local_device("mlx5_0").matches(&path));
+        assert!(!RdmaPathSelector::local_device("mlx5_1").matches(&path));
+        assert!(RdmaPathSelector::remote_device("mlx5_1").matches(&path));
+        assert!(RdmaPathSelector::remote_ip("10.0.0.2".parse().unwrap()).matches(&path));
+        assert!(!RdmaPathSelector::remote_ip("10.0.0.9".parse().unwrap()).matches(&path));
+        let both = RdmaPathSelector {
+            local: Some(NicSelector::Device("mlx5_0".into())),
+            remote: Some(NicSelector::Ip("10.0.0.9".parse().unwrap())),
+        };
+        assert!(!both.matches(&path));
+    }
+
+    #[test]
+    fn test_selector_serde_roundtrip() {
+        let selector = RdmaPathSelector {
+            local: Some(NicSelector::Device("mlx5_0".into())),
+            remote: Some(NicSelector::Ip("10.0.0.2".parse().unwrap())),
+        };
+        let json = serde_json::to_string(&selector).unwrap();
+        let recovered: RdmaPathSelector = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, selector);
+    }
+}

--- a/ruapc/src/rdma/poller.rs
+++ b/ruapc/src/rdma/poller.rs
@@ -386,6 +386,9 @@ pub struct RegisterConn {
     pub supervisor_guard: TaskSupervisorGuard,
     /// Buffer pool bytes pinned by this connection's receive ring.
     pub ring_reservation: RingReservation,
+    /// Keeps the pool's per-device connection count accurate until the
+    /// poll thread tears this connection down.
+    pub conn_count_guard: super::ConnCountGuard,
 }
 
 /// State shared between registrars and the poll thread: the slot
@@ -797,6 +800,7 @@ struct ConnState {
     _budget: BudgetGuard,
     _supervisor_guard: TaskSupervisorGuard,
     _ring_reservation: RingReservation,
+    _conn_count_guard: super::ConnCountGuard,
 }
 
 impl ConnState {
@@ -822,6 +826,7 @@ impl ConnState {
             _budget: budget,
             _supervisor_guard: reg.supervisor_guard,
             _ring_reservation: reg.ring_reservation,
+            _conn_count_guard: reg.conn_count_guard,
         }
     }
 

--- a/ruapc/src/rdma/rdma_device.rs
+++ b/ruapc/src/rdma/rdma_device.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use ruapc_bufpool::DeviceIndex;
-use ruapc_rdma::{ActiveDevice, Context, DeviceInfo, Gid, GidType, ProtectionDomain};
+use ruapc_rdma::{ActiveDevice, Context, DeviceInfo, ProtectionDomain};
 
 pub struct RdmaDevice {
     index: DeviceIndex,
@@ -32,57 +32,13 @@ impl RdmaDevice {
         self.info.load_full()
     }
 
+    /// Refreshes the cached device info snapshot from the hardware.
+    ///
+    /// GID filtering (RoCE v2 loopback / link-local) happens at collection
+    /// time inside [`ActiveDevice::query_device_info`].
     pub fn refresh_port_attrs(&self) -> ruapc_rdma::Result<()> {
-        let mut info = (*self.info()).clone();
-        let device_attr = self.inner.context().query_device()?;
-
-        let mut ports = Vec::with_capacity(device_attr.phys_port_cnt as usize);
-        for port_num in 1..=device_attr.phys_port_cnt {
-            let port_attr = self.inner.context().query_port(port_num)?;
-            let gids = self.collect_port_gids(port_num, &port_attr, &info);
-            ports.push(ruapc_rdma::Port {
-                port_num,
-                port_attr,
-                gids,
-            });
-        }
-
-        info.device_attr = device_attr;
-        info.ports = ports;
-        self.info.store(Arc::new(info));
+        self.info.store(Arc::new(self.inner.query_device_info()?));
         Ok(())
-    }
-
-    fn collect_port_gids(
-        &self,
-        port_num: u8,
-        port_attr: &ruapc_rdma::ibv_port_attr,
-        info: &DeviceInfo,
-    ) -> Vec<Gid> {
-        let mut gids = Vec::with_capacity(port_attr.gid_tbl_len as usize);
-        for gid_index in 0..port_attr.gid_tbl_len as u16 {
-            let Ok(gid) = self.inner.context().query_gid(port_num, gid_index) else {
-                continue;
-            };
-            if let Ok(gid_type) = self.inner.context().query_gid_type(
-                port_num,
-                gid_index,
-                &info.ibdev_path,
-                port_attr,
-            ) {
-                // Filter out loopback addresses for RoCE v2 GIDs since they
-                // cannot be used for RDMA communication.
-                if matches!(gid_type, GidType::RoCEv2) && gid.as_ipv6().is_loopback() {
-                    continue;
-                }
-                gids.push(Gid {
-                    index: gid_index,
-                    gid,
-                    gid_type,
-                });
-            }
-        }
-        gids
     }
 }
 

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -1,48 +1,37 @@
-use ruapc_rdma::{GidType, LinkLayer, ibv_gid, ibv_mtu, ibv_port_state};
+use ruapc_rdma::{Gid, LinkLayer};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{Context, RdmaQueuePairConfig, Result, rdma, service};
 
-/// Minimal port information for RDMA connection negotiation.
+/// Port information advertised for RDMA connection negotiation.
+///
+/// Deliberately kept independent of the `ibv_*` structures generated from
+/// the ibverbs headers: it carries exactly the fields the peer needs to
+/// select a port/GID pair, nothing else. Only usable ports (active, with an
+/// InfiniBand or Ethernet link layer) are advertised, so no port state
+/// travels on the wire.
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct RdmaPortInfo {
     /// Port number (1-based).
     pub port_num: u8,
-    /// Port state (active, down, etc.).
-    pub state: ibv_port_state,
     /// Link layer type (InfiniBand or Ethernet).
     pub link_layer: LinkLayer,
-    /// Active MTU for the port.
-    pub active_mtu: ibv_mtu,
-    /// Local Identifier for InfiniBand routing.
-    pub lid: u16,
-    /// Available GIDs for this port.
-    pub gids: Vec<RdmaGidInfo>,
+    /// Usable GIDs of this port (filtered at collection time).
+    pub gids: Vec<Gid>,
 }
 
-/// Minimal GID information for RDMA connection negotiation.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
-pub struct RdmaGidInfo {
-    /// GID index on the port.
-    pub index: u16,
-    /// The GID value.
-    pub gid: ibv_gid,
-    /// The type of this GID.
-    pub gid_type: GidType,
-}
-
-/// Minimal RDMA device information for connection negotiation.
-///
-/// Contains only the fields needed to establish an RDMA connection,
-/// without heavy metadata like device_attr or ibdev_path.
+/// RDMA device information for connection negotiation.
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct RdmaDeviceInfo {
     /// Device name (e.g., "mlx5_0").
     pub name: String,
+    /// Live RDMA connections (outbound + inbound) currently on this device.
+    /// Advertised so that clients can prefer less-loaded server NICs.
+    pub active_connections: u32,
     /// Server-advertised per-connection RDMA resource limits for this device.
     pub connection: rdma::RdmaConnectionConfig,
-    /// Available ports on this device.
+    /// Usable ports on this device.
     pub ports: Vec<RdmaPortInfo>,
 }
 
@@ -58,19 +47,30 @@ pub struct RdmaInfo {
 }
 
 impl RdmaInfo {
-    /// Build `RdmaInfo` from the full device info list, filtering out
-    /// loopback GIDs for RoCE v2 since they cannot be used for communication.
+    /// Build `RdmaInfo` from the full device info list.
+    ///
+    /// Only usable ports are advertised. GIDs unusable for communication
+    /// (RoCE v2 GIDs derived from loopback or IPv6 link-local addresses)
+    /// are already filtered out at collection time.
     pub(crate) fn from_devices(
         devices: &[super::RdmaDevice],
         config: &crate::RdmaSocketPoolConfig,
+        conn_counts: &[std::sync::atomic::AtomicUsize],
     ) -> Self {
         RdmaInfo {
             devices: devices
                 .iter()
-                .map(|d| {
+                .enumerate()
+                .map(|(index, d)| {
                     let info = d.info();
                     RdmaDeviceInfo {
                         name: info.name.clone(),
+                        active_connections: conn_counts
+                            .get(index)
+                            .map(|c| c.load(std::sync::atomic::Ordering::Acquire))
+                            .unwrap_or(0)
+                            .try_into()
+                            .unwrap_or(u32::MAX),
                         connection: rdma::RdmaConnectionConfig {
                             qp: RdmaQueuePairConfig {
                                 max_send_wr: config
@@ -98,26 +98,11 @@ impl RdmaInfo {
                         ports: info
                             .ports
                             .iter()
+                            .filter(|port| port.is_usable())
                             .map(|port| RdmaPortInfo {
                                 port_num: port.port_num,
-                                state: port.port_attr.state,
                                 link_layer: port.port_attr.link_layer,
-                                active_mtu: port.port_attr.active_mtu,
-                                lid: port.port_attr.lid,
-                                gids: port
-                                    .gids
-                                    .iter()
-                                    .filter(|gid| {
-                                        // Filter out loopback addresses for RoCE v2
-                                        !(matches!(gid.gid_type, GidType::RoCEv2)
-                                            && gid.gid.as_ipv6().is_loopback())
-                                    })
-                                    .map(|gid| RdmaGidInfo {
-                                        index: gid.index,
-                                        gid: gid.gid,
-                                        gid_type: gid.gid_type.clone(),
-                                    })
-                                    .collect(),
+                                gids: port.gids.clone(),
                             })
                             .collect(),
                     }
@@ -199,6 +184,7 @@ mod tests {
         };
         let request = rdma::ConnectRequest {
             endpoint,
+            source_device: "test".into(),
             target: rdma::DeviceSelection {
                 device_name: "missing".into(),
                 port_num: 1,

--- a/ruapc/src/rdma/rdma_socket.rs
+++ b/ruapc/src/rdma/rdma_socket.rs
@@ -5,7 +5,7 @@ use ruapc_rdma::{QueuePair, WRID, ibv_send_flags, ibv_wc_status};
 use serde::Serialize;
 use tokio::sync::mpsc::Sender;
 
-use super::{RdmaState, SendPermit};
+use super::{RdmaPathInfo, RdmaState, SendPermit};
 use crate::{
     Buffer, BufferPool, Context, Error, RemoteIoError, RemoteReadOptions, SocketTrait, State,
     error::{ErrorKind, Result},
@@ -83,6 +83,8 @@ pub struct RdmaSocket {
     /// Negotiated maximum serialized message size (= the peer's receive
     /// buffer size).
     pub(crate) max_msg_size: usize,
+    /// The (local NIC, remote NIC) pair this connection runs on.
+    pub(crate) path: RdmaPathInfo,
 }
 
 impl RdmaSocket {
@@ -93,6 +95,7 @@ impl RdmaSocket {
         poller_waker: PollerWaker,
         max_msg_size: usize,
         send_window: u32,
+        path: RdmaPathInfo,
     ) -> Self {
         Self {
             rdma_completions: dashmap::DashMap::default(),
@@ -102,6 +105,7 @@ impl RdmaSocket {
             pending_sender,
             poller_waker,
             max_msg_size,
+            path,
         }
     }
 

--- a/ruapc/src/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/rdma/rdma_socket_pool.rs
@@ -1,21 +1,25 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::Arc,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::{Arc, Weak},
     time::{Duration, Instant},
 };
 
 use foldhash::fast::RandomState;
 use ruapc_bufpool::Device as _;
 use ruapc_rdma::{
-    DeviceInfo, GidType, LinkLayer, Port, QueuePair, ibv_mtu, ibv_port_state, ibv_qp_cap,
-    ibv_qp_init_attr, ibv_qp_type,
+    DeviceInfo, Gid, GidType, LinkLayer, Port, QueuePair, ibv_mtu, ibv_qp_cap, ibv_qp_init_attr,
+    ibv_qp_type,
 };
 use tokio::sync::RwLock;
 use tokio_util::sync::DropGuard;
 
-use super::rdma_service::{RdmaDeviceInfo, RdmaGidInfo, RdmaPortInfo};
+use super::path::{
+    RdmaConnDirection, RdmaDeviceLoad, RdmaNicInfo, RdmaPathEntry, RdmaPathInfo, RdmaPathReport,
+    RdmaPathSelector, gid_ip,
+};
+use super::rdma_service::RdmaPortInfo;
 use super::{
     ConnectRequest, DevicePollers, DeviceSelection, Endpoint, PollerConfig, RdmaConnectionConfig,
     RdmaDevice, RdmaDeviceRefresher, RdmaInfo, RdmaService, RdmaSocket, RegisterConn,
@@ -25,6 +29,46 @@ use crate::{
     RdmaSocketPoolConfig, Result, Socket, SocketPoolConfig, SocketPoolTrait, SocketType, State,
     TaskSupervisor,
 };
+
+/// One RDMA connection towards a peer, tagged with bookkeeping metadata.
+///
+/// Each stripe carries its own path (NIC pair): stripes of one peer are
+/// placed independently, spreading load across the NICs of both sides.
+#[derive(Clone)]
+pub(crate) struct Stripe {
+    pub(crate) socket: Arc<RdmaSocket>,
+    /// Created for an explicit path selector; exempt from replenishment
+    /// accounting and rebalancing.
+    pub(crate) pinned: bool,
+}
+
+/// RAII increment of one device's live-connection counter; decremented
+/// when the poll thread tears the connection down (the guard travels
+/// through [`RegisterConn`] into the poller's per-connection state).
+pub(crate) struct ConnCountGuard {
+    counts: Arc<Vec<AtomicUsize>>,
+    index: usize,
+}
+
+impl ConnCountGuard {
+    pub(crate) fn acquire(counts: &Arc<Vec<AtomicUsize>>, index: usize) -> Self {
+        if let Some(count) = counts.get(index) {
+            count.fetch_add(1, Ordering::AcqRel);
+        }
+        Self {
+            counts: counts.clone(),
+            index,
+        }
+    }
+}
+
+impl Drop for ConnCountGuard {
+    fn drop(&mut self) {
+        if let Some(count) = self.counts.get(self.index) {
+            count.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
 
 /// A pool managing RDMA sockets and their associated resources.
 ///
@@ -58,7 +102,19 @@ pub struct RdmaSocketPool {
     /// Thread-safe map of active RDMA connection stripes indexed by peer
     /// address; requests are spread round-robin across the stripes.
     /// Dropped after tasks stop → destroys QPs.
-    pub socket_map: RwLock<HashMap<SocketAddr, Vec<Arc<RdmaSocket>>, RandomState>>,
+    pub(crate) socket_map: RwLock<HashMap<SocketAddr, Vec<Stripe>, RandomState>>,
+    /// Live connection count per local RDMA device (outbound + inbound),
+    /// indexed like `devices.rdma_devices()`. Drives least-connections
+    /// placement and is advertised to peers via `RdmaInfo`.
+    conn_counts: Arc<Vec<AtomicUsize>>,
+    /// Inbound (accepted) connections, for path reporting and the
+    /// port-down watchdog; dead entries are pruned opportunistically.
+    inbound: std::sync::Mutex<Vec<Weak<RdmaSocket>>>,
+    /// NIC pairs whose QP setup towards a peer recently failed (e.g. no
+    /// route between the two subnets), with their retry deadline. Device
+    /// matching cannot verify reachability, so failed pairs are penalized
+    /// and placement falls over to the remaining candidates.
+    path_blacklist: std::sync::Mutex<HashMap<(SocketAddr, String, String), Instant, RandomState>>,
     /// Shared buffer pool (owned by State, kept alive via Arc).
     /// Dropped after QPs → deregisters MRs.
     pub buffer_pool: Arc<BufferPool>,
@@ -67,10 +123,14 @@ pub struct RdmaSocketPool {
     pub devices: Arc<Devices>,
     /// RDMA Queue Pair and connection settings.
     pub config: RdmaSocketPoolConfig,
-    /// Counter for round-robin device selection.
-    next_device: AtomicUsize,
     /// Counter for round-robin stripe selection in `acquire`.
     next_stripe: AtomicUsize,
+    /// Sequence for the pool's cheap pseudo-random draws (P2C, jitter).
+    rng_seq: AtomicUsize,
+    /// Whether the background maintenance task has been started.
+    maintenance_started: AtomicBool,
+    /// Round-robin cursor selecting the rebalance target peer.
+    rebalance_cursor: AtomicUsize,
     /// Buffer pool bytes pinned by the receive rings of live connections.
     ring_bytes: Arc<AtomicUsize>,
     /// Ensures the pool-undersized warning fires at most once.
@@ -106,12 +166,13 @@ impl SocketPoolTrait for RdmaSocketPool {
         Ok(RdmaInfo::from_devices(
             self.devices.rdma_devices(),
             &self.config,
+            &self.conn_counts,
         ))
     }
 
     /// Establishes a new RDMA connection with the specified endpoint.
     fn rdma_accept(&self, request: &ConnectRequest, state: &Arc<State>) -> Result<Endpoint> {
-        let device = self.find_device_by_name(&request.target)?;
+        let (device_index, device) = self.find_device_by_name(&request.target)?;
         let connection_config = self.clamp_connection_config(device, request.config);
         let poller = self.pollers.get_or_start(
             device,
@@ -132,7 +193,40 @@ impl SocketPoolTrait for RdmaSocketPool {
             self.config.pkey_index,
         )?;
 
-        let socket = self.register_socket(queue_pair, state, &poller, &connection_config)?;
+        let info = device.info();
+        let local_ip = Self::find_port(&info, request.target.port_num)
+            .ok()
+            .and_then(|port| port.find_gid(request.target.gid_index))
+            .and_then(|gid| gid_ip(&gid.gid));
+        let path = RdmaPathInfo {
+            local: RdmaNicInfo {
+                device: info.name.clone(),
+                port_num: request.target.port_num,
+                gid_index: request.target.gid_index,
+                ip: local_ip,
+            },
+            remote: RdmaNicInfo {
+                device: request.source_device.clone(),
+                port_num: request.endpoint.port_num,
+                gid_index: request.endpoint.gid_index,
+                ip: gid_ip(&request.endpoint.gid),
+            },
+        };
+
+        let socket = self.register_socket(
+            queue_pair,
+            state,
+            &poller,
+            &connection_config,
+            path,
+            device_index,
+        )?;
+        {
+            let mut inbound = self.inbound.lock().unwrap();
+            inbound.retain(|conn| conn.strong_count() > 0);
+            inbound.push(Arc::downgrade(&socket));
+        }
+        self.ensure_maintenance_task(state);
         tracing::debug!(
             local_qp = socket.queue_pair.qp_num(),
             remote_qp = request.endpoint.qp_num,
@@ -154,26 +248,7 @@ impl SocketPoolTrait for RdmaSocketPool {
                 format!("invalid socket type {socket_type} for RdmaSocketPool"),
             ));
         }
-
-        // Check if the socket is already in the socket map.
-        if let Ok(socket_map) = self.socket_map.try_read()
-            && let Some(socket) = socket_map.get(addr).and_then(|s| self.pick_stripe(s))
-        {
-            return Ok(socket);
-        }
-
-        let connect_lock = self
-            .connect_locks
-            .entry(*addr)
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone();
-        let guard = connect_lock.lock().await;
-        let result = self.handshake(addr, state).await;
-        self.connect_locks.remove_if(addr, |_, value| {
-            Arc::ptr_eq(value, &connect_lock) && Arc::strong_count(value) == 2
-        });
-        drop(guard);
-        result
+        self.acquire_path(addr, None, state).await
     }
 
     async fn handle_new_stream(
@@ -191,6 +266,8 @@ impl SocketPoolTrait for RdmaSocketPool {
 
 impl RdmaSocketPool {
     const DEVICE_LIST_CACHE_TTL: Duration = Duration::from_secs(5);
+    /// How long a NIC pair stays penalized after its QP setup failed.
+    const PATH_BLACKLIST_TTL: Duration = Duration::from_secs(30);
 
     /// Creates a new pool using the shared devices and buffer pool.
     pub fn new(
@@ -212,40 +289,124 @@ impl RdmaSocketPool {
             connect_locks: dashmap::DashMap::default(),
             device_list_cache: RwLock::default(),
             socket_map: RwLock::default(),
+            conn_counts: Arc::new(
+                (0..devices.rdma_devices().len())
+                    .map(|_| AtomicUsize::new(0))
+                    .collect(),
+            ),
+            inbound: std::sync::Mutex::new(Vec::new()),
+            path_blacklist: std::sync::Mutex::new(HashMap::default()),
             buffer_pool,
             devices,
             config,
-            next_device: AtomicUsize::new(0),
             next_stripe: AtomicUsize::new(0),
+            rng_seq: AtomicUsize::new(0),
+            maintenance_started: AtomicBool::new(false),
+            rebalance_cursor: AtomicUsize::new(0),
             ring_bytes: Arc::new(AtomicUsize::new(0)),
             pool_capacity_warned: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
+    /// Acquires a healthy connection to `addr`, optionally constrained to
+    /// paths matching `selector`; establishes one when none exists.
+    pub(crate) async fn acquire_path(
+        &self,
+        addr: &SocketAddr,
+        selector: Option<&RdmaPathSelector>,
+        state: &Arc<State>,
+    ) -> Result<Socket> {
+        // Check if a matching socket is already in the socket map.
+        if let Ok(socket_map) = self.socket_map.try_read()
+            && let Some(socket) = socket_map
+                .get(addr)
+                .and_then(|s| self.pick_stripe(s, selector))
+        {
+            return Ok(socket);
+        }
+
+        let connect_lock = self.peer_lock(addr);
+        let guard = connect_lock.lock().await;
+        let result = self.handshake(addr, state, selector).await;
+        self.release_peer_lock(addr, &connect_lock);
+        drop(guard);
+        result
+    }
+
+    /// Returns (creating if necessary) the per-peer connect lock.
+    fn peer_lock(&self, addr: &SocketAddr) -> Arc<tokio::sync::Mutex<()>> {
+        self.connect_locks
+            .entry(*addr)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    /// Drops the per-peer connect lock entry once no other task holds it.
+    fn release_peer_lock(&self, addr: &SocketAddr, lock: &Arc<tokio::sync::Mutex<()>>) {
+        self.connect_locks.remove_if(addr, |_, value| {
+            Arc::ptr_eq(value, lock) && Arc::strong_count(value) == 2
+        });
+    }
+
     /// Picks one healthy connection stripe round-robin, skipping stripes
-    /// that entered the error state.
-    fn pick_stripe(&self, stripes: &[Arc<RdmaSocket>]) -> Option<Socket> {
+    /// that entered the error state or do not match `selector`.
+    fn pick_stripe(
+        &self,
+        stripes: &[Stripe],
+        selector: Option<&RdmaPathSelector>,
+    ) -> Option<Socket> {
         if stripes.is_empty() {
             return None;
         }
         let start = self.next_stripe.fetch_add(1, Ordering::Relaxed);
         (0..stripes.len())
             .map(|i| &stripes[(start + i) % stripes.len()])
-            .find(|s| s.state.is_ok())
-            .map(|s| s.into())
+            .find(|s| {
+                s.socket.state.is_ok() && selector.is_none_or(|sel| sel.matches(&s.socket.path))
+            })
+            .map(|s| (&s.socket).into())
     }
 
-    fn find_device_by_name(&self, selection: &DeviceSelection) -> Result<&RdmaDevice> {
+    fn find_device_by_name(&self, selection: &DeviceSelection) -> Result<(usize, &RdmaDevice)> {
         self.devices
             .rdma_devices()
             .iter()
-            .find(|device| device.info().name.as_str() == selection.device_name)
+            .enumerate()
+            .find(|(_, device)| device.info().name.as_str() == selection.device_name)
             .ok_or_else(|| {
                 Error::new(
                     ErrorKind::InvalidArgument,
                     format!("RDMA device {} not found", selection.device_name),
                 )
             })
+    }
+
+    /// Cheap pseudo-random draw for P2C sampling and interval jitter;
+    /// uniqueness/quality requirements are modest, so a hash of a
+    /// (sequence, nanos) pair suffices — no RNG dependency.
+    fn pseudo_random(&self) -> u64 {
+        pseudo_random(self.rng_seq.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Penalizes a NIC pair towards `addr` after its QP setup failed.
+    fn blacklist_path(&self, addr: &SocketAddr, path: &RdmaPathInfo) {
+        self.path_blacklist.lock().unwrap().insert(
+            (*addr, path.local.device.clone(), path.remote.device.clone()),
+            Instant::now() + Self::PATH_BLACKLIST_TTL,
+        );
+    }
+
+    /// Whether the candidate's NIC pair towards `addr` is currently
+    /// penalized; expired entries are pruned on the way.
+    fn is_blacklisted(&self, addr: &SocketAddr, candidate: &PathCandidate) -> bool {
+        let mut blacklist = self.path_blacklist.lock().unwrap();
+        let now = Instant::now();
+        blacklist.retain(|_, until| *until > now);
+        blacklist.contains_key(&(
+            *addr,
+            candidate.path.local.device.clone(),
+            candidate.path.remote.device.clone(),
+        ))
     }
 
     /// Poll thread tunables derived from the pool configuration.
@@ -295,6 +456,8 @@ impl RdmaSocketPool {
         state: &Arc<State>,
         poller: &super::poller::DevicePoller,
         config: &RdmaConnectionConfig,
+        path: RdmaPathInfo,
+        device_index: usize,
     ) -> Result<Arc<RdmaSocket>> {
         // Reserve the poller slot first: its tag must be stamped into the
         // QP before any work request is posted, since completions map back
@@ -344,6 +507,7 @@ impl RdmaSocketPool {
             poller.waker(),
             config.max_msg_size as usize,
             send_window,
+            path,
         ));
 
         // Pre-post receive buffers *before* the remote can send: the
@@ -372,6 +536,7 @@ impl RdmaSocketPool {
                 msg_aggregation: self.config.msg_aggregation,
                 supervisor_guard: self.task_supervisor.start_async_task(),
                 ring_reservation,
+                conn_count_guard: ConnCountGuard::acquire(&self.conn_counts, device_index),
             },
         )?;
 
@@ -387,49 +552,87 @@ impl RdmaSocketPool {
         Ok(socket)
     }
 
-    async fn handshake(&self, addr: &SocketAddr, state: &Arc<State>) -> Result<Socket> {
+    async fn handshake(
+        &self,
+        addr: &SocketAddr,
+        state: &Arc<State>,
+        selector: Option<&RdmaPathSelector>,
+    ) -> Result<Socket> {
+        self.ensure_maintenance_task(state);
+
         // Re-check under the connect lock: another task may have connected,
-        // or every stripe may have failed and must be replaced.
+        // or every stripe may have failed and must be replaced. `add_one`
+        // covers the selector case: the peer may already have healthy
+        // stripes, just none on the requested path.
+        let mut add_one = selector.is_some();
         {
             let mut socket_map = self.socket_map.write().await;
             if let Some(stripes) = socket_map.get(addr) {
-                if let Some(socket) = self.pick_stripe(stripes) {
+                if let Some(socket) = self.pick_stripe(stripes, selector) {
                     return Ok(socket);
                 }
-                // All stripes are dead: drop them and reconnect. The poll
-                // thread reclaims the connections independently.
-                tracing::info!("all RDMA stripes to {addr} failed, reconnecting");
-                socket_map.remove(addr);
+                if !stripes.iter().any(|s| s.socket.state.is_ok()) {
+                    // All stripes are dead: drop them and reconnect. The
+                    // poll thread reclaims the connections independently.
+                    tracing::info!("all RDMA stripes to {addr} failed, reconnecting");
+                    socket_map.remove(addr);
+                    add_one = selector.is_some();
+                } else {
+                    debug_assert!(selector.is_some());
+                    add_one = true;
+                }
             }
+        }
+
+        let plan = self.prepare_connect_plan(addr, state).await?;
+
+        if add_one {
+            // Append a single (possibly pinned) stripe on the requested
+            // path to whatever the peer already has.
+            let existing = self
+                .socket_map
+                .read()
+                .await
+                .get(addr)
+                .cloned()
+                .unwrap_or_default();
+            let socket = self
+                .connect_with_failover(addr, state, &plan, selector, &existing)
+                .await?;
+            let result = Socket::from(&socket);
+            self.socket_map
+                .write()
+                .await
+                .entry(*addr)
+                .or_default()
+                .push(Stripe {
+                    socket,
+                    pinned: selector.is_some(),
+                });
+            return Ok(result);
         }
 
         // Establish `connections_per_peer` stripes towards this peer;
         // requests are spread round-robin across them (and, with poll
-        // thread shards, across cores). All stripes share one device/GID
-        // selection: verified connectivity matters more than NIC spreading.
-        let acquire_ctx = Context::create_with_state_and_addr(state, addr);
-        let remote_info = self.fetch_remote_device_list(addr, &acquire_ctx).await?;
-        let selection = match self.match_remote_device(&remote_info) {
-            Ok(selection) => selection,
-            Err(err) => {
-                self.invalidate_device_list_cache(addr).await;
-                return Err(err);
-            }
-        };
-
+        // thread shards, across cores). Each stripe picks its own path:
+        // local side by least connections, remote side by
+        // power-of-two-choices over the peer's advertised per-NIC load.
         let stripe_count = self.config.connections_per_peer.max(1);
-        let mut stripes = Vec::with_capacity(stripe_count as usize);
+        let mut stripes: Vec<Stripe> = Vec::with_capacity(stripe_count as usize);
         for _ in 0..stripe_count {
             match self
-                .connect_stripe(addr, state, &acquire_ctx, &selection)
+                .connect_with_failover(addr, state, &plan, None, &stripes)
                 .await
             {
-                Ok(stripe) => stripes.push(stripe),
+                Ok(socket) => stripes.push(Stripe {
+                    socket,
+                    pinned: false,
+                }),
                 Err(err) => {
                     // Don't leak the stripes established so far: mark them
                     // failed so the poll thread tears them down.
                     for stripe in &stripes {
-                        stripe.set_error();
+                        stripe.socket.set_error();
                     }
                     return Err(err);
                 }
@@ -437,32 +640,95 @@ impl RdmaSocketPool {
         }
 
         let socket = self
-            .pick_stripe(&stripes)
+            .pick_stripe(&stripes, None)
             .expect("stripe count is at least 1");
         self.socket_map.write().await.insert(*addr, stripes);
         Ok(socket)
     }
 
-    /// Establishes one RDMA connection (stripe) towards `addr` using the
-    /// given device/GID selection.
+    /// Fetches the peer's device list and enumerates the compatible path
+    /// candidates: everything a placement decision towards `addr` needs.
+    async fn prepare_connect_plan(
+        &self,
+        addr: &SocketAddr,
+        state: &Arc<State>,
+    ) -> Result<ConnectPlan> {
+        let acquire_ctx = Context::create_with_state_and_addr(state, addr);
+        let remote_info = self.fetch_remote_device_list(addr, &acquire_ctx).await?;
+        let candidates = match self.enumerate_path_candidates(&remote_info) {
+            Ok(candidates) => candidates,
+            Err(err) => {
+                self.invalidate_device_list_cache(addr).await;
+                return Err(err);
+            }
+        };
+        Ok(ConnectPlan {
+            acquire_ctx,
+            remote_info,
+            candidates,
+        })
+    }
+
+    /// Establishes one stripe towards `addr`, falling over to the next
+    /// best candidate when a NIC pair turns out to be unreachable
+    /// (device matching cannot verify routability). Each failed pair is
+    /// blacklisted by `connect_stripe`, so later placements avoid it too.
+    async fn connect_with_failover(
+        &self,
+        addr: &SocketAddr,
+        state: &Arc<State>,
+        plan: &ConnectPlan,
+        selector: Option<&RdmaPathSelector>,
+        existing: &[Stripe],
+    ) -> Result<Arc<RdmaSocket>> {
+        let mut remaining: Vec<PathCandidate> = plan.candidates.clone();
+        loop {
+            let candidate =
+                self.select_candidate(addr, &remaining, selector, &plan.remote_info, existing)?;
+            match self
+                .connect_stripe(addr, state, &plan.acquire_ctx, &candidate)
+                .await
+            {
+                Ok(socket) => return Ok(socket),
+                Err(err) => {
+                    remaining.retain(|c| {
+                        c.path.local.device != candidate.path.local.device
+                            || c.path.remote.device != candidate.path.remote.device
+                    });
+                    if remaining.is_empty() {
+                        return Err(err);
+                    }
+                    tracing::warn!(
+                        peer = %addr,
+                        local = %candidate.path.local.device,
+                        remote = %candidate.path.remote.device,
+                        "RDMA path failed ({err}); trying another NIC pair"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Establishes one RDMA connection (stripe) towards `addr` on the
+    /// given path candidate.
     async fn connect_stripe(
         &self,
         addr: &SocketAddr,
         state: &Arc<State>,
         acquire_ctx: &Context,
-        selection: &DeviceMatch,
+        candidate: &PathCandidate,
     ) -> Result<Arc<RdmaSocket>> {
         let device = self
             .devices
             .rdma_devices()
-            .get(selection.local_device_index)
+            .get(candidate.local_device_index)
             .ok_or_else(|| {
                 Error::new(
                     ErrorKind::InvalidArgument,
                     "selected RDMA device disappeared".into(),
                 )
             })?;
-        let connection_config = self.negotiate_connection_config(device, &selection.remote_device);
+        let connection_config = self.negotiate_connection_config(device, &candidate.remote_limits);
         let poller = self.pollers.get_or_start(
             device,
             self.poller_config(),
@@ -472,13 +738,14 @@ impl RdmaSocketPool {
         let local_endpoint = self.build_endpoint(
             &queue_pair,
             device,
-            selection.local_port_num,
-            selection.local_gid_index,
+            candidate.path.local.port_num,
+            candidate.path.local.gid_index,
         )?;
 
         let connect_request = ConnectRequest {
             endpoint: local_endpoint,
-            target: selection.remote.clone(),
+            source_device: candidate.path.local.device.clone(),
+            target: candidate.remote.clone(),
             config: connection_config,
         };
         let remote_endpoint =
@@ -489,22 +756,34 @@ impl RdmaSocketPool {
                     return Err(err);
                 }
             };
-        self.bring_qp_to_rts(
+        if let Err(err) = self.bring_qp_to_rts(
             &queue_pair,
             &local_endpoint,
             &remote_endpoint,
             self.config.pkey_index,
-        )?;
+        ) {
+            // QP setup failures are typically path problems (no route
+            // between the selected NIC pair): penalize the pair so
+            // placement falls over to other candidates.
+            self.blacklist_path(addr, &candidate.path);
+            return Err(err);
+        }
 
-        let socket = self.register_socket(queue_pair, state, &poller, &connection_config)?;
-        let local_info = device.info();
+        let socket = self.register_socket(
+            queue_pair,
+            state,
+            &poller,
+            &connection_config,
+            candidate.path.clone(),
+            candidate.local_device_index,
+        )?;
         tracing::info!(
-            local_device = %local_info.name,
-            local_port = selection.local_port_num,
-            local_gid_index = selection.local_gid_index,
-            remote_device = %selection.remote.device_name,
-            remote_port = selection.remote.port_num,
-            remote_gid_index = selection.remote.gid_index,
+            local_device = %candidate.path.local.device,
+            local_port = candidate.path.local.port_num,
+            local_gid_index = candidate.path.local.gid_index,
+            remote_device = %candidate.remote.device_name,
+            remote_port = candidate.remote.port_num,
+            remote_gid_index = candidate.remote.gid_index,
             local_qp = socket.queue_pair.qp_num(),
             remote_qp = remote_endpoint.qp_num,
             "acquired RDMA socket"
@@ -542,7 +821,13 @@ impl RdmaSocketPool {
         self.device_list_cache.write().await.remove(addr);
     }
 
-    fn match_remote_device(&self, remote_info: &RdmaInfo) -> Result<DeviceMatch> {
+    /// Enumerates every compatible (local NIC, remote NIC) pair.
+    ///
+    /// One candidate is produced per compatible port pair (the GID within
+    /// a port pair is chosen by the existing preference logic). Candidates
+    /// are pre-filtered to the best available class: InfiniBand matches
+    /// win over RoCE v2 matches, which win over other RoCE matches.
+    fn enumerate_path_candidates(&self, remote_info: &RdmaInfo) -> Result<Vec<PathCandidate>> {
         let local_devices = self.devices.rdma_devices();
         if local_devices.is_empty() {
             return Err(Error::new(
@@ -551,23 +836,26 @@ impl RdmaSocketPool {
             ));
         }
 
+        let remote_filter = &self.config.remote_device_filter;
         let mut ib_matches = Vec::new();
-        let mut roce_matches = Vec::new();
-        let mut remote_usable_ports = 0usize;
+        let mut roce_v2_matches = Vec::new();
+        let mut roce_other_matches = Vec::new();
+        let mut remote_ports = 0usize;
         let mut local_usable_ports = 0usize;
         let mut link_layer_matches = 0usize;
 
+        // Remote ports are pre-filtered: peers only advertise usable ports.
         for remote_device in &remote_info.devices {
+            if !remote_filter.is_empty() && !remote_filter.contains(&remote_device.name) {
+                continue;
+            }
             for remote_port in &remote_device.ports {
-                if !Self::remote_port_is_usable(remote_port) {
-                    continue;
-                }
-                remote_usable_ports += 1;
+                remote_ports += 1;
 
                 for (local_device_index, local_device) in local_devices.iter().enumerate() {
                     let local_info = local_device.info();
                     for local_port in &local_info.ports {
-                        if !Self::port_is_usable(local_port) {
+                        if !local_port.is_usable() {
                             continue;
                         }
                         local_usable_ports += 1;
@@ -582,21 +870,48 @@ impl RdmaSocketPool {
                             continue;
                         };
 
-                        let selected = DeviceMatch {
+                        let local_ip = local_port
+                            .find_gid(local_gid_index)
+                            .and_then(|gid| gid_ip(&gid.gid));
+                        let remote_ip = remote_port
+                            .gids
+                            .iter()
+                            .find(|gid| gid.index == remote_gid_index)
+                            .and_then(|gid| gid_ip(&gid.gid));
+                        let selected = PathCandidate {
                             local_device_index,
-                            local_port_num: local_port.port_num,
-                            local_gid_index,
                             remote: DeviceSelection {
                                 device_name: remote_device.name.clone(),
                                 port_num: remote_port.port_num,
                                 gid_index: remote_gid_index,
                             },
-                            remote_device: remote_device.clone(),
+                            remote_limits: remote_device.connection,
+                            path: RdmaPathInfo {
+                                local: RdmaNicInfo {
+                                    device: local_info.name.clone(),
+                                    port_num: local_port.port_num,
+                                    gid_index: local_gid_index,
+                                    ip: local_ip,
+                                },
+                                remote: RdmaNicInfo {
+                                    device: remote_device.name.clone(),
+                                    port_num: remote_port.port_num,
+                                    gid_index: remote_gid_index,
+                                    ip: remote_ip,
+                                },
+                            },
                         };
 
                         match local_port.port_attr.link_layer {
                             LinkLayer::InfiniBand => ib_matches.push(selected),
-                            LinkLayer::Ethernet => roce_matches.push(selected),
+                            LinkLayer::Ethernet => {
+                                // Prefer RoCE v2 matches whenever one exists.
+                                if Self::gid_index_is_rocev2(local_port, local_gid_index) {
+                                    roce_v2_matches.push(selected);
+                                } else {
+                                    roce_other_matches.push(selected);
+                                }
+                            }
                             LinkLayer::Unspecified => {}
                         }
                     }
@@ -604,119 +919,180 @@ impl RdmaSocketPool {
             }
         }
 
-        let matches = if ib_matches.is_empty() {
-            &roce_matches
+        let matches = if !ib_matches.is_empty() {
+            ib_matches
+        } else if !roce_v2_matches.is_empty() {
+            roce_v2_matches
         } else {
-            &ib_matches
+            roce_other_matches
         };
         if matches.is_empty() {
             return Err(Error::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "no compatible RDMA device/port/GID pair found: remote_devices={} local_devices={} remote_usable_ports={} local_usable_ports={} link_layer_matches={}",
+                    "no compatible RDMA device/port/GID pair found: remote_devices={} local_devices={} remote_ports={} local_usable_ports={} link_layer_matches={}",
                     remote_info.devices.len(),
                     local_devices.len(),
-                    remote_usable_ports,
+                    remote_ports,
                     local_usable_ports,
                     link_layer_matches
                 ),
             ));
         }
-
-        let idx = self.next_device.fetch_add(1, Ordering::Relaxed) % matches.len();
-        Ok(matches[idx].clone())
+        Ok(matches)
     }
 
-    fn port_is_usable(port: &Port) -> bool {
-        matches!(
-            port.port_attr.state,
-            ibv_port_state::IBV_PORT_ACTIVE | ibv_port_state::IBV_PORT_ACTIVE_DEFER
-        ) && matches!(
-            port.port_attr.link_layer,
-            LinkLayer::InfiniBand | LinkLayer::Ethernet
-        )
+    /// Picks the path for a new stripe.
+    ///
+    /// Remote NIC: power-of-two-choices over the peer's advertised per-NIC
+    /// connection counts (plus our own healthy stripes to this peer, which
+    /// the possibly-stale advertisement may not include yet). P2C keeps
+    /// clients from herding onto the same "least loaded" server NIC when
+    /// they all act on the same cached snapshot.
+    ///
+    /// Local NIC: plain least-connections over the live per-device
+    /// counters — they are exact, and equal counts self-balance because
+    /// every placement increments the chosen device's counter.
+    fn select_candidate(
+        &self,
+        addr: &SocketAddr,
+        candidates: &[PathCandidate],
+        selector: Option<&RdmaPathSelector>,
+        remote_info: &RdmaInfo,
+        peer_stripes: &[Stripe],
+    ) -> Result<PathCandidate> {
+        let mut filtered: Vec<&PathCandidate> = candidates
+            .iter()
+            .filter(|c| selector.is_none_or(|sel| sel.matches(&c.path)))
+            .collect();
+        if filtered.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                format!("no compatible RDMA path matches selector {selector:?}"),
+            ));
+        }
+        // Soft blacklist: skip recently failed pairs, but when every
+        // remaining candidate is penalized, try them anyway — the fault
+        // may have cleared, and failing fast helps nobody.
+        let usable: Vec<&PathCandidate> = filtered
+            .iter()
+            .copied()
+            .filter(|c| !self.is_blacklisted(addr, c))
+            .collect();
+        if !usable.is_empty() {
+            filtered = usable;
+        }
+
+        let remote_score = |name: &str| -> u64 {
+            let advertised = remote_info
+                .devices
+                .iter()
+                .find(|d| d.name == name)
+                .map_or(0, |d| u64::from(d.active_connections));
+            let ours = peer_stripes
+                .iter()
+                .filter(|s| s.socket.state.is_ok() && s.socket.path.remote.device == name)
+                .count() as u64;
+            advertised + ours
+        };
+
+        let mut remote_names: Vec<&str> = Vec::new();
+        for candidate in &filtered {
+            if !remote_names.contains(&candidate.path.remote.device.as_str()) {
+                remote_names.push(candidate.path.remote.device.as_str());
+            }
+        }
+        let chosen_remote = if remote_names.len() == 1 {
+            remote_names[0]
+        } else {
+            let n = remote_names.len();
+            let a = self.pseudo_random() as usize % n;
+            let mut b = self.pseudo_random() as usize % (n - 1);
+            if b >= a {
+                b += 1;
+            }
+            if remote_score(remote_names[b]) < remote_score(remote_names[a]) {
+                remote_names[b]
+            } else {
+                remote_names[a]
+            }
+        };
+
+        let local_count = |c: &PathCandidate| -> usize {
+            self.conn_counts
+                .get(c.local_device_index)
+                .map_or(0, |count| count.load(Ordering::Acquire))
+        };
+        Ok(filtered
+            .iter()
+            .filter(|c| c.path.remote.device == chosen_remote)
+            .min_by_key(|c| local_count(c))
+            .copied()
+            .expect("chosen remote device came from the filtered candidates")
+            .clone())
     }
 
-    fn remote_port_is_usable(port: &RdmaPortInfo) -> bool {
-        matches!(
-            port.state,
-            ibv_port_state::IBV_PORT_ACTIVE | ibv_port_state::IBV_PORT_ACTIVE_DEFER
-        ) && matches!(port.link_layer, LinkLayer::InfiniBand | LinkLayer::Ethernet)
+    fn gid_index_is_rocev2(port: &Port, gid_index: u8) -> bool {
+        port.find_gid(gid_index)
+            .is_some_and(|gid| gid.gid_type == GidType::RoCEv2)
     }
 
+    /// Selects a (local, remote) GID index pair for the given port pair.
+    ///
+    /// Both GID tables only contain usable GIDs — unusable ones (RoCE v2
+    /// loopback / link-local) are filtered out at collection time on each
+    /// side (see `query_device_info`).
     fn match_gid_pair(local_port: &Port, remote_port: &RdmaPortInfo) -> Option<(u8, u8)> {
+        let (local_gids, remote_gids) = (&local_port.gids[..], &remote_port.gids[..]);
         match local_port.port_attr.link_layer {
             LinkLayer::InfiniBand => Some((
-                Self::first_local_gid(local_port, |_| true).unwrap_or(0),
-                Self::first_remote_gid(remote_port, |_| true).unwrap_or(0),
+                Self::first_gid(local_gids, |_| true).unwrap_or(0),
+                Self::first_gid(remote_gids, |_| true).unwrap_or(0),
             )),
-            LinkLayer::Ethernet => Self::match_roce_gid_pair(local_port, remote_port),
+            LinkLayer::Ethernet => Self::match_roce_gid_pair(local_gids, remote_gids),
             LinkLayer::Unspecified => None,
         }
     }
 
-    fn match_roce_gid_pair(local_port: &Port, remote_port: &RdmaPortInfo) -> Option<(u8, u8)> {
-        let preferred = [
-            (
-                Self::first_local_gid(local_port, |gid| matches!(gid.gid_type, GidType::RoCEv2)),
-                Self::first_remote_gid(remote_port, |gid| matches!(gid.gid_type, GidType::RoCEv2)),
-            ),
-            (
-                Self::first_local_gid(local_port, |gid| matches!(gid.gid_type, GidType::RoCEv1)),
-                Self::first_remote_gid(remote_port, |gid| matches!(gid.gid_type, GidType::RoCEv1)),
-            ),
-        ];
-
-        for (local, remote) in preferred {
+    fn match_roce_gid_pair(local_gids: &[Gid], remote_gids: &[Gid]) -> Option<(u8, u8)> {
+        // Prefer RoCE v2 pairs, then RoCE v1 pairs.
+        for wanted in [GidType::RoCEv2, GidType::RoCEv1] {
+            let local = Self::first_gid(local_gids, |gid| gid.gid_type == wanted);
+            let remote = Self::first_gid(remote_gids, |gid| gid.gid_type == wanted);
             if let (Some(local), Some(remote)) = (local, remote) {
                 return Some((local, remote));
             }
         }
 
-        for local_gid in &local_port.gids {
-            for remote_gid in &remote_port.gids {
-                if local_gid.gid_type == remote_gid.gid_type {
-                    return Some((
-                        u8::try_from(local_gid.index).ok()?,
-                        u8::try_from(remote_gid.index).ok()?,
-                    ));
-                }
+        // Then any pair with matching GID types.
+        for local_gid in local_gids {
+            let remote = Self::first_gid(remote_gids, |remote_gid| {
+                remote_gid.gid_type == local_gid.gid_type
+            });
+            if let Some(remote) = remote {
+                return Some((local_gid.index, remote));
             }
         }
 
+        // Finally, fall back to the first GID on each side.
         Some((
-            Self::first_local_gid(local_port, |_| true)?,
-            Self::first_remote_gid(remote_port, |_| true)?,
+            Self::first_gid(local_gids, |_| true)?,
+            Self::first_gid(remote_gids, |_| true)?,
         ))
     }
 
-    fn first_local_gid(
-        port: &Port,
-        mut predicate: impl FnMut(&ruapc_rdma::Gid) -> bool,
-    ) -> Option<u8> {
-        port.gids
-            .iter()
-            .find(|gid| predicate(gid))
-            .and_then(|gid| u8::try_from(gid.index).ok())
-    }
-
-    fn first_remote_gid(
-        port: &RdmaPortInfo,
-        mut predicate: impl FnMut(&RdmaGidInfo) -> bool,
-    ) -> Option<u8> {
-        port.gids
-            .iter()
-            .find(|gid| predicate(gid))
-            .and_then(|gid| u8::try_from(gid.index).ok())
+    /// Returns the index of the first GID matching `predicate`.
+    fn first_gid(gids: &[Gid], mut predicate: impl FnMut(&Gid) -> bool) -> Option<u8> {
+        gids.iter().find(|gid| predicate(gid)).map(|gid| gid.index)
     }
 
     fn negotiate_connection_config(
         &self,
         local_device: &RdmaDevice,
-        remote_device: &RdmaDeviceInfo,
+        remote: &RdmaConnectionConfig,
     ) -> RdmaConnectionConfig {
         let local = self.local_connection_config(local_device);
-        let remote = remote_device.connection;
+        let remote = *remote;
         RdmaConnectionConfig {
             qp: RdmaQueuePairConfig {
                 max_send_wr: local.qp.max_send_wr.min(remote.qp.max_recv_wr),
@@ -802,18 +1178,14 @@ impl RdmaSocketPool {
     ) -> Result<Endpoint> {
         let info = device.info();
         let port = Self::find_port(&info, port_num)?;
-        if !Self::port_is_usable(port) {
+        if !port.is_usable() {
             return Err(Error::new(
                 ErrorKind::InvalidArgument,
                 format!("RDMA port {}:{} is not active", info.name, port_num),
             ));
         }
 
-        let gid = port
-            .gids
-            .iter()
-            .find(|gid| u8::try_from(gid.index).ok() == Some(gid_index))
-            .map(|gid| gid.gid);
+        let gid = port.find_gid(gid_index).map(|gid| gid.gid);
         if port.port_attr.link_layer.is_ethernet() && gid.is_none() {
             return Err(Error::new(
                 ErrorKind::InvalidArgument,
@@ -899,6 +1271,408 @@ impl RdmaSocketPool {
     fn min_mtu(a: ibv_mtu, b: ibv_mtu) -> ibv_mtu {
         if (a as u32) <= (b as u32) { a } else { b }
     }
+
+    /// Starts the background maintenance task on first use (when an
+    /// `Arc<State>` is available). The task holds only a `Weak<State>`;
+    /// it exits when the pool's supervisor stops or the state is dropped.
+    fn ensure_maintenance_task(&self, state: &Arc<State>) {
+        let interval_ms = self.config.maintenance_interval_ms;
+        if interval_ms == 0 || self.maintenance_started.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let weak_state = Arc::downgrade(state);
+        let guard = self.task_supervisor.start_async_task();
+        tokio::spawn(async move {
+            let mut seq = 0usize;
+            loop {
+                // 0.5x..1.5x jitter decorrelates clients that would
+                // otherwise all rebalance against the same (cached) server
+                // load snapshot.
+                seq = seq.wrapping_add(1);
+                let sleep_ms = interval_ms / 2 + pseudo_random(seq) % interval_ms.max(1);
+                tokio::select! {
+                    () = guard.stopped() => break,
+                    () = tokio::time::sleep(Duration::from_millis(sleep_ms)) => {}
+                }
+                let Some(state) = weak_state.upgrade() else {
+                    break;
+                };
+                let Some(pool) = state.socket_pool.rdma_pool() else {
+                    break;
+                };
+                pool.run_maintenance(&state).await;
+            }
+        });
+    }
+
+    /// One maintenance tick: fail connections on dead local ports, prune
+    /// dead stripes, replenish peers below `connections_per_peer`, and
+    /// rebalance at most one connection of one peer (rate-limited by the
+    /// tick interval, so recovered NICs regain traffic gradually).
+    pub(crate) async fn run_maintenance(&self, state: &Arc<State>) {
+        self.fail_paths_on_dead_ports().await;
+        self.prune_dead().await;
+        let peers: Vec<SocketAddr> = self.socket_map.read().await.keys().copied().collect();
+        if peers.is_empty() {
+            return;
+        }
+        for addr in &peers {
+            self.replenish_peer(addr, state).await;
+        }
+        let target = peers[self.rebalance_cursor.fetch_add(1, Ordering::Relaxed) % peers.len()];
+        self.rebalance_peer(&target, state).await;
+    }
+
+    /// Whether the local NIC of `nic` can no longer carry traffic
+    /// (device gone or port not usable, per the refresher's snapshot).
+    fn local_nic_dead(&self, nic: &RdmaNicInfo) -> bool {
+        let Some(device) = self
+            .devices
+            .rdma_devices()
+            .iter()
+            .find(|d| d.info().name == nic.device)
+        else {
+            return true;
+        };
+        !device
+            .info()
+            .ports
+            .iter()
+            .any(|port| port.port_num == nic.port_num && port.is_usable())
+    }
+
+    /// Proactively fails connections whose local port went down; the port
+    /// state comes from the periodic device refresher, so failures are
+    /// detected even on idle connections that see no completion errors.
+    async fn fail_paths_on_dead_ports(&self) {
+        let fail_if_dead = |socket: &Arc<RdmaSocket>| {
+            if socket.state.is_ok() && self.local_nic_dead(&socket.path.local) {
+                tracing::warn!(
+                    device = %socket.path.local.device,
+                    qp = socket.queue_pair.qp_num(),
+                    "local RDMA port down; failing connection"
+                );
+                socket.set_error();
+            }
+        };
+        {
+            let socket_map = self.socket_map.read().await;
+            for stripes in socket_map.values() {
+                for stripe in stripes {
+                    fail_if_dead(&stripe.socket);
+                }
+            }
+        }
+        let inbound: Vec<Arc<RdmaSocket>> = self
+            .inbound
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect();
+        for socket in &inbound {
+            fail_if_dead(socket);
+        }
+    }
+
+    /// Removes dead stripes (and fully dead peers) from the socket map and
+    /// prunes released inbound connections.
+    async fn prune_dead(&self) {
+        let mut socket_map = self.socket_map.write().await;
+        socket_map.retain(|_, stripes| {
+            stripes.retain(|s| s.socket.state.is_ok());
+            !stripes.is_empty()
+        });
+        drop(socket_map);
+        self.inbound
+            .lock()
+            .unwrap()
+            .retain(|conn| conn.strong_count() > 0);
+    }
+
+    /// Tops a peer with surviving stripes back up to
+    /// `connections_per_peer` unpinned stripes (each independently
+    /// placed, so replacements land on the currently least-loaded NICs).
+    /// Fully dead peers are left to the on-demand reconnect in `acquire`.
+    async fn replenish_peer(&self, addr: &SocketAddr, state: &Arc<State>) {
+        let target = self.config.connections_per_peer.max(1) as usize;
+        let needed = {
+            let socket_map = self.socket_map.read().await;
+            let Some(stripes) = socket_map.get(addr) else {
+                return;
+            };
+            if !stripes.iter().any(|s| s.socket.state.is_ok()) {
+                return;
+            }
+            let healthy_unpinned = stripes
+                .iter()
+                .filter(|s| s.socket.state.is_ok() && !s.pinned)
+                .count();
+            target.saturating_sub(healthy_unpinned)
+        };
+        if needed == 0 {
+            return;
+        }
+
+        let lock = self.peer_lock(addr);
+        let Ok(guard) = lock.try_lock() else {
+            // An acquire is already connecting to this peer; retry next tick.
+            self.release_peer_lock(addr, &lock);
+            return;
+        };
+        let result: Result<()> = async {
+            let plan = self.prepare_connect_plan(addr, state).await?;
+            for _ in 0..needed {
+                let existing = self
+                    .socket_map
+                    .read()
+                    .await
+                    .get(addr)
+                    .cloned()
+                    .unwrap_or_default();
+                let socket = self
+                    .connect_with_failover(addr, state, &plan, None, &existing)
+                    .await?;
+                self.socket_map
+                    .write()
+                    .await
+                    .entry(*addr)
+                    .or_default()
+                    .push(Stripe {
+                        socket,
+                        pinned: false,
+                    });
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(err) = result {
+            tracing::debug!("replenishing RDMA stripes to {addr} failed: {err}");
+        }
+        drop(guard);
+        self.release_peer_lock(addr, &lock);
+    }
+
+    /// Migrates at most one connection of `addr` onto a strictly less
+    /// loaded path (make-before-break: the replacement is established and
+    /// enters the rotation before the victim is drained and closed).
+    ///
+    /// Scores are connection counts with the victim's own contribution
+    /// excluded on both sides — i.e. the world as it would look with the
+    /// victim removed: `stay = victim's pair load`, `move = candidate
+    /// pair load`. Migration requires `move + rebalance_threshold <=
+    /// stay`; the victim's own pair scores exactly `stay`, so a balanced
+    /// pool never oscillates and the threshold adds hysteresis on top.
+    async fn rebalance_peer(&self, addr: &SocketAddr, state: &Arc<State>) {
+        let threshold = u64::from(self.config.rebalance_threshold.max(1));
+        let stripes: Vec<Stripe> = {
+            let socket_map = self.socket_map.read().await;
+            match socket_map.get(addr) {
+                Some(stripes) => stripes
+                    .iter()
+                    .filter(|s| s.socket.state.is_ok() && !s.pinned)
+                    .cloned()
+                    .collect(),
+                None => return,
+            }
+        };
+        if stripes.is_empty() {
+            return;
+        }
+
+        let Ok(plan) = self.prepare_connect_plan(addr, state).await else {
+            return;
+        };
+        let remote_info = &plan.remote_info;
+        // Never migrate onto a recently failed pair; unlike placement
+        // (which may have no alternative), skipping a rebalance is free.
+        let candidates: Vec<PathCandidate> = plan
+            .candidates
+            .iter()
+            .filter(|c| !self.is_blacklisted(addr, c))
+            .cloned()
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
+
+        // A NIC that is no longer advertised/present scores prohibitively
+        // high, so its connections migrate away as soon as any healthy
+        // alternative exists.
+        const GONE: u64 = u64::MAX / 4;
+        let remote_count = |name: &str| -> u64 {
+            remote_info
+                .devices
+                .iter()
+                .find(|d| d.name == name)
+                .map_or(GONE, |d| u64::from(d.active_connections))
+        };
+        let local_count_by_index = |index: usize| -> u64 {
+            self.conn_counts
+                .get(index)
+                .map_or(0, |c| c.load(Ordering::Acquire) as u64)
+        };
+        let local_count = |name: &str| -> u64 {
+            self.devices
+                .rdma_devices()
+                .iter()
+                .enumerate()
+                .find(|(_, d)| d.info().name == name)
+                .map_or(GONE, |(index, _)| local_count_by_index(index))
+        };
+
+        // A stripe's "stay" score: the load on its pair with itself
+        // removed from both sides.
+        let stripe_score = |s: &Stripe| -> u64 {
+            local_count(&s.socket.path.local.device).saturating_sub(1)
+                + remote_count(&s.socket.path.remote.device).saturating_sub(1)
+        };
+        let Some(victim) = stripes.iter().max_by_key(|s| stripe_score(s)) else {
+            return;
+        };
+        let victim_score = stripe_score(victim);
+        // A candidate's "move" score: the load the victim would join,
+        // likewise with the victim's own contribution excluded (it still
+        // occupies its current pair while we measure).
+        let candidate_score = |c: &PathCandidate| -> u64 {
+            let mut local = local_count_by_index(c.local_device_index);
+            if c.path.local.device == victim.socket.path.local.device {
+                local = local.saturating_sub(1);
+            }
+            let mut remote = remote_count(&c.path.remote.device);
+            if c.path.remote.device == victim.socket.path.remote.device {
+                remote = remote.saturating_sub(1);
+            }
+            local + remote
+        };
+        let Some((best_score, best)) = candidates
+            .iter()
+            .map(|c| (candidate_score(c), c))
+            .min_by_key(|(score, _)| *score)
+        else {
+            return;
+        };
+        if best_score.saturating_add(threshold) > victim_score {
+            return;
+        }
+        // Herd damping: many clients may decide to move against the same
+        // stale load snapshot in the same tick; a coin flip (on top of the
+        // jittered tick) halves the worst-case simultaneous moves, and the
+        // threshold hysteresis absorbs the overshoot that remains.
+        if self.pseudo_random().is_multiple_of(2) {
+            return;
+        }
+
+        let lock = self.peer_lock(addr);
+        let Ok(guard) = lock.try_lock() else {
+            self.release_peer_lock(addr, &lock);
+            return;
+        };
+        match self
+            .connect_stripe(addr, state, &plan.acquire_ctx, best)
+            .await
+        {
+            Ok(socket) => {
+                let mut socket_map = self.socket_map.write().await;
+                if let Some(stripes) = socket_map.get_mut(addr) {
+                    stripes.push(Stripe {
+                        socket: socket.clone(),
+                        pinned: false,
+                    });
+                    if let Some(pos) = stripes
+                        .iter()
+                        .position(|s| Arc::ptr_eq(&s.socket, &victim.socket))
+                    {
+                        stripes.remove(pos);
+                        drop(socket_map);
+                        tracing::info!(
+                            peer = %addr,
+                            from_local = %victim.socket.path.local.device,
+                            from_remote = %victim.socket.path.remote.device,
+                            to_local = %socket.path.local.device,
+                            to_remote = %socket.path.remote.device,
+                            "rebalancing RDMA connection"
+                        );
+                        // The victim already left the rotation; give its
+                        // in-flight responses time to arrive, then close.
+                        self.drain_then_close(victim.socket.clone());
+                    }
+                } else {
+                    socket.set_error();
+                }
+            }
+            Err(err) => tracing::debug!("rebalance connect to {addr} failed: {err}"),
+        }
+        drop(guard);
+        self.release_peer_lock(addr, &lock);
+    }
+
+    /// Closes `socket` after the drain timeout; used for stripes removed
+    /// from the rotation whose in-flight responses must still arrive.
+    fn drain_then_close(&self, socket: Arc<RdmaSocket>) {
+        let drain = Duration::from_millis(self.config.drain_timeout_ms);
+        let guard = self.task_supervisor.start_async_task();
+        tokio::spawn(async move {
+            tokio::select! {
+                () = guard.stopped() => {}
+                () = tokio::time::sleep(drain) => {}
+            }
+            socket.set_error();
+        });
+    }
+
+    /// Snapshot of every live connection with its NIC pair, plus
+    /// per-device connection counts.
+    pub(crate) async fn path_report(&self) -> RdmaPathReport {
+        let devices = self
+            .devices
+            .rdma_devices()
+            .iter()
+            .enumerate()
+            .map(|(index, device)| RdmaDeviceLoad {
+                device: device.info().name.clone(),
+                connections: self
+                    .conn_counts
+                    .get(index)
+                    .map_or(0, |c| c.load(Ordering::Acquire)),
+            })
+            .collect();
+
+        let mut paths = Vec::new();
+        {
+            let socket_map = self.socket_map.read().await;
+            for (addr, stripes) in socket_map.iter() {
+                for stripe in stripes {
+                    paths.push(RdmaPathEntry {
+                        peer: Some(*addr),
+                        direction: RdmaConnDirection::Outbound,
+                        path: stripe.socket.path.clone(),
+                        qp_num: stripe.socket.queue_pair.qp_num(),
+                        healthy: stripe.socket.state.is_ok(),
+                        pinned: stripe.pinned,
+                    });
+                }
+            }
+        }
+        let inbound: Vec<Arc<RdmaSocket>> = self
+            .inbound
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect();
+        for socket in inbound {
+            paths.push(RdmaPathEntry {
+                peer: None,
+                direction: RdmaConnDirection::Inbound,
+                path: socket.path.clone(),
+                qp_num: socket.queue_pair.qp_num(),
+                healthy: socket.state.is_ok(),
+                pinned: false,
+            });
+        }
+        RdmaPathReport { devices, paths }
+    }
 }
 
 impl Drop for RdmaSocketPool {
@@ -914,16 +1688,303 @@ impl std::fmt::Debug for RdmaSocketPool {
     }
 }
 
-#[derive(Clone)]
-struct DeviceMatch {
+/// Everything a placement decision towards one peer needs: the bootstrap
+/// context, the peer's advertised device list and the compatible path
+/// candidates derived from it.
+struct ConnectPlan {
+    acquire_ctx: Context,
+    remote_info: RdmaInfo,
+    candidates: Vec<PathCandidate>,
+}
+
+/// One compatible (local NIC, remote NIC) pair a new connection could use.
+#[derive(Clone, Debug)]
+struct PathCandidate {
+    /// Index of the local device in `devices.rdma_devices()`.
     local_device_index: usize,
-    local_port_num: u8,
-    local_gid_index: u8,
+    /// Remote device/port/GID to request in the `connect` RPC.
     remote: DeviceSelection,
-    remote_device: RdmaDeviceInfo,
+    /// Remote per-connection resource limits advertised for that device.
+    remote_limits: RdmaConnectionConfig,
+    /// Full NIC-pair identity of this candidate.
+    path: RdmaPathInfo,
 }
 
 struct CachedRdmaInfo {
     info: RdmaInfo,
     cached_at: Instant,
+}
+
+/// Cheap pseudo-random draw; see [`RdmaSocketPool::pseudo_random`].
+fn pseudo_random(seq: usize) -> u64 {
+    use std::hash::BuildHasher as _;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    RandomState::default().hash_one((seq, nanos))
+}
+
+#[cfg(test)]
+mod path_selection_tests {
+    use super::*;
+    use crate::rdma::rdma_service::RdmaDeviceInfo;
+
+    fn make_pool() -> RdmaSocketPool {
+        let devices = crate::rdma::test_utils::make_rdma_devices();
+        let buffer_pool = ruapc_bufpool::BufferPoolBuilder::new(devices.clone()).build();
+        RdmaSocketPool::new(devices, buffer_pool, RdmaSocketPoolConfig::default()).unwrap()
+    }
+
+    fn connection_limits() -> RdmaConnectionConfig {
+        RdmaConnectionConfig {
+            qp: RdmaQueuePairConfig::default(),
+            cq_len: 128,
+            recv_queue_len: 8,
+            max_msg_size: 64 * 1024,
+        }
+    }
+
+    fn candidate(local_index: usize, remote_dev: &str) -> PathCandidate {
+        PathCandidate {
+            local_device_index: local_index,
+            remote: DeviceSelection {
+                device_name: remote_dev.into(),
+                port_num: 1,
+                gid_index: 0,
+            },
+            remote_limits: connection_limits(),
+            path: RdmaPathInfo {
+                local: RdmaNicInfo {
+                    device: format!("local{local_index}"),
+                    port_num: 1,
+                    gid_index: 0,
+                    ip: None,
+                },
+                remote: RdmaNicInfo {
+                    device: remote_dev.into(),
+                    port_num: 1,
+                    gid_index: 0,
+                    ip: None,
+                },
+            },
+        }
+    }
+
+    fn remote_info(devices: &[(&str, u32)]) -> RdmaInfo {
+        RdmaInfo {
+            devices: devices
+                .iter()
+                .map(|(name, load)| RdmaDeviceInfo {
+                    name: (*name).to_string(),
+                    active_connections: *load,
+                    connection: connection_limits(),
+                    ports: Vec::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn addr() -> SocketAddr {
+        "127.0.0.1:9999".parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_select_prefers_less_loaded_remote() {
+        let pool = make_pool();
+        let candidates = [candidate(0, "remoteA"), candidate(0, "remoteB")];
+        let info = remote_info(&[("remoteA", 5), ("remoteB", 0)]);
+        // With exactly two distinct remote NICs, P2C compares both every
+        // time, so the choice is deterministic.
+        for _ in 0..8 {
+            let chosen = pool
+                .select_candidate(&addr(), &candidates, None, &info, &[])
+                .unwrap();
+            assert_eq!(chosen.path.remote.device, "remoteB");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_select_respects_selector() {
+        let pool = make_pool();
+        let candidates = [candidate(0, "remoteA"), candidate(0, "remoteB")];
+        let info = remote_info(&[("remoteA", 5), ("remoteB", 0)]);
+
+        let selector = RdmaPathSelector::remote_device("remoteA");
+        let chosen = pool
+            .select_candidate(&addr(), &candidates, Some(&selector), &info, &[])
+            .unwrap();
+        assert_eq!(chosen.path.remote.device, "remoteA");
+
+        let missing = RdmaPathSelector::remote_device("nonexistent");
+        let err = pool
+            .select_candidate(&addr(), &candidates, Some(&missing), &info, &[])
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_select_local_least_connections() {
+        let pool = make_pool();
+        // Simulate load on local device 0; device index 1 may not exist in
+        // this environment, but placement only reads its (zero) counter.
+        pool.conn_counts[0].fetch_add(2, Ordering::AcqRel);
+        let candidates = [candidate(0, "remoteA"), candidate(1, "remoteA")];
+        let info = remote_info(&[("remoteA", 0)]);
+        let chosen = pool
+            .select_candidate(&addr(), &candidates, None, &info, &[])
+            .unwrap();
+        assert_eq!(chosen.local_device_index, 1);
+    }
+
+    #[tokio::test]
+    async fn test_select_avoids_blacklisted_pair() {
+        let pool = make_pool();
+        let candidates = [candidate(0, "remoteA"), candidate(0, "remoteB")];
+        let info = remote_info(&[("remoteA", 0), ("remoteB", 0)]);
+
+        pool.blacklist_path(&addr(), &candidates[0].path);
+        for _ in 0..8 {
+            let chosen = pool
+                .select_candidate(&addr(), &candidates, None, &info, &[])
+                .unwrap();
+            assert_eq!(chosen.path.remote.device, "remoteB");
+        }
+        // The blacklist is per peer: another address is unaffected.
+        let other: SocketAddr = "127.0.0.1:9998".parse().unwrap();
+        assert!(!pool.is_blacklisted(&other, &candidates[0]));
+
+        // Soft fallback: with every candidate blacklisted, selection still
+        // returns one instead of failing.
+        pool.blacklist_path(&addr(), &candidates[1].path);
+        assert!(
+            pool.select_candidate(&addr(), &candidates, None, &info, &[])
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conn_count_guard_accounting() {
+        let counts: Arc<Vec<AtomicUsize>> = Arc::new(vec![AtomicUsize::new(0)]);
+        let a = ConnCountGuard::acquire(&counts, 0);
+        let b = ConnCountGuard::acquire(&counts, 0);
+        // Out-of-range indices are tolerated and count nothing.
+        let c = ConnCountGuard::acquire(&counts, 7);
+        assert_eq!(counts[0].load(Ordering::Acquire), 2);
+        drop(a);
+        assert_eq!(counts[0].load(Ordering::Acquire), 1);
+        drop((b, c));
+        assert_eq!(counts[0].load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn test_device_list_advertises_connection_counts() {
+        let pool = make_pool();
+        pool.conn_counts[0].fetch_add(3, Ordering::AcqRel);
+        let info = pool.rdma_device_list().unwrap();
+        assert_eq!(info.devices[0].active_connections, 3);
+    }
+}
+
+#[cfg(test)]
+mod gid_match_tests {
+    use super::*;
+
+    fn make_gid(addr: &str) -> ruapc_rdma::ibv_gid {
+        let bits = addr.parse::<std::net::Ipv6Addr>().unwrap().to_bits();
+        let mut gid = ruapc_rdma::ibv_gid::default();
+        gid.global.subnet_prefix = ((bits >> 64) as u64).to_be();
+        gid.global.interface_id = (bits as u64).to_be();
+        gid
+    }
+
+    fn gid(index: u8, addr: &str, gid_type: GidType) -> Gid {
+        Gid {
+            index,
+            gid: make_gid(addr),
+            gid_type,
+        }
+    }
+
+    fn local_port(gids: Vec<Gid>) -> Port {
+        Port {
+            port_num: 1,
+            port_attr: ruapc_rdma::ibv_port_attr::default(),
+            gids,
+        }
+    }
+
+    #[test]
+    fn test_prefers_rocev2_over_rocev1() {
+        let local = [
+            gid(0, "fe80::1", GidType::RoCEv1),
+            gid(3, "::ffff:10.0.0.1", GidType::RoCEv2),
+        ];
+        let remote = [
+            gid(0, "fe80::2", GidType::RoCEv1),
+            gid(5, "::ffff:10.0.0.2", GidType::RoCEv2),
+        ];
+        assert_eq!(
+            RdmaSocketPool::match_roce_gid_pair(&local, &remote),
+            Some((3, 5))
+        );
+    }
+
+    #[test]
+    fn test_falls_back_to_rocev1_when_remote_lacks_rocev2() {
+        let local = [
+            gid(0, "fe80::1", GidType::RoCEv1),
+            gid(3, "::ffff:10.0.0.1", GidType::RoCEv2),
+        ];
+        let remote = [gid(0, "fe80::2", GidType::RoCEv1)];
+        assert_eq!(
+            RdmaSocketPool::match_roce_gid_pair(&local, &remote),
+            Some((0, 0))
+        );
+    }
+
+    #[test]
+    fn test_matches_same_gid_type_when_no_roce_pair() {
+        let local = [gid(0, "fe80::1", GidType::Other("custom".into()))];
+        let remote = [
+            gid(0, "::ffff:10.0.0.2", GidType::RoCEv2),
+            gid(2, "fe80::2", GidType::Other("custom".into())),
+        ];
+        assert_eq!(
+            RdmaSocketPool::match_roce_gid_pair(&local, &remote),
+            Some((0, 2))
+        );
+    }
+
+    #[test]
+    fn test_empty_remote_gid_table_returns_none() {
+        let local = [gid(3, "::ffff:10.0.0.1", GidType::RoCEv2)];
+        assert_eq!(RdmaSocketPool::match_roce_gid_pair(&local, &[]), None);
+    }
+
+    #[test]
+    fn test_match_gid_pair_ethernet() {
+        let mut local = local_port(vec![gid(0, "::ffff:10.0.0.1", GidType::RoCEv2)]);
+        local.port_attr.link_layer = LinkLayer::Ethernet;
+        let remote = RdmaPortInfo {
+            port_num: 1,
+            link_layer: LinkLayer::Ethernet,
+            gids: vec![gid(2, "::ffff:10.0.0.2", GidType::RoCEv2)],
+        };
+        assert_eq!(
+            RdmaSocketPool::match_gid_pair(&local, &remote),
+            Some((0, 2))
+        );
+    }
+
+    #[test]
+    fn test_gid_index_is_rocev2() {
+        let port = local_port(vec![
+            gid(0, "fe80::1", GidType::RoCEv1),
+            gid(3, "::ffff:10.0.0.1", GidType::RoCEv2),
+        ]);
+        assert!(RdmaSocketPool::gid_index_is_rocev2(&port, 3));
+        assert!(!RdmaSocketPool::gid_index_is_rocev2(&port, 0));
+        assert!(!RdmaSocketPool::gid_index_is_rocev2(&port, 7));
+    }
 }

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -162,6 +162,27 @@ pub struct RdmaSocketPoolConfig {
     /// fabric (device matching cannot verify reachability).
     #[serde(default)]
     pub device_filter: Vec<String>,
+    /// If non-empty, only remote RDMA devices whose name is listed are
+    /// considered when selecting a path. Per-request selection is also
+    /// available via `Context::with_rdma_path`.
+    #[serde(default)]
+    pub remote_device_filter: Vec<String>,
+    /// Interval (milliseconds) of the background maintenance task, which
+    /// fails connections on downed local ports, replaces dead stripes,
+    /// and migrates at most one connection per tick towards less loaded
+    /// NIC pairs (make-before-break). The interval is jittered by ±50%
+    /// per process. `0` disables maintenance entirely.
+    #[serde(default = "default_maintenance_interval_ms")]
+    pub maintenance_interval_ms: u64,
+    /// Minimum connection-count improvement required before a connection
+    /// is migrated to another NIC pair; provides hysteresis on top of the
+    /// self-excluding score model. Values below 1 are treated as 1.
+    #[serde(default = "default_rebalance_threshold")]
+    pub rebalance_threshold: u32,
+    /// Grace period (milliseconds) a migrated-away connection stays alive
+    /// after leaving the rotation, so its in-flight responses can arrive.
+    #[serde(default = "default_drain_timeout_ms")]
+    pub drain_timeout_ms: u64,
 }
 
 #[cfg(feature = "rdma")]
@@ -205,6 +226,21 @@ fn default_connections_per_peer() -> u32 {
 }
 
 #[cfg(feature = "rdma")]
+fn default_maintenance_interval_ms() -> u64 {
+    5000
+}
+
+#[cfg(feature = "rdma")]
+fn default_rebalance_threshold() -> u32 {
+    2
+}
+
+#[cfg(feature = "rdma")]
+fn default_drain_timeout_ms() -> u64 {
+    10_000
+}
+
+#[cfg(feature = "rdma")]
 impl Default for RdmaSocketPoolConfig {
     fn default() -> Self {
         Self {
@@ -221,6 +257,10 @@ impl Default for RdmaSocketPoolConfig {
             dispatch_workers: default_dispatch_workers(),
             connections_per_peer: default_connections_per_peer(),
             device_filter: Vec::new(),
+            remote_device_filter: Vec::new(),
+            maintenance_interval_ms: default_maintenance_interval_ms(),
+            rebalance_threshold: default_rebalance_threshold(),
+            drain_timeout_ms: default_drain_timeout_ms(),
         }
     }
 }
@@ -416,6 +456,34 @@ impl SocketPool {
             SocketPool::RDMA(_) => Err(Error::new(
                 ErrorKind::InvalidArgument,
                 "invalid socket type".into(),
+            )),
+        }
+    }
+
+    /// Returns the underlying RDMA socket pool, if this pool has one.
+    #[cfg(feature = "rdma")]
+    pub(crate) fn rdma_pool(&self) -> Option<&RdmaSocketPool> {
+        match self {
+            SocketPool::RDMA(p) => Some(p),
+            SocketPool::UNIFIED(p) => Some(&p.rdma_socket_pool),
+            _ => None,
+        }
+    }
+
+    /// Acquires an RDMA socket to `addr` whose path (NIC pair) matches
+    /// `selector`, establishing one when none exists.
+    #[cfg(feature = "rdma")]
+    pub(crate) async fn acquire_rdma_path(
+        &self,
+        addr: &SocketAddr,
+        selector: &crate::rdma::RdmaPathSelector,
+        state: &Arc<State>,
+    ) -> Result<Socket> {
+        match self.rdma_pool() {
+            Some(pool) => pool.acquire_path(addr, Some(selector), state).await,
+            None => Err(Error::new(
+                ErrorKind::InvalidArgument,
+                "RDMA is not supported: invalid socket type".into(),
             )),
         }
     }
@@ -617,6 +685,7 @@ mod tests {
         let pool = SocketPool::create(&config, &devices, &buffer_pool).unwrap();
         let (state, _guard) = crate::State::create(crate::Router::default(), &config).unwrap();
         let request = crate::rdma::ConnectRequest {
+            source_device: "test".into(),
             target: crate::rdma::DeviceSelection {
                 device_name: "missing".into(),
                 port_num: 1,

--- a/ruapc/src/sockets/unified/unified_socket_pool.rs
+++ b/ruapc/src/sockets/unified/unified_socket_pool.rs
@@ -199,6 +199,7 @@ mod tests {
         let pool = UnifiedSocketPool::create(&config, &devices, &buffer_pool).unwrap();
         let (state, _guard) = crate::State::create(crate::Router::default(), &config).unwrap();
         let request = crate::rdma::ConnectRequest {
+            source_device: "test".into(),
             target: crate::rdma::DeviceSelection {
                 device_name: "missing".into(),
                 port_num: 1,

--- a/ruapc/tests/test_rdma_path.rs
+++ b/ruapc/tests/test_rdma_path.rs
@@ -1,0 +1,110 @@
+#![forbid(unsafe_code)]
+#![feature(return_type_notation)]
+#![cfg(feature = "rdma")]
+
+use std::{str::FromStr, sync::Arc};
+
+use ruapc::{RdmaConnDirection, RdmaPathSelector, SocketPoolConfig, SocketType};
+
+#[ruapc::service]
+trait Foo {
+    async fn hello(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+}
+
+struct FooImpl;
+
+impl Foo for FooImpl {
+    async fn hello(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String> {
+        Ok(format!("hello {}!", req))
+    }
+}
+
+/// End-to-end NIC awareness: after an RDMA call, both sides report the
+/// connection with its full path (NIC pair), the per-device connection
+/// counters are populated, and explicit path selectors are honored.
+#[tokio::test]
+async fn test_rdma_path_report_and_selector() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let foo = Arc::new(FooImpl);
+    let mut router = ruapc::Router::default();
+    foo.ruapc_export(&mut router);
+
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+        ..Default::default()
+    };
+    let server = ruapc::Server::create(router, &config).unwrap();
+    let addr = std::net::SocketAddr::from_str("0.0.0.0:0").unwrap();
+    let addr = server.listen(addr).await.unwrap();
+
+    let client = ruapc::Client {
+        socket_type: Some(SocketType::RDMA),
+        ..Default::default()
+    };
+    let ctx = ruapc::Context::create(&config).unwrap().with_addr(addr);
+    let rsp = client.hello(&ctx, &"ruapc".to_string()).await.unwrap();
+    assert_eq!(rsp, "hello ruapc!");
+
+    // Client side: one healthy outbound path towards the server.
+    let report = ctx.state.rdma_path_report().await.unwrap();
+    let outbound: Vec<_> = report
+        .paths
+        .iter()
+        .filter(|p| p.direction == RdmaConnDirection::Outbound)
+        .collect();
+    assert!(!outbound.is_empty());
+    let path = &outbound[0].path;
+    assert_eq!(outbound[0].peer, Some(addr));
+    assert!(outbound[0].healthy);
+    assert!(!outbound[0].pinned);
+    assert!(!path.local.device.is_empty());
+    assert!(!path.remote.device.is_empty());
+    // The local NIC's live connection counter accounts this connection.
+    let load = report
+        .devices
+        .iter()
+        .find(|d| d.device == path.local.device)
+        .unwrap();
+    assert!(load.connections >= 1);
+
+    // Server side: the mirrored inbound path, including the client's
+    // device name (carried in the connect request).
+    let server_report = server.state().rdma_path_report().await.unwrap();
+    let inbound = server_report
+        .paths
+        .iter()
+        .find(|p| p.direction == RdmaConnDirection::Inbound)
+        .unwrap();
+    assert_eq!(inbound.peer, None);
+    assert_eq!(inbound.path.local.device, path.remote.device);
+    assert_eq!(inbound.path.remote.device, path.local.device);
+
+    // Explicit selectors matching the established path are honored.
+    for selector in [
+        RdmaPathSelector::local_device(path.local.device.clone()),
+        RdmaPathSelector::remote_device(path.remote.device.clone()),
+    ] {
+        let hinted = ctx.with_rdma_path(selector);
+        let rsp = client.hello(&hinted, &"path".to_string()).await.unwrap();
+        assert_eq!(rsp, "hello path!");
+    }
+
+    // A selector no NIC can satisfy fails the request.
+    let bad = ctx.with_rdma_path(RdmaPathSelector::remote_device("nonexistent"));
+    client.hello(&bad, &"nope".to_string()).await.unwrap_err();
+
+    // Non-RDMA requests ignore the selector.
+    let tcp_client = ruapc::Client {
+        socket_type: Some(SocketType::TCP),
+        ..Default::default()
+    };
+    let hinted = ctx.with_rdma_path(RdmaPathSelector::remote_device("nonexistent"));
+    let rsp = tcp_client.hello(&hinted, &"tcp".to_string()).await.unwrap();
+    assert_eq!(rsp, "hello tcp!");
+
+    server.stop();
+    tokio::time::timeout(std::time::Duration::from_secs(30), server.join())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Peers stay identified by their bootstrap TCP address, but every RDMA connection (stripe) now carries its path — the (local NIC, remote NIC) pair — and picks it independently:

- Local NIC by least-connections over live per-device counters (outbound + inbound, RAII-accurate via ConnCountGuard).
- Remote NIC by power-of-two-choices over the peer's advertised per-NIC load (new RdmaDeviceInfo.active_connections), avoiding client herding on stale snapshots.
- Device matching cannot verify routability: QP setup failures blacklist the NIC pair per peer for 30s and placement falls over to the next candidate.

A per-pool maintenance task (jittered rdma.maintenance_interval_ms) fails connections on downed local ports, prunes dead stripes, replenishes peers up to connections_per_peer, and migrates at most one connection per tick onto a less-loaded pair (make-before-break with a drain grace period; self-excluding scores plus rebalance_threshold hysteresis prevent oscillation). Rate-limited migration makes traffic return gradually to recovered NICs.

Explicit control and introspection:
- Context::with_rdma_path(RdmaPathSelector) pins requests to paths matching a device name or GID-embedded IP, creating pinned (rebalance-exempt) connections on demand.
- rdma.remote_device_filter complements the local device_filter.
- State::rdma_path_report() / Server::state() expose every live connection with its NIC pair, direction, health and per-device load; ConnectRequest.source_device gives servers the client-side NIC of inbound connections.