### PR TITLE
feat(core): production-readiness — metrics, deadlines, load shedding, retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ RuaPC ("Rua! Procedure Call") is a high-performance Rust RPC library supporting 
 
 - **Enum dispatch over `dyn Trait`**: All runtime polymorphism uses enum variants (e.g. `Socket`, `SocketPool`, `HttpSocket`) instead of trait objects. Two reasons: (1) we don't need open-ended extensibility and won't sacrifice performance for it; (2) `async`-compatible `dyn Trait` has high runtime cost and is not mature enough. When adding new transport types or socket variants, add enum variants rather than trait objects.
 
+### Request Lifecycle & Dispatch Policies
+
+- **Connection tracking**: every connection (TCP/WS/HTTP-stream/RDMA) has a process-unique `conn_id`. Requests bind to it on send (`Waiter::bind_connection`); when a connection dies, `State::connection_closed` eagerly fails its pending waiters (`ErrorKind::ConnectionClosed`). Transport pools evict dead sockets exactly once (`mark_closed`) with identity checks against replacements.
+- **Deadline propagation**: `Client.timeout` (min'd with the context's remaining budget for nested RPCs) travels as `MsgMeta.timeout_ms`; the server derives `Context::deadline()` / `remaining_time()` / `is_expired()` on arrival and drops requests that expire before execution.
+- **No mid-flight cancellation**: once a handler starts it runs to completion (aborting user code at await points risks broken invariants, and cancel signals are inherently unreliable). Long-running handlers should poll `Context::is_expired()` to stop wasted work; undeliverable responses are simply discarded.
+- **Server dispatch** (`spawn_handler`, called by macro-generated code): load shedding (`SocketPoolConfig.max_inflight_requests`, rejects with `Overloaded`), expired-request drop, panic containment (`catch_handler_panic` → `HandlerPanic` error response), per-method metrics.
+- **Client retries**: `Client.max_retries` (default 2) retries only pre-wire failures (acquire/send); the waiter entry is allocated *after* connect so slow connection setup doesn't consume the response budget. `Context::with_addrs` gives round-robin multi-address with connect-phase failover.
+- **Metrics**: emitted through the `metrics` facade crate (`ruapc_server_*` / `ruapc_client_*` per-method counters/gauges/latency histograms, `ruapc_connections`, shed/expired counters, `ruapc_waiter_pending`); see `ruapc/src/metrics.rs` for the full table. RuaPC never renders or exports — users install their own `metrics::Recorder`/exporter; without one, emissions are no-ops. Per-method handles are interned per `State` (install the recorder before serving traffic). The only locally-tracked value is `Metrics.server_inflight` (an `AtomicI64`), because load shedding needs a readable count and the facade is write-only.
+
 ### RDMA Multi-NIC Path Awareness
 
 - **Peer identity vs path**: peers are identified by their bootstrap TCP address (the socket_map key); the *path* — the (local NIC, remote NIC) pair, `RdmaPathInfo` — is a per-connection property carried on every `RdmaSocket`. Each stripe of a peer picks its own path.
@@ -43,7 +52,8 @@ RuaPC ("Rua! Procedure Call") is a high-performance Rust RPC library supporting 
 - RDMA send: a sequence of self-delimiting frames `[4B frame_len][4B meta_len][meta][payload]` (usually one). Window-blocked sends are aggregated by plain frame concatenation; one RDMA send consumes one flow-control credit (= one peer receive buffer) regardless of frame count. The poll thread never parses messages — received buffers are batched per CQ drain and routed (sticky, spilling on pressure) to a fixed pool of dispatch worker tasks (`rdma.dispatch_workers`, default 32), each owning one SPSC queue, that walk and parse the frames; when every worker is saturated the poll thread falls back to a one-shot `tokio::spawn` per batch.
 
 ### Serialization
-- JSON (default) or MessagePack (via `MsgFlags::UseMessagePack`)
+- Meta (`MsgMeta`): always MessagePack with named fields — the encoding cannot depend on a flag stored inside itself; new fields are added with `#[serde(default)]` + `skip_serializing_if` for compatible evolution
+- Payload: JSON (default) or MessagePack (via `MsgFlags::UseMessagePack`)
 
 ## Development
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hyper-util = { version = "0.1", features = ["tokio", "http1", "http2", "server-a
 indexmap = "2.11"
 libc = "0.2"
 openapiv3 = "2.2"
+metrics = "0.24"
 pkg-config = "0.3"
 rmp-serde = "1.3"
 schemars = "1.0"

--- a/ruapc-demo/src/bin/client.rs
+++ b/ruapc-demo/src/bin/client.rs
@@ -130,6 +130,7 @@ async fn stress_test(args: Args) {
                     timeout: Duration::from_secs(5),
                     use_msgpack: args.use_msgpack,
                     socket_type: Some(args.socket_type),
+                    ..Default::default()
                 };
                 for _ in 0..256 {
                     let result = client.echo(&ctx, &value).await;
@@ -185,6 +186,7 @@ async fn bench_test(args: Args) {
                 timeout: Duration::from_secs(5),
                 use_msgpack: args.use_msgpack,
                 socket_type: Some(args.socket_type),
+                ..Default::default()
             };
             let mut fails = 0u64;
             loop {

--- a/ruapc-macro/src/lib.rs
+++ b/ruapc-macro/src/lib.rs
@@ -148,9 +148,12 @@ pub fn service(_attr: TokenStream, input: TokenStream) -> TokenStream {
             // a completed `Context::remote_write` + `SentBuffer::reply`).
             invoke_branchs.push(quote! {
                 let this = self.clone();
-                router.add_method::<#req_type, #rsp_type>(#method_name, Box::new(move |mut ctx, payload| {
+                router.add_method::<#req_type, #rsp_type>(#method_name, Box::new(move |ctx, payload| {
                     let this = this.clone();
-                    ::tokio::spawn(async move {
+                    // `spawn_handler` applies the dispatch policies (load
+                    // shedding, deadline enforcement, cancellation
+                    // registration, metrics) around the handler future.
+                    #krate::spawn_handler(ctx, #method_name, payload, move |mut ctx, payload| async move {
                         match payload.deserialize(&ctx.msg_meta) {
                             Ok(req) => {
                                 // Convert handler panics into error responses;

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -29,6 +29,7 @@ hyper.workspace = true
 hyper-tungstenite.workspace = true
 hyper-util.workspace = true
 indexmap.workspace = true
+metrics.workspace = true
 openapiv3.workspace = true
 rmp-serde.workspace = true
 schemars.workspace = true
@@ -48,4 +49,5 @@ libc.workspace = true
 workspace = true
 
 [dev-dependencies]
+metrics-util = "0.20"
 reqwest = { version = "0.12", features = ["json"] }

--- a/ruapc/src/core/client.rs
+++ b/ruapc/src/core/client.rs
@@ -29,6 +29,11 @@ use crate::{
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct Client {
     /// Timeout duration for RPC requests. Default is 1 second.
+    ///
+    /// The effective per-request budget is the minimum of this value and
+    /// the remaining deadline of the context (for nested RPCs issued while
+    /// handling a request). The budget travels with the request so the
+    /// server can drop work the client no longer waits for.
     #[serde_inline_default(Duration::from_secs(1))]
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
@@ -40,6 +45,14 @@ pub struct Client {
     /// If None, uses the socket type from the context's socket pool.
     #[serde_inline_default(None)]
     pub socket_type: Option<SocketType>,
+    /// Maximum number of retries for failures that occur *before the
+    /// request reaches the wire* (connection acquire or send-queue
+    /// failures) — always safe, even for non-idempotent methods. With a
+    /// multi-address context (`Context::with_addrs`) each retry moves to
+    /// the next address. Waiting-phase failures (timeout, connection
+    /// closed mid-flight) are never retried automatically. Default is 2.
+    #[serde_inline_default(2u32)]
+    pub max_retries: u32,
 }
 
 impl Default for Client {
@@ -99,17 +112,117 @@ impl Client {
         Rsp: for<'c> Deserialize<'c> + JsonSchema,
         E: std::error::Error + From<crate::Error> + for<'c> Deserialize<'c>,
     {
-        // 1. get socket.
-        let socket = match &ctx.endpoint {
-            SocketEndpoint::Invalid => {
-                return Err(Error::new(
-                    ErrorKind::InvalidArgument,
-                    "client context without address".to_string(),
-                )
-                .into());
+        let metrics = ctx.state.metrics.client_method(method_name);
+        metrics.requests.increment(1);
+        metrics.inflight.increment(1.0);
+        let start = std::time::Instant::now();
+        let result = self
+            .request_inner(ctx, req, read_buffer, write_buffer_slot, method_name)
+            .await;
+        metrics.latency.record(start.elapsed().as_secs_f64());
+        metrics.inflight.decrement(1.0);
+        if result.is_err() {
+            metrics.errors.increment(1);
+        }
+        result
+    }
+
+    async fn request_inner<Req, Rsp, E>(
+        &self,
+        ctx: &Context,
+        req: &Req,
+        read_buffer: Option<&Buffer>,
+        write_buffer_slot: Option<&mut Option<Buffer>>,
+        method_name: &str,
+    ) -> std::result::Result<Rsp, E>
+    where
+        Req: Serialize + JsonSchema,
+        Rsp: for<'c> Deserialize<'c> + JsonSchema,
+        E: std::error::Error + From<crate::Error> + for<'c> Deserialize<'c>,
+    {
+        // Effective budget: the configured timeout, shrunk to the remaining
+        // deadline when issuing a nested RPC from within a handler.
+        let timeout = match ctx.remaining_time() {
+            Some(remaining) => {
+                if remaining.is_zero() {
+                    return Err(Error::new(
+                        ErrorKind::Timeout,
+                        "request deadline already expired".to_string(),
+                    )
+                    .into());
+                }
+                self.timeout.min(remaining)
             }
-            SocketEndpoint::Connected(socket) => socket.clone(),
-            SocketEndpoint::Address(socket_addr) => {
+            None => self.timeout,
+        };
+
+        let mut flags = MsgFlags::IsReq;
+        if self.use_msgpack {
+            flags |= MsgFlags::UseMessagePack;
+        }
+
+        // 1.+2. acquire a socket and send the request, retrying failures
+        // that provably happen before the request reaches the wire. Each
+        // attempt allocates its waiter entry *after* the connection is
+        // established, so connection setup (which can be slow, e.g. RDMA QP
+        // negotiation with path failover) does not consume the budget. A
+        // failed attempt drops its receiver, cleaning the entry up.
+        let addr_base = match &ctx.endpoint {
+            SocketEndpoint::Addresses(set) => set.next_base(),
+            _ => 0,
+        };
+        let mut attempt = 0usize;
+        let receiver = loop {
+            let addr = attempt_addr(ctx, addr_base, attempt)?;
+            let result = self
+                .try_send(ctx, req, read_buffer, method_name, flags, timeout, addr)
+                .await;
+            match result {
+                Ok(receiver) => break receiver,
+                Err(err) => {
+                    if attempt >= self.max_retries as usize {
+                        return Err(err.into());
+                    }
+                    tracing::warn!("attempt {attempt} for {method_name} failed, retrying: {err}");
+                    attempt += 1;
+                }
+            }
+        };
+
+        // 3. recv response (fails with Timeout once the entry expires).
+        let (response, write_buffer) = receiver.recv().await?;
+        // Pass the write buffer to the caller if a slot was provided.
+        if let Some(slot) = write_buffer_slot {
+            *slot = write_buffer;
+        }
+        response.payload.deserialize(&response.meta)?
+    }
+
+    /// One connect + send attempt. Failures here are always safe to retry:
+    /// an error from `acquire` or `send` means the request was never handed
+    /// to the transport.
+    ///
+    /// The waiter entry is allocated between the two phases so that
+    /// connection setup does not eat into the response budget; it is
+    /// returned as a [`Receiver`](crate::Receiver) whose drop (on send
+    /// failure) removes the entry again.
+    #[allow(clippy::too_many_arguments)]
+    async fn try_send<'a, Req>(
+        &self,
+        ctx: &'a Context,
+        req: &Req,
+        read_buffer: Option<&Buffer>,
+        method_name: &str,
+        flags: MsgFlags,
+        timeout: Duration,
+        addr: Option<std::net::SocketAddr>,
+    ) -> std::result::Result<crate::Receiver<'a>, Error>
+    where
+        Req: Serialize + JsonSchema,
+    {
+        let socket = match (&ctx.endpoint, addr) {
+            (SocketEndpoint::Connected(socket), _) => socket.clone(),
+            (_, Some(socket_addr)) => {
                 let socket_type = self
                     .socket_type
                     .unwrap_or(ctx.state.socket_pool.socket_type());
@@ -118,13 +231,13 @@ impl Client {
                     Some(selector) if socket_type == SocketType::RDMA => {
                         ctx.state
                             .socket_pool
-                            .acquire_rdma_path(socket_addr, selector, &ctx.state)
+                            .acquire_rdma_path(&socket_addr, selector, &ctx.state)
                             .await?
                     }
                     _ => {
                         ctx.state
                             .socket_pool
-                            .acquire(socket_addr, socket_type, &ctx.state)
+                            .acquire(&socket_addr, socket_type, &ctx.state)
                             .await?
                     }
                 };
@@ -132,17 +245,12 @@ impl Client {
                 let socket = ctx
                     .state
                     .socket_pool
-                    .acquire(socket_addr, socket_type, &ctx.state)
+                    .acquire(&socket_addr, socket_type, &ctx.state)
                     .await?;
                 socket
             }
+            _ => unreachable!("attempt_addr rejects endpoints without an address"),
         };
-
-        // 2. send request.
-        let mut flags = MsgFlags::IsReq;
-        if self.use_msgpack {
-            flags |= MsgFlags::UseMessagePack;
-        }
 
         // Extract buffer info if a read buffer is provided.
         let buffer_info = if let Some(buf) = read_buffer {
@@ -155,24 +263,43 @@ impl Client {
             None
         };
 
-        // The waiter entry expires after `self.timeout` (coarse, swept
+        // The waiter entry expires after `timeout` (coarse, swept
         // periodically); no per-request timer is registered.
-        let (msgid, receiver) = ctx.state.waiter.alloc(self.timeout);
+        let (msgid, receiver) = ctx.state.waiter.alloc(timeout);
         let mut meta = MsgMeta {
             method: method_name.into(),
             flags,
             msgid,
             buffer_info,
+            // Ship the *effective* budget so the whole downstream call
+            // tree inherits the shrunk deadline.
+            timeout_ms: Some(u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX)),
         };
         socket.send(&mut meta, req, &ctx.state).await?;
+        Ok(receiver)
+    }
+}
 
-        // 3. recv response (fails with Timeout once the entry expires).
-        let (response, write_buffer) = receiver.recv().await?;
-        // Pass the write buffer to the caller if a slot was provided.
-        if let Some(slot) = write_buffer_slot {
-            *slot = write_buffer;
-        }
-        response.payload.deserialize(&response.meta)?
+/// Resolves the target address for the `attempt`-th try, or `None` for an
+/// already-connected endpoint.
+fn attempt_addr(
+    ctx: &Context,
+    base: usize,
+    attempt: usize,
+) -> std::result::Result<Option<std::net::SocketAddr>, Error> {
+    match &ctx.endpoint {
+        SocketEndpoint::Invalid => Err(Error::new(
+            ErrorKind::InvalidArgument,
+            "client context without address".to_string(),
+        )),
+        SocketEndpoint::Connected(_) => Ok(None),
+        SocketEndpoint::Address(addr) => Ok(Some(*addr)),
+        SocketEndpoint::Addresses(set) => set.pick(base, attempt).map(Some).ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidArgument,
+                "client context with empty address set".to_string(),
+            )
+        }),
     }
 }
 
@@ -266,6 +393,7 @@ mod tests {
             timeout: Duration::from_millis(500),
             use_msgpack: false,
             socket_type: Some(SocketType::TCP),
+            max_retries: 4,
         };
         let json = serde_json::to_string(&client).unwrap();
         let recovered: Client = serde_json::from_str(&json).unwrap();

--- a/ruapc/src/core/context.rs
+++ b/ruapc/src/core/context.rs
@@ -25,6 +25,44 @@ pub enum SocketEndpoint {
     Connected(Socket),
     /// A socket address to establish a connection to.
     Address(SocketAddr),
+    /// Several equivalent server addresses; requests pick one round-robin
+    /// and connect-phase retries fail over to the next.
+    Addresses(Arc<AddrSet>),
+}
+
+/// A set of equivalent server addresses with a round-robin cursor.
+#[derive(Debug)]
+pub struct AddrSet {
+    addrs: Vec<SocketAddr>,
+    cursor: std::sync::atomic::AtomicUsize,
+}
+
+impl AddrSet {
+    /// Creates an address set. Empty sets are permitted but every request
+    /// through them fails with `InvalidArgument`.
+    #[must_use]
+    pub fn new(addrs: Vec<SocketAddr>) -> Self {
+        Self {
+            addrs,
+            cursor: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    /// Address for the `attempt`-th try of one request: the first attempt
+    /// advances the round-robin cursor, retries move to subsequent
+    /// addresses.
+    pub(crate) fn pick(&self, base: usize, attempt: usize) -> Option<SocketAddr> {
+        if self.addrs.is_empty() {
+            return None;
+        }
+        Some(self.addrs[(base + attempt) % self.addrs.len()])
+    }
+
+    /// Reserves a starting position for a new request.
+    pub(crate) fn next_base(&self) -> usize {
+        self.cursor
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
 }
 
 /// RPC context carrying request metadata and connection information.
@@ -53,6 +91,10 @@ pub struct Context {
     pub(crate) endpoint: SocketEndpoint,
     /// Message metadata for the current RPC operation.
     pub msg_meta: MsgMeta,
+    /// Deadline of the request being handled, derived from the client's
+    /// `timeout_ms` budget on arrival. `None` when the request carries no
+    /// budget (or for client-created contexts).
+    pub(crate) deadline: Option<std::time::Instant>,
     /// Optional constraint on the RDMA path (NIC pair) used by requests
     /// issued through this context. See [`Context::with_rdma_path`].
     #[cfg(feature = "rdma")]
@@ -73,6 +115,7 @@ impl Context {
             endpoint: SocketEndpoint::Invalid,
             drop_guard: Some(Arc::new(drop_guard)),
             msg_meta: MsgMeta::default(),
+            deadline: None,
             #[cfg(feature = "rdma")]
             rdma_path: None,
         })
@@ -88,11 +131,15 @@ impl Context {
             endpoint: SocketEndpoint::Address(*addr),
             drop_guard: None,
             msg_meta: MsgMeta::default(),
+            deadline: None,
             rdma_path: None,
         }
     }
 
     /// Creates a new context with the specified target address.
+    ///
+    /// The deadline (if any) is inherited: nested RPCs issued while handling
+    /// a request keep the caller's remaining time budget.
     #[must_use]
     pub fn with_addr(&self, addr: SocketAddr) -> Self {
         Self {
@@ -100,9 +147,52 @@ impl Context {
             endpoint: SocketEndpoint::Address(addr),
             drop_guard: self.drop_guard.clone(),
             msg_meta: MsgMeta::default(),
+            deadline: self.deadline,
             #[cfg(feature = "rdma")]
             rdma_path: self.rdma_path.clone(),
         }
+    }
+
+    /// Creates a new context that load-balances across several addresses.
+    ///
+    /// Each request picks the next address round-robin; when an attempt
+    /// fails before the request reaches the wire (connect or send failure),
+    /// the retry moves on to the following address (see
+    /// [`Client::max_retries`](crate::Client::max_retries)).
+    #[must_use]
+    pub fn with_addrs(&self, addrs: Vec<SocketAddr>) -> Self {
+        Self {
+            state: self.state.clone(),
+            endpoint: SocketEndpoint::Addresses(Arc::new(AddrSet::new(addrs))),
+            drop_guard: self.drop_guard.clone(),
+            msg_meta: MsgMeta::default(),
+            deadline: self.deadline,
+            #[cfg(feature = "rdma")]
+            rdma_path: self.rdma_path.clone(),
+        }
+    }
+
+    /// Deadline of the request being handled, if the client sent a time
+    /// budget.
+    #[must_use]
+    pub fn deadline(&self) -> Option<std::time::Instant> {
+        self.deadline
+    }
+
+    /// Remaining time budget of the request being handled. Returns
+    /// `Duration::ZERO` when the deadline already passed and `None` when
+    /// the request carries no budget.
+    #[must_use]
+    pub fn remaining_time(&self) -> Option<std::time::Duration> {
+        self.deadline
+            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    /// Whether the request's deadline has passed. Handlers of long-running
+    /// methods can poll this to stop work the client no longer waits for.
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.remaining_time() == Some(std::time::Duration::ZERO)
     }
 
     /// Constrains RDMA requests issued through this context to
@@ -131,13 +221,20 @@ impl Context {
     }
 
     /// Creates a server-side context with an established socket connection.
+    ///
+    /// Derives the request deadline from the client-provided `timeout_ms`
+    /// budget, anchored at arrival time.
     #[must_use]
     pub(crate) fn server_ctx(state: &Arc<State>, socket: Socket, msg_meta: MsgMeta) -> Self {
+        let deadline = msg_meta
+            .timeout_ms
+            .map(|ms| std::time::Instant::now() + std::time::Duration::from_millis(u64::from(ms)));
         Self {
             state: state.clone(),
             endpoint: SocketEndpoint::Connected(socket),
             drop_guard: None,
             msg_meta,
+            deadline,
             #[cfg(feature = "rdma")]
             rdma_path: None,
         }
@@ -149,14 +246,24 @@ impl Context {
         Rsp: Serialize,
         E: std::error::Error + From<Error> + Serialize,
     {
+        // Error accounting for the method being handled (server side).
+        if rsp.is_err() && !self.msg_meta.method.is_empty() {
+            self.state
+                .metrics
+                .server_method(&self.msg_meta.method)
+                .errors
+                .increment(1);
+        }
+
         // Responses are correlated by msgid alone: drop the request's method
-        // and buffer_info so the response meta encodes as a fixed prefix
-        // with no serde tail (decoded allocation-free on the hot path).
+        // and buffer_info so the response meta stays minimal (flags + msgid
+        // only; absent fields are skipped by the meta encoding).
         let mut meta = MsgMeta {
             method: String::new(),
             flags: self.msg_meta.flags,
             msgid: self.msg_meta.msgid,
             buffer_info: None,
+            timeout_ms: None,
         };
         meta.flags.remove(MsgFlags::IsReq);
         meta.flags.insert(MsgFlags::IsRsp);

--- a/ruapc/src/core/dispatch.rs
+++ b/ruapc/src/core/dispatch.rs
@@ -1,0 +1,187 @@
+//! Server-side handler dispatch: the glue between the router's method table
+//! and user handler futures.
+//!
+//! [`spawn_handler`] wraps every handler execution with:
+//!
+//! - **load shedding** — when `max_inflight_requests` is reached the request
+//!   is rejected immediately with [`ErrorKind::Overloaded`];
+//! - **deadline enforcement** — requests whose client-provided budget
+//!   already expired are dropped without execution (the client stopped
+//!   waiting; a response would be wasted work);
+//! - **metrics** — per-method request counters, in-flight gauges and
+//!   latency histograms.
+//!
+//! Once a handler starts it always runs to completion: there is no
+//! mid-flight cancellation. Aborting arbitrary user code at await points
+//! risks breaking application invariants, and a cancel signal is inherently
+//! unreliable — deadline checks (`Context::is_expired`) inside long-running
+//! handlers are the supported way to stop wasted work.
+
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use crate::{Context, Error, ErrorKind, MethodMetrics, Payload, State};
+
+/// Spawns a request handler with dispatch policies applied.
+///
+/// `f` receives the context and payload and must perform the complete
+/// handling (deserialize, invoke, respond); it is produced by the
+/// `#[ruapc::service]` macro.
+///
+/// Hidden from docs: this is macro plumbing, not a public API.
+#[doc(hidden)]
+pub fn spawn_handler<F, Fut>(mut ctx: Context, method: &'static str, payload: Payload, f: F)
+where
+    F: FnOnce(Context, Payload) -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let state = ctx.state.clone();
+    let metrics = &state.metrics;
+
+    // Load shedding: reject before spawning any work.
+    let cap = state.max_inflight_requests;
+    if cap > 0 && metrics.server_inflight.load(Ordering::Relaxed) >= cap as i64 {
+        metrics.request_rejected();
+        tokio::spawn(async move {
+            ctx.send_err_rsp(Error::new(
+                ErrorKind::Overloaded,
+                format!("server over capacity ({cap} requests in flight)"),
+            ))
+            .await;
+        });
+        return;
+    }
+
+    // Deadline enforcement: the client stopped waiting already.
+    if ctx.is_expired() {
+        metrics.request_expired();
+        tracing::warn!(
+            "dropping expired request {method} (msgid {})",
+            ctx.msg_meta.msgid
+        );
+        return;
+    }
+
+    let method_metrics = metrics.server_method(method);
+    method_metrics.requests.increment(1);
+    method_metrics.inflight.increment(1.0);
+    metrics.server_inflight.fetch_add(1, Ordering::Relaxed);
+
+    let guard = InflightGuard {
+        state,
+        method_metrics,
+        start: Instant::now(),
+    };
+    let fut = f(ctx, payload);
+    tokio::spawn(async move {
+        // The guard lives inside the task: normal completion and panic
+        // both run its Drop.
+        let _guard = guard;
+        fut.await;
+    });
+}
+
+/// Reverts the bookkeeping of one in-flight handler; runs on completion
+/// and panic alike.
+struct InflightGuard {
+    state: std::sync::Arc<State>,
+    method_metrics: MethodMetrics,
+    start: Instant,
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        self.method_metrics
+            .latency
+            .record(self.start.elapsed().as_secs_f64());
+        self.method_metrics.inflight.decrement(1.0);
+        self.state
+            .metrics
+            .server_inflight
+            .fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Context, MsgFlags, MsgMeta, SocketPoolConfig, SocketType};
+
+    fn make_ctx(config: &SocketPoolConfig, timeout_ms: Option<u32>) -> Context {
+        let base = Context::create(config).unwrap();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let socket = crate::Socket::TCP(crate::sockets::tcp::TcpSocket::new(tx));
+        let meta = MsgMeta {
+            method: "TestSvc/x".into(),
+            flags: MsgFlags::IsReq,
+            msgid: 1,
+            buffer_info: None,
+            timeout_ms,
+        };
+        Context::server_ctx(&base.state, socket, meta)
+    }
+
+    fn tcp_config() -> SocketPoolConfig {
+        SocketPoolConfig {
+            socket_type: SocketType::TCP,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_expired_request_is_dropped() {
+        let ctx = make_ctx(&tcp_config(), Some(0));
+        // The zero budget expired on arrival.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let state = ctx.state.clone();
+        let ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ran_clone = ran.clone();
+        spawn_handler(ctx, "TestSvc/x", crate::Payload::Empty, move |_, _| {
+            ran_clone.store(true, Ordering::SeqCst);
+            async {}
+        });
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::SeqCst));
+        assert_eq!(state.metrics.server_inflight.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn test_load_shedding_rejects_over_cap() {
+        let config = SocketPoolConfig {
+            socket_type: SocketType::TCP,
+            max_inflight_requests: 1,
+            ..Default::default()
+        };
+        let ctx = make_ctx(&config, None);
+        let state = ctx.state.clone();
+        // Simulate one request already in flight.
+        state
+            .metrics
+            .server_inflight
+            .fetch_add(1, Ordering::Relaxed);
+        let ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ran_clone = ran.clone();
+        spawn_handler(ctx, "TestSvc/x", crate::Payload::Empty, move |_, _| {
+            ran_clone.store(true, Ordering::SeqCst);
+            async {}
+        });
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::SeqCst));
+        // The rejected request must not consume in-flight capacity.
+        assert_eq!(state.metrics.server_inflight.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_handler_runs_and_metrics_settle() {
+        let ctx = make_ctx(&tcp_config(), Some(30_000));
+        let state = ctx.state.clone();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        spawn_handler(ctx, "TestSvc/x", crate::Payload::Empty, move |_, _| async {
+            let _ = done_tx.send(());
+        });
+        done_rx.await.unwrap();
+        // Give the guard drop a moment to run after the handler body.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(state.metrics.server_inflight.load(Ordering::Relaxed), 0);
+    }
+}

--- a/ruapc/src/core/mod.rs
+++ b/ruapc/src/core/mod.rs
@@ -2,7 +2,7 @@ mod client;
 pub use client::{Client, ClientWithBuffer};
 
 mod context;
-pub use context::{Context, SocketEndpoint};
+pub use context::{AddrSet, Context, SocketEndpoint};
 
 mod server;
 pub use server::Server;
@@ -24,3 +24,6 @@ pub use contract::{CallPlain, CallWithBuffer, RawCall, RpcCall};
 
 mod panic_guard;
 pub use panic_guard::catch_handler_panic;
+
+mod dispatch;
+pub use dispatch::spawn_handler;

--- a/ruapc/src/core/state.rs
+++ b/ruapc/src/core/state.rs
@@ -3,7 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio_util::sync::DropGuard;
 
 use crate::{
-    BufferPool, Context, Devices, Message, RawStream, Result, Router, Socket, SocketPool,
+    BufferPool, Context, Devices, Message, Metrics, RawStream, Result, Router, Socket, SocketPool,
     SocketPoolConfig, Waiter,
 };
 
@@ -27,6 +27,12 @@ pub struct State {
     pub devices: Arc<Devices>,
     /// Shared buffer pool for RDMA and memory operations.
     pub buffer_pool: Arc<BufferPool>,
+    /// Metric emission helpers (see [`crate::metrics`]); the actual
+    /// storage/export belongs to the user-installed [`metrics::Recorder`].
+    pub(crate) metrics: Arc<Metrics>,
+    /// Server-side in-flight request cap (0 = unlimited); excess requests
+    /// are rejected with [`ErrorKind::Overloaded`](crate::ErrorKind).
+    pub(crate) max_inflight_requests: usize,
 }
 
 impl State {
@@ -69,6 +75,8 @@ impl State {
             socket_pool,
             devices,
             buffer_pool,
+            metrics: Arc::default(),
+            max_inflight_requests: config.max_inflight_requests,
         };
         let state = Arc::new(state);
         let drop_guard = state.drop_guard();
@@ -120,6 +128,14 @@ impl State {
             tracing::warn!("invalid msg type {:?}", msg.meta);
         }
         Ok(())
+    }
+
+    /// Central handling of a dead connection: eagerly fails requests still
+    /// waiting on a response over it. Handlers already executing keep
+    /// running to completion; their responses are simply discarded when
+    /// the send fails.
+    pub(crate) fn connection_closed(&self, conn_id: u64, err: &crate::Error) {
+        self.waiter.fail_connection(conn_id, err);
     }
 
     /// Handles a new incoming stream connection.
@@ -191,6 +207,7 @@ mod tests {
                 flags: MsgFlags::empty(),
                 msgid: 0,
                 buffer_info: None,
+                timeout_ms: None,
             },
             payload: Payload::Empty,
         };

--- a/ruapc/src/error.rs
+++ b/ruapc/src/error.rs
@@ -55,6 +55,9 @@ pub enum ErrorKind {
     HttpUpgradeFailed,
     /// The connection was closed while requests were still in flight.
     ConnectionClosed,
+    /// The server rejected the request because its in-flight request cap
+    /// was reached (load shedding). Safe to retry after backoff.
+    Overloaded,
     /// The service handler panicked while processing the request.
     HandlerPanic,
     /// Failed to send message over RDMA.

--- a/ruapc/src/lib.rs
+++ b/ruapc/src/lib.rs
@@ -10,12 +10,15 @@ mod msg;
 pub use msg::{Message, MsgFlags, MsgMeta, Payload};
 
 mod core;
-#[doc(hidden)]
-pub use core::{CallPlain, CallWithBuffer, RawCall, RpcCall, catch_handler_panic};
 pub use core::{
-    Client, ClientWithBuffer, Context, Listener, MethodInfo, ResultWithBuffer, Router, SentBuffer,
-    Server, SocketEndpoint, State, WithBuffer,
+    AddrSet, Client, ClientWithBuffer, Context, Listener, MethodInfo, ResultWithBuffer, Router,
+    SentBuffer, Server, SocketEndpoint, State, WithBuffer,
 };
+#[doc(hidden)]
+pub use core::{CallPlain, CallWithBuffer, RawCall, RpcCall, catch_handler_panic, spawn_handler};
+
+mod metrics;
+pub(crate) use metrics::{MethodMetrics, Metrics};
 
 mod task;
 pub(crate) use task::Receiver;

--- a/ruapc/src/metrics.rs
+++ b/ruapc/src/metrics.rs
@@ -1,0 +1,245 @@
+//! Metric instrumentation via the [`metrics`] facade.
+//!
+//! RuaPC only *emits* metrics; it never renders or exports them. Install
+//! any [`metrics::Recorder`] (e.g. `metrics-exporter-prometheus`,
+//! `metrics-exporter-statsd`, ...) to collect them — without one, every
+//! emission is a no-op.
+//!
+//! Per-method handles are interned in a [`dashmap::DashMap`] so the hot
+//! path costs one lock-free lookup instead of label allocation. Handles
+//! bind to the recorder installed at first use: install the recorder
+//! before serving traffic.
+//!
+//! # Emitted metrics
+//!
+//! | name | type | labels |
+//! |------|------|--------|
+//! | `ruapc_server_requests_total` | counter | `method` |
+//! | `ruapc_server_errors_total` | counter | `method` |
+//! | `ruapc_server_inflight` | gauge | `method` |
+//! | `ruapc_server_latency_seconds` | histogram | `method` |
+//! | `ruapc_client_requests_total` | counter | `method` |
+//! | `ruapc_client_errors_total` | counter | `method` |
+//! | `ruapc_client_inflight` | gauge | `method` |
+//! | `ruapc_client_latency_seconds` | histogram | `method` |
+//! | `ruapc_connections` | gauge | `transport` |
+//! | `ruapc_requests_rejected_total` | counter | |
+//! | `ruapc_requests_expired_total` | counter | |
+//! | `ruapc_waiter_pending` | gauge | |
+
+use std::sync::atomic::AtomicI64;
+
+use foldhash::fast::RandomState;
+use metrics::{Counter, Gauge, Histogram, counter, gauge, histogram};
+
+/// Per-method metric handles (facade handles; cheap to clone).
+#[derive(Clone)]
+pub(crate) struct MethodMetrics {
+    /// Requests started.
+    pub(crate) requests: Counter,
+    /// Requests completed with an error.
+    pub(crate) errors: Counter,
+    /// Requests currently in flight.
+    pub(crate) inflight: Gauge,
+    /// Completion latency histogram (seconds).
+    pub(crate) latency: Histogram,
+}
+
+impl MethodMetrics {
+    fn new(side: &'static str, method: &str) -> Self {
+        let method = method.to_string();
+        Self {
+            requests: counter!(format!("ruapc_{side}_requests_total"), "method" => method.clone()),
+            errors: counter!(format!("ruapc_{side}_errors_total"), "method" => method.clone()),
+            inflight: gauge!(format!("ruapc_{side}_inflight"), "method" => method.clone()),
+            latency: histogram!(format!("ruapc_{side}_latency_seconds"), "method" => method),
+        }
+    }
+}
+
+/// Per-[`State`](crate::State) instrumentation helpers.
+///
+/// Only the interned handle caches and the load-shedding source of truth
+/// live here; the actual metric storage belongs to the user-installed
+/// [`metrics::Recorder`].
+#[derive(Default)]
+pub(crate) struct Metrics {
+    /// Server-side requests currently in flight across all methods.
+    ///
+    /// This is dispatch state, not just a metric: load shedding reads it
+    /// on every request, and the facade offers no read-back, so it is
+    /// tracked locally (the `ruapc_server_inflight` gauges remain
+    /// per-method, emitted through the facade).
+    pub(crate) server_inflight: AtomicI64,
+    server_methods: dashmap::DashMap<String, MethodMetrics, RandomState>,
+    client_methods: dashmap::DashMap<String, MethodMetrics, RandomState>,
+}
+
+impl Metrics {
+    /// Interned per-method server-side metrics.
+    pub(crate) fn server_method(&self, method: &str) -> MethodMetrics {
+        Self::intern(&self.server_methods, "server", method)
+    }
+
+    /// Interned per-method client-side metrics.
+    pub(crate) fn client_method(&self, method: &str) -> MethodMetrics {
+        Self::intern(&self.client_methods, "client", method)
+    }
+
+    fn intern(
+        cache: &dashmap::DashMap<String, MethodMetrics, RandomState>,
+        side: &'static str,
+        method: &str,
+    ) -> MethodMetrics {
+        if let Some(m) = cache.get(method) {
+            return m.clone();
+        }
+        cache
+            .entry(method.to_string())
+            .or_insert_with(|| MethodMetrics::new(side, method))
+            .clone()
+    }
+
+    /// Records a new live connection for `transport`.
+    pub(crate) fn connection_opened(&self, transport: &'static str) {
+        gauge!("ruapc_connections", "transport" => transport).increment(1.0);
+    }
+
+    /// Records a closed connection for `transport`.
+    pub(crate) fn connection_closed(&self, transport: &'static str) {
+        gauge!("ruapc_connections", "transport" => transport).decrement(1.0);
+    }
+
+    /// Records a request rejected by the in-flight cap.
+    pub(crate) fn request_rejected(&self) {
+        counter!("ruapc_requests_rejected_total").increment(1);
+    }
+
+    /// Records a request dropped because its deadline expired before
+    /// execution.
+    pub(crate) fn request_expired(&self) {
+        counter!("ruapc_requests_expired_total").increment(1);
+    }
+}
+
+impl std::fmt::Debug for Metrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Metrics").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+    /// `(name, labels, value)` triple captured from a snapshot.
+    type Recorded = (String, Vec<(String, String)>, DebugValue);
+
+    /// Runs `f` under a local debugging recorder and returns the snapshot
+    /// as `(name, labels, value)` tuples.
+    fn record<F: FnOnce(&Metrics)>(f: F) -> Vec<Recorded> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let metrics = Metrics::default();
+        metrics::with_local_recorder(&recorder, || f(&metrics));
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(key, _, _, value)| {
+                let key = key.key();
+                (
+                    key.name().to_string(),
+                    key.labels()
+                        .map(|l| (l.key().to_string(), l.value().to_string()))
+                        .collect(),
+                    value,
+                )
+            })
+            .collect()
+    }
+
+    fn find<'a>(
+        snapshot: &'a [Recorded],
+        name: &str,
+        label: Option<(&str, &str)>,
+    ) -> &'a DebugValue {
+        &snapshot
+            .iter()
+            .find(|(n, labels, _)| {
+                n == name
+                    && label.is_none_or(|(k, v)| labels.iter().any(|(lk, lv)| lk == k && lv == v))
+            })
+            .unwrap_or_else(|| panic!("metric {name} not found"))
+            .2
+    }
+
+    #[test]
+    fn test_method_metrics_emission() {
+        let snapshot = record(|metrics| {
+            let m = metrics.server_method("Svc/echo");
+            m.requests.increment(3);
+            m.errors.increment(1);
+            m.latency.record(0.000_05);
+        });
+        let label = Some(("method", "Svc/echo"));
+        assert!(matches!(
+            find(&snapshot, "ruapc_server_requests_total", label),
+            DebugValue::Counter(3)
+        ));
+        assert!(matches!(
+            find(&snapshot, "ruapc_server_errors_total", label),
+            DebugValue::Counter(1)
+        ));
+        assert!(matches!(
+            find(&snapshot, "ruapc_server_latency_seconds", label),
+            DebugValue::Histogram(v) if v.len() == 1
+        ));
+    }
+
+    #[test]
+    fn test_connection_gauge_up_down() {
+        let snapshot = record(|metrics| {
+            metrics.connection_opened("HTTP");
+            metrics.connection_opened("HTTP");
+            metrics.connection_closed("HTTP");
+        });
+        let value = find(&snapshot, "ruapc_connections", Some(("transport", "HTTP")));
+        assert!(matches!(value, DebugValue::Gauge(g) if g.0 == 1.0));
+    }
+
+    #[test]
+    fn test_method_interning_reuses_handles() {
+        let recorder = DebuggingRecorder::new();
+        let metrics = Metrics::default();
+        metrics::with_local_recorder(&recorder, || {
+            let a = metrics.client_method("Svc/x");
+            let b = metrics.client_method("Svc/x");
+            a.requests.increment(1);
+            b.requests.increment(1);
+        });
+        let snapshot = recorder.snapshotter().snapshot().into_vec();
+        // Both handles feed the same counter.
+        let total: u64 = snapshot
+            .iter()
+            .filter(|(key, ..)| key.key().name() == "ruapc_client_requests_total")
+            .map(|(.., value)| match value {
+                DebugValue::Counter(c) => *c,
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn test_noop_without_recorder() {
+        // Without a recorder every emission must be a silent no-op.
+        let metrics = Metrics::default();
+        let m = metrics.server_method("Svc/echo");
+        m.requests.increment(1);
+        m.latency.record(0.1);
+        metrics.connection_opened("TCP");
+        metrics.request_rejected();
+    }
+}

--- a/ruapc/src/msg/message.rs
+++ b/ruapc/src/msg/message.rs
@@ -38,101 +38,54 @@ bitflags! {
 /// - Method name for routing
 /// - Flags controlling message behavior
 /// - Message ID for request/response correlation
+///
+/// # Wire encoding
+///
+/// The whole struct is MessagePack-encoded with field names
+/// ([`rmp_serde::encode::write_named`]), *regardless* of the
+/// `UseMessagePack` flag — the flag only selects the payload format. The
+/// meta encoding cannot depend on a flag stored inside itself, and a fixed
+/// format keeps decoding self-contained. Named encoding makes the meta
+/// extensible: new fields are added with `#[serde(default)]` (+
+/// `skip_serializing_if` to keep them free when absent) and old peers
+/// ignore them.
 #[derive(Deserialize, Serialize, Debug, Default, PartialEq, Eq, Clone)]
 pub struct MsgMeta {
     /// The fully qualified method name (e.g., "ServiceName/method_name").
+    /// Empty for responses, which are correlated by `msgid` alone.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub method: String,
     /// Message flags controlling behavior and format.
+    #[serde(default)]
     pub flags: MsgFlags,
     /// Message ID for correlating requests and responses.
+    #[serde(default)]
     pub msgid: u64,
     /// Optional remote buffer information for server-side reading.
     /// Present when the client uses `_with_read_buffer` methods, allowing the
     /// server to perform `remote_read` on the client's registered memory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub buffer_info: Option<RemoteBufferInfo>,
-}
-
-/// Extensible (serde-encoded) part of the wire metadata. New metadata
-/// fields belong here with `#[serde(default)]`; only `flags` and `msgid`
-/// live in the fixed binary prefix because the transport hot path (e.g. the
-/// RDMA poll thread) needs them to route every message.
-#[derive(Serialize)]
-struct MetaTailRef<'a> {
-    method: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    buffer_info: Option<&'a RemoteBufferInfo>,
-}
-
-/// Deserialization counterpart of [`MetaTailRef`].
-#[derive(Deserialize, Default)]
-struct MetaTail {
-    #[serde(default)]
-    method: String,
-    #[serde(default)]
-    buffer_info: Option<RemoteBufferInfo>,
+    /// Remaining time budget of the request in milliseconds, set by the
+    /// client. The server derives a deadline from it on arrival (relative
+    /// budgets avoid clock-skew issues of absolute timestamps), drops the
+    /// request if it expires before execution, and shrinks the budget of
+    /// nested RPCs issued while handling it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u32>,
 }
 
 impl MsgMeta {
-    /// Size of the fixed binary prefix: flags (1) + msgid (8).
-    const FIXED_PREFIX_LEN: usize = 9;
-
-    /// Encodes the metadata as a fixed binary prefix plus an optional
-    /// serde-encoded tail:
-    ///
-    /// ```text
-    /// | 1B    | 8B    | 0..N bytes                                |
-    /// | flags | msgid | serde tail (method, buffer_info, ...)     |
-    /// ```
-    ///
-    /// The prefix carries exactly what message routing needs; everything
-    /// else stays serde-encoded (JSON, or MessagePack when the
-    /// `UseMessagePack` flag is set) so new fields remain easy to add. The
-    /// tail is omitted entirely when it holds no information — notably for
-    /// responses — making their decode allocation- and serde-free.
+    /// Encodes the metadata (MessagePack, named fields — see the type-level
+    /// docs for the rationale).
     fn encode_to<W: Write>(&self, mut w: W) -> Result<()> {
-        w.write_all(&[self.flags.bits()])
-            .and_then(|()| w.write_all(&self.msgid.to_be_bytes()))
-            .map_err(|e| Error::new(ErrorKind::SerializeFailed, e.to_string()))?;
-        if self.method.is_empty() && self.buffer_info.is_none() {
-            return Ok(());
-        }
-        let tail = MetaTailRef {
-            method: &self.method,
-            buffer_info: self.buffer_info.as_ref(),
-        };
-        if self.flags.contains(MsgFlags::UseMessagePack) {
-            rmp_serde::encode::write_named(&mut w, &tail)?;
-        } else {
-            serde_json::to_writer(w, &tail)?;
-        }
+        rmp_serde::encode::write_named(&mut w, self)?;
         Ok(())
     }
 
     /// Decodes metadata encoded by [`encode_to`](Self::encode_to).
     fn decode(buf: &[u8]) -> Result<Self> {
-        if buf.len() < Self::FIXED_PREFIX_LEN {
-            return Err(Error::new(
-                ErrorKind::DeserializeFailed,
-                format!("invalid msg meta: len {}", buf.len()),
-            ));
-        }
-        let flags = MsgFlags::from_bits_retain(buf[0]);
-        let msgid = u64::from_be_bytes(buf[1..9].try_into().unwrap());
-        let tail = &buf[Self::FIXED_PREFIX_LEN..];
-        let tail: MetaTail = if tail.is_empty() {
-            MetaTail::default()
-        } else if flags.contains(MsgFlags::UseMessagePack) {
-            rmp_serde::from_slice(tail)?
-        } else {
-            serde_json::from_slice(tail)?
-        };
-        Ok(Self {
-            method: tail.method,
-            flags,
-            msgid,
-            buffer_info: tail.buffer_info,
-        })
+        Ok(rmp_serde::from_slice(buf)?)
     }
 
     /// Checks if this message is a request.
@@ -174,8 +127,9 @@ impl MsgMeta {
 ///
 /// Messages are serialized in a custom binary format:
 /// - 4 bytes: metadata length (big-endian u32)
-/// - N bytes: serialized metadata (JSON or MessagePack)
-/// - M bytes: serialized payload (JSON or MessagePack)
+/// - N bytes: serialized metadata (always MessagePack, named fields)
+/// - M bytes: serialized payload (JSON, or MessagePack when the
+///   `UseMessagePack` flag is set)
 #[derive(Debug, Default)]
 pub struct Message {
     /// Message metadata.
@@ -298,7 +252,7 @@ impl MsgMeta {
     ///
     /// This method handles the complete serialization process:
     /// 1. Writes a 4-byte length prefix for the metadata
-    /// 2. Serializes the metadata (JSON or MessagePack based on flags)
+    /// 2. Serializes the metadata (always MessagePack)
     /// 3. Serializes the payload (JSON or MessagePack based on flags)
     /// 4. Updates the length prefix with the actual metadata size
     ///
@@ -439,6 +393,7 @@ mod tests {
             flags,
             msgid: 42,
             buffer_info: None,
+            timeout_ms: None,
         }
     }
 
@@ -478,6 +433,7 @@ mod tests {
                 addr: 0xdead_beef_cafe_f00d,
                 len: 1 << 40,
             }),
+            timeout_ms: Some(1500),
         };
         let buf = serialize_to_bytes(&meta, &serde_json::json!({"x": 1}));
         let msg = Message::parse(Bytes::from(buf)).unwrap();
@@ -486,27 +442,47 @@ mod tests {
 
     #[test]
     fn test_meta_decode_rejects_garbage() {
-        // Too short.
-        assert!(MsgMeta::decode(&[0u8; 4]).is_err());
-        // Garbage serde tail (JSON expected because UseMessagePack is unset).
-        let mut bytes = vec![0u8; MsgMeta::FIXED_PREFIX_LEN];
-        bytes.extend_from_slice(b"\xff\xff");
-        assert!(MsgMeta::decode(&bytes).is_err());
+        // Empty and truncated inputs are not valid MessagePack maps.
+        assert!(MsgMeta::decode(&[]).is_err());
+        // 0xc1 is reserved ("never used") in MessagePack.
+        assert!(MsgMeta::decode(&[0xc1]).is_err());
+        // A msgpack array is not a named struct map.
+        assert!(MsgMeta::decode(&[0x93, 0x01, 0x02, 0x03]).is_err());
     }
 
     #[test]
-    fn test_meta_empty_tail_decodes_to_defaults() {
-        // A prefix-only meta (as produced for responses) decodes without any
-        // serde work.
+    fn test_minimal_response_meta_roundtrip() {
+        // Response metas skip `method`/`buffer_info`/`timeout_ms`; only
+        // flags and msgid travel, and absent fields decode to defaults.
         let meta = MsgMeta {
             method: String::new(),
             flags: MsgFlags::IsRsp,
             msgid: 42,
             buffer_info: None,
+            timeout_ms: None,
         };
         let buf = serialize_to_bytes(&meta, &serde_json::json!({"ok": true}));
         let msg = Message::parse(Bytes::from(buf)).unwrap();
         assert_eq!(msg.meta, meta);
+    }
+
+    #[test]
+    fn test_meta_encoding_is_flag_independent() {
+        // The meta encoding must not vary with UseMessagePack: it only
+        // selects the payload format.
+        let mut json_meta = make_meta("Svc/m", false);
+        let msgpack_meta = make_meta("Svc/m", true);
+        let mut json_buf = Vec::new();
+        let mut msgpack_buf = Vec::new();
+        json_meta.encode_to(&mut json_buf).unwrap();
+        msgpack_meta.encode_to(&mut msgpack_buf).unwrap();
+        // Identical except for the flags byte content inside the map; both
+        // decode back losslessly.
+        json_meta.flags = msgpack_meta.flags;
+        json_buf.clear();
+        json_meta.encode_to(&mut json_buf).unwrap();
+        assert_eq!(json_buf, msgpack_buf);
+        assert_eq!(MsgMeta::decode(&msgpack_buf).unwrap(), msgpack_meta);
     }
 
     #[test]
@@ -575,6 +551,7 @@ mod tests {
             flags: MsgFlags::IsRsp,
             msgid: 7,
             buffer_info: None,
+            timeout_ms: None,
         };
         let payload = crate::Payload::from(bytes::Bytes::from_static(b"data"));
         let msg2 = Message::new(meta, payload);

--- a/ruapc/src/rdma/poller.rs
+++ b/ruapc/src/rdma/poller.rs
@@ -805,6 +805,7 @@ struct ConnState {
 
 impl ConnState {
     fn new(reg: RegisterConn, generation: u8, budget: BudgetGuard) -> Self {
+        reg.state.metrics.connection_opened("RDMA");
         Self {
             generation,
             recv: RecvStats {
@@ -1404,6 +1405,18 @@ impl PollLoop {
                         tracing::error!("flow control update error: {e}");
                     }
                     if conn.ready_to_remove() {
+                        // Eagerly fail requests waiting on this connection
+                        // and abort handlers serving its peer; all involved
+                        // structures are runtime-agnostic, safe to touch
+                        // from the poll thread.
+                        conn.state.metrics.connection_closed("RDMA");
+                        conn.state.connection_closed(
+                            conn.socket.conn_id,
+                            &Error::new(
+                                ErrorKind::ConnectionClosed,
+                                "rdma connection closed".into(),
+                            ),
+                        );
                         // Drop the connection before recycling its slot so
                         // no new occupant can race its teardown.
                         self.conns[slot] = None;

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -89,7 +89,6 @@ impl RdmaInfo {
                                     .qp
                                     .max_recv_sge
                                     .min(info.device_attr.max_sge as u32),
-                                max_inline_data: config.qp.max_inline_data,
                             },
                             cq_len: config.cq_len.min(info.device_attr.max_cqe as u32),
                             recv_queue_len: config.recv_queue_len,

--- a/ruapc/src/rdma/rdma_socket.rs
+++ b/ruapc/src/rdma/rdma_socket.rs
@@ -85,6 +85,8 @@ pub struct RdmaSocket {
     pub(crate) max_msg_size: usize,
     /// The (local NIC, remote NIC) pair this connection runs on.
     pub(crate) path: RdmaPathInfo,
+    /// Process-wide unique connection id (see [`crate::task::next_conn_id`]).
+    pub(crate) conn_id: u64,
 }
 
 impl RdmaSocket {
@@ -106,6 +108,7 @@ impl RdmaSocket {
             poller_waker,
             max_msg_size,
             path,
+            conn_id: crate::task::next_conn_id(),
         }
     }
 
@@ -235,9 +238,15 @@ impl SocketTrait for RdmaSocket {
         &self,
         meta: &mut MsgMeta,
         payload: &P,
-        _: &Arc<State>,
+        state: &Arc<State>,
     ) -> Result<()> {
         let buf = self.serialize_msg(meta, payload)?;
+
+        // Bind the pending request to this connection so it fails eagerly
+        // if the connection dies before the response arrives.
+        if meta.is_req() {
+            state.waiter.bind_connection(meta.msgid, self.conn_id);
+        }
 
         match self.state.try_acquire() {
             SendPermit::Granted { window_tail } => {

--- a/ruapc/src/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/rdma/rdma_socket_pool.rs
@@ -282,6 +282,7 @@ impl RdmaSocketPool {
                 timeout: std::time::Duration::from_secs(5),
                 use_msgpack: true,
                 socket_type: Some(SocketType::TCP),
+                max_retries: 2,
             },
             task_supervisor,
             pollers: DevicePollers::default(),
@@ -435,7 +436,7 @@ impl RdmaSocketPool {
                 max_recv_wr: config.qp.max_recv_wr,
                 max_send_sge: config.qp.max_send_sge,
                 max_recv_sge: config.qp.max_recv_sge,
-                max_inline_data: config.qp.max_inline_data,
+                max_inline_data: 0,
             },
             ..Default::default()
         };
@@ -1103,7 +1104,6 @@ impl RdmaSocketPool {
                 // capability constrains the other.
                 max_send_sge: local.qp.max_send_sge,
                 max_recv_sge: local.qp.max_recv_sge,
-                max_inline_data: local.qp.max_inline_data.min(remote.qp.max_inline_data),
             },
             cq_len: local.cq_len.min(remote.cq_len),
             recv_queue_len: local.recv_queue_len.min(remote.recv_queue_len),
@@ -1126,7 +1126,6 @@ impl RdmaSocketPool {
                 // regardless of what the initiator requested for itself.
                 max_send_sge: local.qp.max_send_sge,
                 max_recv_sge: local.qp.max_recv_sge,
-                max_inline_data: requested.qp.max_inline_data.min(local.qp.max_inline_data),
             },
             cq_len: requested.cq_len.min(local.cq_len),
             recv_queue_len: requested.recv_queue_len.min(local.recv_queue_len),
@@ -1158,7 +1157,6 @@ impl RdmaSocketPool {
                     .qp
                     .max_recv_sge
                     .min(info.device_attr.max_sge as u32),
-                max_inline_data: self.config.qp.max_inline_data,
             },
             cq_len: self.config.cq_len.min(info.device_attr.max_cqe as u32),
             recv_queue_len: self.config.recv_queue_len,

--- a/ruapc/src/sockets/http/http_socket.rs
+++ b/ruapc/src/sockets/http/http_socket.rs
@@ -22,6 +22,7 @@ pub enum HttpSocket {
 pub struct StreamSocket {
     sender: mpsc::Sender<Bytes>,
     conn_id: u64,
+    closed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl StreamSocket {
@@ -29,6 +30,7 @@ impl StreamSocket {
         Self {
             sender,
             conn_id: crate::task::next_conn_id(),
+            closed: Arc::default(),
         }
     }
 
@@ -40,6 +42,11 @@ impl StreamSocket {
     /// Whether `other` refers to the same underlying connection.
     pub(crate) fn same_socket(&self, other: &Self) -> bool {
         self.conn_id == other.conn_id
+    }
+
+    /// Marks the connection closed; returns `true` exactly once.
+    pub(crate) fn mark_closed(&self) -> bool {
+        !self.closed.swap(true, std::sync::atomic::Ordering::SeqCst)
     }
 }
 

--- a/ruapc/src/sockets/http/http_socket_pool.rs
+++ b/ruapc/src/sockets/http/http_socket_pool.rs
@@ -194,12 +194,14 @@ impl HttpSocketPool {
             }
         }
 
-        let (msgid, rx) = state.waiter.alloc(std::time::Duration::from_secs(30));
+        const UNARY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        let (msgid, rx) = state.waiter.alloc(UNARY_TIMEOUT);
         let meta = MsgMeta {
             method: req.uri().path().trim_start_matches('/').to_string(),
             flags: MsgFlags::IsReq,
             msgid,
             buffer_info: None,
+            timeout_ms: Some(u32::try_from(UNARY_TIMEOUT.as_millis()).unwrap_or(u32::MAX)),
         };
         // Cap the request body at the wire-format message limit; an
         // unauthenticated POST must not be able to buffer unbounded data.
@@ -251,6 +253,7 @@ impl HttpSocketPool {
         let (tx, rx) = mpsc::channel::<Bytes>(1024);
         let stream_socket = StreamSocket::new(tx);
         let socket_for_recv = Socket::HTTP(HttpSocket::Stream(stream_socket.clone()));
+        state.metrics.connection_opened("HTTP");
 
         // Spawn recv loop: read framed messages from the request body.
         tokio::spawn({
@@ -262,12 +265,16 @@ impl HttpSocketPool {
                     tracing::error!("http rpc recv loop for {addr} failed: {e}");
                 }
                 // The stream ended: eagerly fail requests (e.g. reverse
-                // RPCs) still pending on this connection.
-                let err = Error::new(
-                    ErrorKind::ConnectionClosed,
-                    format!("http stream from {addr} closed: {:?}", r.err()),
-                );
-                state.waiter.fail_connection(stream_socket.conn_id(), &err);
+                // RPCs) still pending on this connection and abort
+                // handlers still serving its requests.
+                if stream_socket.mark_closed() {
+                    state.metrics.connection_closed("HTTP");
+                    let err = Error::new(
+                        ErrorKind::ConnectionClosed,
+                        format!("http stream from {addr} closed: {:?}", r.err()),
+                    );
+                    state.connection_closed(stream_socket.conn_id(), &err);
+                }
             }
         });
 
@@ -343,6 +350,7 @@ impl HttpSocketPool {
         // Create the socket for sending messages.
         let stream_socket = StreamSocket::new(req_tx);
         let socket = HttpSocket::Stream(stream_socket.clone());
+        state.metrics.connection_opened("HTTP");
 
         // Spawn recv loop on the response body. When it exits — error or
         // clean end of stream — evict the socket from the pool and eagerly
@@ -356,6 +364,10 @@ impl HttpSocketPool {
             if let Err(e) = &r {
                 tracing::error!("http rpc client recv loop for {addr} failed: {e}");
             }
+            if !stream_socket.mark_closed() {
+                return;
+            }
+            state.metrics.connection_closed("HTTP");
             {
                 let mut socket_map = socket_map.write().await;
                 // Identity check: don't evict a replacement connection.
@@ -369,7 +381,7 @@ impl HttpSocketPool {
                 ErrorKind::ConnectionClosed,
                 format!("http connection to {addr} closed: {:?}", r.err()),
             );
-            state.waiter.fail_connection(stream_socket.conn_id(), &err);
+            state.connection_closed(stream_socket.conn_id(), &err);
         });
 
         Ok(socket)

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -74,6 +74,11 @@ pub struct SocketPoolConfig {
     /// buffers, and in-flight sends allocate from the same pool.
     #[serde_inline_default(0usize)]
     pub buffer_pool_memory: usize,
+    /// Maximum number of server-side requests processed concurrently;
+    /// excess requests are rejected immediately with an `Overloaded` error
+    /// response (load shedding). `0` disables the cap.
+    #[serde_inline_default(0usize)]
+    pub max_inflight_requests: usize,
     /// RDMA-specific connection and Queue Pair settings.
     #[cfg(feature = "rdma")]
     #[serde(default)]
@@ -273,7 +278,6 @@ pub struct RdmaQueuePairConfig {
     pub max_recv_wr: u32,
     pub max_send_sge: u32,
     pub max_recv_sge: u32,
-    pub max_inline_data: u32,
 }
 
 #[cfg(feature = "rdma")]
@@ -288,7 +292,6 @@ impl Default for RdmaQueuePairConfig {
             // device's `max_sge` at connection setup.
             max_send_sge: 16,
             max_recv_sge: 1,
-            max_inline_data: 0,
         }
     }
 }

--- a/ruapc/src/sockets/tcp/tcp_socket.rs
+++ b/ruapc/src/sockets/tcp/tcp_socket.rs
@@ -14,6 +14,7 @@ use crate::{
 pub struct TcpSocket {
     stream: mpsc::Sender<Bytes>,
     conn_id: u64,
+    closed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl TcpSocket {
@@ -21,6 +22,7 @@ impl TcpSocket {
         Self {
             stream,
             conn_id: crate::task::next_conn_id(),
+            closed: Arc::default(),
         }
     }
 
@@ -32,6 +34,12 @@ impl TcpSocket {
     /// Whether `other` refers to the same underlying connection.
     pub(crate) fn same_socket(&self, other: &Self) -> bool {
         self.conn_id == other.conn_id
+    }
+
+    /// Marks the connection closed; returns `true` exactly once (the send
+    /// and recv loops both report failures — teardown must run once).
+    pub(crate) fn mark_closed(&self) -> bool {
+        !self.closed.swap(true, std::sync::atomic::Ordering::SeqCst)
     }
 }
 

--- a/ruapc/src/sockets/tcp/tcp_socket_pool.rs
+++ b/ruapc/src/sockets/tcp/tcp_socket_pool.rs
@@ -116,6 +116,7 @@ impl TcpSocketPool {
         let (recv_stream, send_stream) = stream.into_split();
         let (sender, receiver) = mpsc::channel(1024);
         let tcp_socket = TcpSocket::new(sender);
+        state.metrics.connection_opened("TCP");
 
         let task_supervisor = self.task_supervisor.start_async_task();
         tokio::spawn({
@@ -165,6 +166,11 @@ impl TcpSocketPool {
         state: &Arc<State>,
         err: &Error,
     ) {
+        // The send and recv loops both report failures; run teardown once.
+        if !socket.mark_closed() {
+            return;
+        }
+        state.metrics.connection_closed("TCP");
         {
             let mut socket_map = socket_map.write().await;
             // Identity check: don't evict a replacement connection.
@@ -178,7 +184,7 @@ impl TcpSocketPool {
             ErrorKind::ConnectionClosed,
             format!("connection to {addr} closed: {err}"),
         );
-        state.waiter.fail_connection(socket.conn_id(), &err);
+        state.connection_closed(socket.conn_id(), &err);
     }
 
     fn parse_message(buffer: &mut BytesMut) -> Result<Option<Bytes>> {

--- a/ruapc/src/sockets/ws/web_socket.rs
+++ b/ruapc/src/sockets/ws/web_socket.rs
@@ -14,6 +14,7 @@ use crate::{
 pub struct WebSocket {
     stream: mpsc::Sender<Bytes>,
     conn_id: u64,
+    closed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl WebSocket {
@@ -21,6 +22,7 @@ impl WebSocket {
         Self {
             stream,
             conn_id: crate::task::next_conn_id(),
+            closed: Arc::default(),
         }
     }
 
@@ -32,6 +34,12 @@ impl WebSocket {
     /// Whether `other` refers to the same underlying connection.
     pub(crate) fn same_socket(&self, other: &Self) -> bool {
         self.conn_id == other.conn_id
+    }
+
+    /// Marks the connection closed; returns `true` exactly once (the send
+    /// and recv loops both report failures — teardown must run once).
+    pub(crate) fn mark_closed(&self) -> bool {
+        !self.closed.swap(true, std::sync::atomic::Ordering::SeqCst)
     }
 }
 

--- a/ruapc/src/sockets/ws/web_socket_pool.rs
+++ b/ruapc/src/sockets/ws/web_socket_pool.rs
@@ -139,6 +139,7 @@ impl WebSocketPool {
         let (send_stream, recv_stream) = stream.split();
         let (sender, receiver) = mpsc::channel(1024);
         let web_socket = WebSocket::new(sender);
+        state.metrics.connection_opened("WS");
 
         let task_supervisor = self.task_supervisor.start_async_task();
         tokio::spawn({
@@ -188,6 +189,11 @@ impl WebSocketPool {
         state: &Arc<State>,
         err: &Error,
     ) {
+        // The send and recv loops both report failures; run teardown once.
+        if !socket.mark_closed() {
+            return;
+        }
+        state.metrics.connection_closed("WS");
         {
             let mut socket_map = socket_map.write().await;
             // Identity check: don't evict a replacement connection.
@@ -201,7 +207,7 @@ impl WebSocketPool {
             ErrorKind::ConnectionClosed,
             format!("connection to {addr} closed: {err}"),
         );
-        state.waiter.fail_connection(socket.conn_id(), &err);
+        state.connection_closed(socket.conn_id(), &err);
     }
 
     async fn start_recv_loop<S>(

--- a/ruapc/src/task/waiter.rs
+++ b/ruapc/src/task/waiter.rs
@@ -164,6 +164,11 @@ impl Waiter {
         self.id_map.contains_key(&msgid)
     }
 
+    /// Number of requests currently waiting for a response.
+    pub fn pending_count(&self) -> usize {
+        self.id_map.len()
+    }
+
     /// Stores a write buffer for a pending request.
     ///
     /// Called by `MemoryService` handlers when the server performs a
@@ -202,6 +207,7 @@ impl Waiter {
     pub fn spawn_sweeper(self: &std::sync::Arc<Self>) {
         let weak = std::sync::Arc::downgrade(self);
         tokio::spawn(async move {
+            let pending = metrics::gauge!("ruapc_waiter_pending");
             let mut interval = tokio::time::interval(Self::SWEEP_INTERVAL);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
@@ -210,6 +216,8 @@ impl Waiter {
                     break;
                 };
                 waiter.expire(Instant::now());
+                #[allow(clippy::cast_precision_loss)]
+                pending.set(waiter.pending_count() as f64);
             }
         });
     }

--- a/ruapc/tests/test_production.rs
+++ b/ruapc/tests/test_production.rs
@@ -1,0 +1,327 @@
+//! Production-readiness tests: metrics emission, deadline propagation,
+//! run-to-completion semantics, load shedding, and multi-address failover.
+
+#![forbid(unsafe_code)]
+#![feature(return_type_notation)]
+
+use std::{
+    net::SocketAddr,
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use ruapc::{ErrorKind, SocketPoolConfig, SocketType};
+
+/// Installs a process-wide debugging recorder (once) and returns its
+/// snapshotter. Must be called before the traffic whose metrics are
+/// asserted: facade handles bind to the recorder installed at first use.
+///
+/// `Snapshotter::snapshot()` *drains* recorded values, so only one test in
+/// this binary may take snapshots (`test_metrics_emission`) — concurrent
+/// snapshots would steal each other's deltas.
+fn global_snapshotter() -> &'static Snapshotter {
+    static SNAPSHOTTER: std::sync::OnceLock<Snapshotter> = std::sync::OnceLock::new();
+    SNAPSHOTTER.get_or_init(|| {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        recorder.install().expect("install debugging recorder");
+        snapshotter
+    })
+}
+
+type SnapshotVec = Vec<(
+    metrics_util::CompositeKey,
+    Option<metrics::Unit>,
+    Option<metrics::SharedString>,
+    DebugValue,
+)>;
+
+/// Sums all values in `snapshot` for `name` whose labels contain `label`.
+/// Histograms count samples. Returns `None` when the metric never appeared.
+fn metric_sum(snapshot: &SnapshotVec, name: &str, label: Option<(&str, &str)>) -> Option<u64> {
+    let mut found = false;
+    let mut sum = 0u64;
+    for (key, _, _, value) in snapshot {
+        let key = key.key();
+        if key.name() != name {
+            continue;
+        }
+        if let Some((k, v)) = label
+            && !key.labels().any(|l| l.key() == k && l.value() == v)
+        {
+            continue;
+        }
+        found = true;
+        sum += match value {
+            DebugValue::Counter(c) => *c,
+            DebugValue::Gauge(g) => g.0 as u64,
+            DebugValue::Histogram(h) => h.len() as u64,
+        };
+    }
+    found.then_some(sum)
+}
+
+#[ruapc::service]
+trait Prod {
+    async fn echo(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+    /// Like `echo`, but only used by the metrics test so its counters are
+    /// isolated from other tests sharing the process-wide recorder.
+    async fn metered(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+    /// Returns the remaining request budget in milliseconds
+    /// (`u64::MAX` when the request carries none).
+    async fn budget(&self, _: &ruapc::Context, req: &()) -> ruapc::Result<u64>;
+    async fn sleepy(&self, _: &ruapc::Context, req: &u64) -> ruapc::Result<()>;
+}
+
+#[derive(Default)]
+struct ProdImpl {
+    sleepy_started: AtomicU64,
+    sleepy_finished: AtomicU64,
+}
+
+impl Prod for ProdImpl {
+    async fn echo(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String> {
+        Ok(req.clone())
+    }
+
+    async fn metered(&self, _: &ruapc::Context, req: &String) -> ruapc::Result<String> {
+        Ok(req.clone())
+    }
+
+    async fn budget(&self, ctx: &ruapc::Context, (): &()) -> ruapc::Result<u64> {
+        Ok(ctx
+            .remaining_time()
+            .map_or(u64::MAX, |d| u64::try_from(d.as_millis()).unwrap()))
+    }
+
+    async fn sleepy(&self, _: &ruapc::Context, req: &u64) -> ruapc::Result<()> {
+        self.sleepy_started.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(*req)).await;
+        self.sleepy_finished.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn unified_config() -> SocketPoolConfig {
+    SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+        ..Default::default()
+    }
+}
+
+fn make_server(service: Arc<ProdImpl>, config: &SocketPoolConfig) -> ruapc::Server {
+    let mut router = ruapc::Router::default();
+    service.ruapc_export(&mut router);
+    ruapc::Server::create(router, config).unwrap()
+}
+
+async fn start(config: &SocketPoolConfig) -> (Arc<ProdImpl>, ruapc::Server, SocketAddr) {
+    let service = Arc::new(ProdImpl::default());
+    let server = make_server(service.clone(), config);
+    let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
+    let addr = server.listen(addr).await.unwrap();
+    (service, server, addr)
+}
+
+/// RPC traffic must be observable through any user-installed
+/// [`metrics::Recorder`] (here: `metrics-util`'s debugging recorder).
+#[tokio::test]
+async fn test_metrics_emission() {
+    let _ = tracing_subscriber::fmt().try_init();
+    // Install the recorder *before* any traffic.
+    let snapshotter = global_snapshotter();
+
+    let config = unified_config();
+    let (_service, server, addr) = start(&config).await;
+
+    let client = ruapc::Client::default();
+    let ctx = ruapc::Context::create(&config).unwrap().with_addr(addr);
+    for _ in 0..3 {
+        client.metered(&ctx, &"x".to_string()).await.unwrap();
+    }
+
+    // Let the last handler's guard finish its bookkeeping, then take ONE
+    // snapshot (snapshots drain the recorder).
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let snapshot = snapshotter.snapshot().into_vec();
+
+    let label = Some(("method", "Prod/metered"));
+    // Server side: requests counted, none failed, latency samples recorded.
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_server_requests_total", label),
+        Some(3)
+    );
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_server_errors_total", label).unwrap_or(0),
+        0
+    );
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_server_latency_seconds", label),
+        Some(3)
+    );
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_server_inflight", label),
+        Some(0)
+    );
+    // Client side mirrors it.
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_client_requests_total", label),
+        Some(3)
+    );
+    assert_eq!(
+        metric_sum(&snapshot, "ruapc_client_latency_seconds", label),
+        Some(3)
+    );
+    // Connection gauges were emitted for the live transport.
+    assert!(metric_sum(&snapshot, "ruapc_connections", None).is_some());
+
+    server.stop();
+    server.join().await;
+}
+
+/// The client's time budget must reach the server and be visible as a
+/// deadline in the handler context.
+#[tokio::test]
+async fn test_deadline_propagation() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let config = unified_config();
+    let (_service, server, addr) = start(&config).await;
+
+    let client = ruapc::Client {
+        timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+    let ctx = ruapc::Context::create(&config).unwrap().with_addr(addr);
+    let remaining_ms = client.budget(&ctx, &()).await.unwrap();
+    assert!(
+        remaining_ms > 0 && remaining_ms <= 5000,
+        "server should see a deadline derived from the 5s client budget, got {remaining_ms}ms"
+    );
+
+    server.stop();
+    server.join().await;
+}
+
+/// A client timeout must not affect the server-side handler: started
+/// requests always run to completion (no mid-flight cancellation).
+#[tokio::test]
+async fn test_handler_runs_to_completion_after_client_timeout() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let config = unified_config();
+    let (service, server, addr) = start(&config).await;
+
+    let client = ruapc::Client {
+        timeout: Duration::from_millis(300),
+        socket_type: Some(SocketType::TCP),
+        ..Default::default()
+    };
+    let ctx = ruapc::Context::create(&config).unwrap().with_addr(addr);
+
+    // 1s of work against a 300ms budget: the client times out...
+    let err = client.sleepy(&ctx, &1_000).await.unwrap_err();
+    assert_eq!(err.kind, ErrorKind::Timeout);
+    assert_eq!(service.sleepy_started.load(Ordering::SeqCst), 1);
+    assert_eq!(service.sleepy_finished.load(Ordering::SeqCst), 0);
+
+    // ...but the handler still finishes its work.
+    let mut finished = false;
+    for _ in 0..50 {
+        if service.sleepy_finished.load(Ordering::SeqCst) == 1 {
+            finished = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(finished, "handler should have run to completion");
+
+    server.stop();
+    server.join().await;
+}
+
+/// Requests beyond `max_inflight_requests` must be rejected immediately
+/// with `Overloaded` instead of queueing up.
+#[tokio::test]
+async fn test_load_shedding() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+        max_inflight_requests: 2,
+        ..Default::default()
+    };
+    let (_service, server, addr) = start(&config).await;
+
+    let client_config = unified_config();
+    let ctx = ruapc::Context::create(&client_config)
+        .unwrap()
+        .with_addr(addr);
+
+    // Fill the two slots, then hit the cap.
+    let occupants: Vec<_> = (0..2)
+        .map(|_| {
+            let ctx = ctx.clone();
+            tokio::spawn(async move {
+                let client = ruapc::Client {
+                    timeout: Duration::from_secs(10),
+                    ..Default::default()
+                };
+                client.sleepy(&ctx, &2_000).await
+            })
+        })
+        .collect();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = ruapc::Client {
+        timeout: Duration::from_secs(10),
+        ..Default::default()
+    };
+    let started = std::time::Instant::now();
+    let err = client.echo(&ctx, &"nope".to_string()).await.unwrap_err();
+    assert_eq!(err.kind, ErrorKind::Overloaded, "err={err:?}");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "shedding must reject immediately"
+    );
+
+    for occupant in occupants {
+        occupant.await.unwrap().unwrap();
+    }
+    // Capacity freed: requests pass again.
+    client.echo(&ctx, &"ok".to_string()).await.unwrap();
+
+    server.stop();
+    server.join().await;
+}
+
+/// With a multi-address context, connect failures must fail over to the
+/// next address transparently.
+#[tokio::test]
+async fn test_multi_address_failover() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let config = unified_config();
+    let (_service, server, addr) = start(&config).await;
+
+    // A dead address (nothing listens there) plus the live server.
+    let dead = SocketAddr::from_str("127.0.0.1:1").unwrap();
+    let ctx = ruapc::Context::create(&config)
+        .unwrap()
+        .with_addrs(vec![dead, addr]);
+
+    let client = ruapc::Client {
+        socket_type: Some(SocketType::TCP),
+        ..Default::default()
+    };
+    // Round-robin alternates the starting address; every request must
+    // still succeed thanks to connect-phase failover.
+    for i in 0..4 {
+        let rsp = client.echo(&ctx, &format!("try{i}")).await.unwrap();
+        assert_eq!(rsp, format!("try{i}"));
+    }
+
+    server.stop();
+    server.join().await;
+}


### PR DESCRIPTION
- Metrics via the `metrics` facade crate: per-method request/error counters, in-flight gauges and latency histograms on both sides, plus connection gauges and shed/expired/waiter-pending metrics. RuaPC only emits — users install their own Recorder/exporter; without one every emission is a no-op. Per-method handles are interned per State; the only locally-tracked value is the server in-flight count, which load shedding must be able to read back.
- Deadline propagation: the client ships its effective time budget as MsgMeta.timeout_ms (relative, clock-skew free); the server derives Context::deadline()/remaining_time()/is_expired() on arrival, drops requests that expired before execution, and nested RPCs inherit the shrunk budget. No mid-flight cancellation by design: started handlers always run to completion, long-running ones may poll is_expired().
- Load shedding: SocketPoolConfig.max_inflight_requests (0 = off) rejects excess requests immediately with the new Overloaded error.
- Dispatch policies centralized in spawn_handler (expiry drop, shedding, panic containment, metrics); macro codegen now routes through it.
- Client retries: Client.max_retries (default 2) retries only pre-wire failures (acquire/send). Context::with_addrs gives round-robin multi-address with connect-phase failover. The waiter entry is now allocated after the connection is established, so slow connection setup (e.g. RDMA path failover) no longer consumes the response budget.
- RDMA teardown now eagerly fails pending waiters (ConnectionClosed) and maintains the connection gauge from the poll thread.