### PR TITLE
build(release): fix publish chain, make rdma opt-in, add echo bench and macro UI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
 
     - run: |
         sudo apt install -y pkg-config libibverbs-dev ibverbs-utils
-        cargo publish -p ruapc-macro || echo skip publishing ruapc-macro
-        cargo publish -p ruapc-rdma || echo skip publishing ruapc-rdma
+        # Publish in dependency order. Any failure fails the release.
+        cargo publish -p ruapc-bufpool
+        cargo publish -p ruapc-macro
+        cargo publish -p ruapc-rdma
         cargo publish -p ruapc
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
         sudo apt install -y pkg-config libibverbs-dev ibverbs-utils
         ibv_devinfo -d rxe_0 -v
         cargo fmt -- --check
-        cargo clippy --release -- -D warnings
+        cargo clippy --release --all-features -- -D warnings
         cargo llvm-cov --all-features --ignore-filename-regex "ruapc-demo/*|ruapc-macro/*|ruapc/src/bin/*|ruapc-rdma/src/bin/*" --cobertura --output-path cobertura.xml
 
     - name: Upload coverage reports to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,12 @@ RuaPC ("Rua! Procedure Call") is a high-performance Rust RPC library supporting 
 
 ### Workspace Structure
 - `ruapc/` — Core library: server, client, router, socket abstractions, message format
+- `ruapc-bufpool/` — Buddy allocator + slab buffer pool with device registration (transport-independent)
 - `ruapc-macro/` — Proc macro `#[service]` for service definition and code generation
-- `ruapc-rdma/` — RDMA transport (optional, behind `rdma` feature flag)
-- `ruapc-demo/` — Example server/client applications
+- `ruapc-rdma/` — Low-level ibverbs FFI bindings (optional, behind `ruapc`'s `rdma` feature flag)
+- `ruapc-demo/` — Example server/client applications (not published)
+
+The `rdma` feature is NOT in `ruapc`'s default features (it requires libibverbs at build time, which e.g. docs.rs doesn't have). `ruapc`'s own tests and benches always enable it via a self dev-dependency (`ruapc = { path = ".", features = ["rdma"] }`), so `cargo test` in this repo requires libibverbs-dev.
 
 ### Transport Protocols
 - **TCP**: Custom binary protocol with magic number `RUA!`, length-prefixed framing
@@ -63,10 +66,12 @@ cargo build --all-features
 cargo test --all-features
 cargo fmt
 cargo clippy --all-features
+cargo bench -p ruapc --bench echo  # end-to-end echo RPC benchmark
 ```
 
 ### CI
-- GitHub Actions: build, test (cargo-nextest with `-j 1`), clippy, rustfmt, CodeQL, codecov
+- `rust.yml`: rustfmt check, clippy (`--all-features -D warnings`), tests with coverage via cargo-llvm-cov (`--all-features`), Codecov upload
+- `release.yml` (on `v*` tags): publishes to crates.io in dependency order (ruapc-bufpool → ruapc-macro → ruapc-rdma → ruapc)
 - RDMA tests use `rxe_0` virtual device in CI (env var `RUAPC_PREFER_RXE=1`)
 
 ### Conventions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A high-performance Rust RPC library that supports multiple transport protocols (
 | Crate | Description |
 |---|---|
 | `ruapc` | Core library: server, client, router, socket abstractions, message format |
-| `ruapc-bufpool` | Generic buffer pool with device registration (transport-independent) |
+| `ruapc-bufpool` | Buddy allocator + slab buffer pool with device registration (transport-independent) |
 | `ruapc-macro` | Proc macro `#[service]` for service definition and code generation |
 | `ruapc-rdma` | Low-level FFI bindings to libibverbs with type-safe RDMA device management |
 | `ruapc-demo` | Example server/client applications |
@@ -27,6 +27,17 @@ A high-performance Rust RPC library that supports multiple transport protocols (
 - **Multiple Serialization Formats**: JSON (default) and MessagePack support
 - **OpenAPI Integration**: Automatic OpenAPI 3.0 specification generation with JSON Schema support
 - **Built-in Documentation**: RapiDoc integration for interactive API documentation
+
+## Cargo Features
+
+RDMA support is **not** enabled by default (it requires `libibverbs-dev` at build time). Enable it explicitly:
+
+```toml
+[dependencies]
+ruapc = { version = "0.1", features = ["rdma"] }
+```
+
+Note: this crate requires a nightly toolchain (`#![feature(return_type_notation)]`).
 
 ## Example
 
@@ -161,6 +172,19 @@ cargo run --release --bin server --features rdma -- --socket-type unified
 # Stress testing with RDMA
 cargo run --release --bin client --features rdma -- --stress --coroutines 128
 ```
+
+### Benchmark
+
+```bash
+# End-to-end echo RPC benchmark: serial latency + concurrent throughput
+# for every transport (TCP / WebSocket / HTTP / RDMA) on a unified server.
+cargo bench -p ruapc --bench echo
+
+# On NUMA machines, pin to the RDMA NIC's node for stable/better numbers:
+numactl -N 1 -m 1 cargo bench -p ruapc --bench echo
+```
+
+See [docs/benchmark.md](docs/benchmark.md) for details and reference results.
 
 ## License
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,65 @@
+# Echo RPC Benchmark
+
+End-to-end echo RPC benchmark: a single UNIFIED server serves all
+protocols on one port, and each transport (TCP / WebSocket / HTTP / RDMA)
+is measured with the same client-side workload:
+
+- **serial**: round-trip latency with one in-flight request (16 B and 4 KiB payloads)
+- **concurrent**: closed-loop throughput at 64 and 1024 tasks (16 B payload,
+  256k total requests per run, split evenly across tasks)
+
+Source: [`ruapc/benches/echo.rs`](../ruapc/benches/echo.rs).
+
+## How to Run
+
+```bash
+cargo bench -p ruapc --bench echo
+```
+
+On NUMA machines, pin the benchmark (CPU and memory) to the node the RDMA
+NIC is attached to — cross-node traffic between the NIC, DMA buffers, and
+the tokio workers otherwise costs a significant fraction of throughput and
+adds run-to-run variance:
+
+```bash
+# Find the NIC's NUMA node:
+cat /sys/class/infiniband/<device>/device/numa_node
+
+# Pin CPUs and memory to that node (node 1 here):
+numactl -N 1 -m 1 cargo bench -p ruapc --bench echo
+```
+
+Notes:
+
+- RDMA requires `libibverbs-dev` and a usable RDMA device; the benchmark
+  reports RDMA as skipped otherwise. Make sure the memory-lock limit is
+  unlimited: `sudo prlimit --pid $$ -l=unlimited`.
+- The benchmark enlarges the shared buffer pool to 1 GiB
+  (`SocketPoolConfig.buffer_pool_memory`); the 256 MiB default is exhausted
+  by per-request send buffers at 1024 closed-loop tasks, and allocation
+  waits would show up as artificial latency/timeouts.
+
+## Results
+
+Environment:
+
+- Intel Xeon 6966P-C, 2 NUMA nodes, 384 logical CPUs; Linux 6.8.0
+- RDMA: Mellanox mlx5 (loopback through the local NIC); benchmark pinned to
+  the NIC's NUMA node with `numactl -N 1 -m 1`
+- rustc 1.99.0-nightly (2026-07-13), `bench` profile
+- Client and server share one process and one tokio runtime; numbers
+  include both sides' work
+
+| Transport | Serial 16B | Serial 4KiB | 64 tasks | 1024 tasks |
+|---|---:|---:|---:|---:|
+| TCP  | 31.8 us/op | 34.9 us/op | 264 kops/s (243 us/op) | 281 kops/s (3.6 ms/op) |
+| WS   | 44.4 us/op | 48.0 us/op | 149 kops/s (429 us/op) | 153 kops/s (6.7 ms/op) |
+| HTTP | 36.9 us/op | 42.7 us/op | 113 kops/s (567 us/op) | 111 kops/s (9.2 ms/op) |
+| RDMA | 33.1 us/op | 38.3 us/op | 401 kops/s (160 us/op) | 417 kops/s (2.5 ms/op) |
+
+`us/op` in the concurrent rows is the average per-request latency observed
+by each closed-loop task (queueing included).
+
+Without NUMA pinning, RDMA drops to ~270 kops/s @64 / ~226 kops/s @1024 on
+the same machine with high run-to-run variance; the other transports are
+mostly unaffected.

--- a/ruapc-macro/Cargo.toml
+++ b/ruapc-macro/Cargo.toml
@@ -16,3 +16,9 @@ proc-macro-crate = "3.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+# Used by trybuild UI tests to compile expanded code end-to-end.
+ruapc = { path = "../ruapc" }
+tokio.workspace = true
+trybuild = "1.0"

--- a/ruapc-macro/tests/trybuild.rs
+++ b/ruapc-macro/tests/trybuild.rs
@@ -1,0 +1,13 @@
+//! UI tests for the `#[service]` macro: valid definitions must compile
+//! end-to-end (including the generated `Client` impls), invalid ones must
+//! fail with the macro's diagnostics pinned in `.stderr` files.
+//!
+//! Regenerate the expected output after intentional changes with
+//! `TRYBUILD=overwrite cargo test -p ruapc-macro`.
+
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/*.rs");
+    t.compile_fail("tests/ui/fail/*.rs");
+}

--- a/ruapc-macro/tests/ui/fail/not_async.rs
+++ b/ruapc-macro/tests/ui/fail/not_async.rs
@@ -1,0 +1,8 @@
+//! Service methods must be `async`.
+
+#[ruapc::service]
+pub trait Foo {
+    fn hello(&self, ctx: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+}
+
+fn main() {}

--- a/ruapc-macro/tests/ui/fail/not_async.stderr
+++ b/ruapc-macro/tests/ui/fail/not_async.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> tests/ui/fail/not_async.rs:3:1
+  |
+3 | #[ruapc::service]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: the function should be in the form `async fn func(&self, ctx: &Context, req: &Req) -> Result<Rsp>`.

--- a/ruapc-macro/tests/ui/fail/on_struct.rs
+++ b/ruapc-macro/tests/ui/fail/on_struct.rs
@@ -1,0 +1,6 @@
+//! The `#[service]` attribute only applies to traits.
+
+#[ruapc::service]
+pub struct Foo;
+
+fn main() {}

--- a/ruapc-macro/tests/ui/fail/on_struct.stderr
+++ b/ruapc-macro/tests/ui/fail/on_struct.stderr
@@ -1,0 +1,5 @@
+error: expected `trait`
+ --> tests/ui/fail/on_struct.rs:4:5
+  |
+4 | pub struct Foo;
+  |     ^^^^^^

--- a/ruapc-macro/tests/ui/fail/reserved_name.rs
+++ b/ruapc-macro/tests/ui/fail/reserved_name.rs
@@ -1,0 +1,8 @@
+//! `ruapc_export` and `ruapc_request` are reserved method names.
+
+#[ruapc::service]
+pub trait Foo {
+    async fn ruapc_export(&self, ctx: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+}
+
+fn main() {}

--- a/ruapc-macro/tests/ui/fail/reserved_name.stderr
+++ b/ruapc-macro/tests/ui/fail/reserved_name.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> tests/ui/fail/reserved_name.rs:3:1
+  |
+3 | #[ruapc::service]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: the function cannot be named `ruapc_export` or `ruapc_request`!

--- a/ruapc-macro/tests/ui/fail/wrong_arity.rs
+++ b/ruapc-macro/tests/ui/fail/wrong_arity.rs
@@ -1,0 +1,8 @@
+//! Service methods must take exactly `&self, &Context, &Req`.
+
+#[ruapc::service]
+pub trait Foo {
+    async fn hello(&self, ctx: &ruapc::Context) -> ruapc::Result<String>;
+}
+
+fn main() {}

--- a/ruapc-macro/tests/ui/fail/wrong_arity.stderr
+++ b/ruapc-macro/tests/ui/fail/wrong_arity.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> tests/ui/fail/wrong_arity.rs:3:1
+  |
+3 | #[ruapc::service]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = help: message: the function should be in the form `async fn func(&self, ctx: &Context, req: &Req) -> Result<Rsp>`.

--- a/ruapc-macro/tests/ui/pass/basic_service.rs
+++ b/ruapc-macro/tests/ui/pass/basic_service.rs
@@ -1,0 +1,36 @@
+//! A well-formed service compiles: the trait keeps its methods, the router
+//! registration and the generated `Client` / `ClientWithBuffer` impls all
+//! type-check.
+#![feature(return_type_notation)]
+
+use std::sync::Arc;
+
+#[ruapc::service]
+pub trait Greeter {
+    async fn greet(&self, ctx: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+    async fn ping(&self, ctx: &ruapc::Context, req: &()) -> ruapc::Result<()>;
+}
+
+struct GreeterImpl;
+
+impl Greeter for GreeterImpl {
+    async fn greet(&self, _ctx: &ruapc::Context, req: &String) -> ruapc::Result<String> {
+        Ok(format!("hello {req}!"))
+    }
+
+    async fn ping(&self, _ctx: &ruapc::Context, _req: &()) -> ruapc::Result<()> {
+        Ok(())
+    }
+}
+
+fn assert_impls_greeter<T: Greeter>() {}
+
+fn main() {
+    assert_eq!(<GreeterImpl as Greeter>::NAME, "Greeter");
+
+    let mut router = ruapc::Router::default();
+    Arc::new(GreeterImpl).ruapc_export(&mut router);
+
+    // The macro implements the trait for the RPC clients as well.
+    assert_impls_greeter::<ruapc::Client>();
+}

--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -14,7 +14,7 @@ bin = ["dep:clap"]
 [dependencies]
 clap = { workspace = true, optional = true }
 libc.workspace = true
-ruapc-bufpool = { path = "../ruapc-bufpool" }
+ruapc-bufpool = { version = "0.1.0", path = "../ruapc-bufpool" }
 schemars.workspace = true
 serde.workspace = true
 

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [features]
 rdma = ["ruapc-rdma"]
-default = ["rdma"]
+default = []
 
 [dependencies]
 ruapc-macro ={ version = "0.1.3", path = "../ruapc-macro" }
@@ -49,5 +49,13 @@ libc.workspace = true
 workspace = true
 
 [dev-dependencies]
+# Self dev-dependency: enables the `rdma` feature for this crate's own unit,
+# integration tests, and benches without forcing it on downstream users.
+ruapc = { path = ".", features = ["rdma"] }
+
 metrics-util = "0.20"
 reqwest = { version = "0.12", features = ["json"] }
+
+[[bench]]
+name = "echo"
+harness = false

--- a/ruapc/benches/echo.rs
+++ b/ruapc/benches/echo.rs
@@ -1,0 +1,172 @@
+//! End-to-end echo RPC benchmark across transports.
+//!
+//! Run with: `cargo bench -p ruapc --bench echo`
+//!
+//! A single UNIFIED server serves all protocols on one port; each transport
+//! is measured with the same client-side workload:
+//! - serial round-trip latency (one in-flight request)
+//! - concurrent throughput (many tasks issuing requests in a closed loop)
+//!
+//! Transports whose setup fails in the current environment (e.g. RDMA
+//! without a usable device) are reported as skipped instead of aborting
+//! the whole run.
+
+#![feature(return_type_notation)]
+// `#[service]` request types must be owned deserializable types behind a
+// reference (`&String`), so `&str` is not an option here.
+#![allow(clippy::ptr_arg)]
+
+use std::{str::FromStr, sync::Arc, time::Instant};
+
+use ruapc::{Client, Context, Router, Server, SocketPoolConfig, SocketType};
+
+const WARMUP_ITERS: usize = 1_000;
+const SERIAL_ITERS: usize = 5_000;
+/// Concurrency levels for the closed-loop throughput benchmark.
+const CONCURRENT_TASKS: [usize; 2] = [64, 1024];
+/// Total number of requests per concurrent run, split evenly across tasks
+/// so every concurrency level issues the same amount of work.
+const CONCURRENT_TOTAL_OPS: usize = 256_000;
+
+fn bench_client(socket_type: SocketType) -> Client {
+    Client {
+        socket_type: Some(socket_type),
+        ..Default::default()
+    }
+}
+
+#[ruapc::service]
+trait EchoService {
+    async fn echo(&self, ctx: &ruapc::Context, req: &String) -> ruapc::Result<String>;
+}
+
+struct EchoImpl;
+
+impl EchoService for EchoImpl {
+    async fn echo(&self, _ctx: &ruapc::Context, req: &String) -> ruapc::Result<String> {
+        Ok(req.clone())
+    }
+}
+
+/// Serial round-trip latency: one request in flight at a time.
+async fn bench_serial(ctx: &Context, socket_type: SocketType, payload_size: usize) {
+    let client = bench_client(socket_type);
+    let req = "x".repeat(payload_size);
+
+    for _ in 0..WARMUP_ITERS {
+        client.echo(ctx, &req).await.unwrap();
+    }
+
+    let start = Instant::now();
+    for _ in 0..SERIAL_ITERS {
+        std::hint::black_box(client.echo(ctx, &req).await.unwrap());
+    }
+    let secs = start.elapsed().as_secs_f64();
+
+    #[allow(clippy::cast_precision_loss)]
+    let us_per_op = secs * 1e6 / SERIAL_ITERS as f64;
+    println!("  serial     {payload_size:>5}B: {us_per_op:>8.2} us/op");
+}
+
+/// Concurrent closed-loop throughput at the given concurrency level.
+async fn bench_concurrent(
+    ctx: &Context,
+    socket_type: SocketType,
+    payload_size: usize,
+    num_tasks: usize,
+) {
+    let req = Arc::new("x".repeat(payload_size));
+    let iters_per_task = CONCURRENT_TOTAL_OPS / num_tasks;
+
+    let start = Instant::now();
+    let mut tasks = Vec::with_capacity(num_tasks);
+    for _ in 0..num_tasks {
+        let ctx = ctx.clone();
+        let req = req.clone();
+        tasks.push(tokio::spawn(async move {
+            let client = bench_client(socket_type);
+            for _ in 0..iters_per_task {
+                std::hint::black_box(client.echo(&ctx, &req).await.unwrap());
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+    let secs = start.elapsed().as_secs_f64();
+
+    let total_ops = num_tasks * iters_per_task;
+    #[allow(clippy::cast_precision_loss)]
+    let kops = total_ops as f64 / secs / 1e3;
+    #[allow(clippy::cast_precision_loss)]
+    let us_per_op = secs * 1e6 / iters_per_task as f64;
+    println!(
+        "  concurrent {payload_size:>5}B: {kops:>8.1} kops/s | {us_per_op:>8.2} us/op \
+         ({num_tasks} tasks)"
+    );
+}
+
+async fn run() {
+    let echo = Arc::new(EchoImpl);
+    let mut router = Router::default();
+    echo.ruapc_export(&mut router);
+
+    let config = SocketPoolConfig {
+        socket_type: SocketType::UNIFIED,
+        // The default pool (256 MiB) is sized for regular workloads; at
+        // 1024 closed-loop tasks the per-request send buffers exhaust it
+        // and allocation waits show up as artificial latency/timeouts.
+        buffer_pool_memory: 1 << 30,
+        ..Default::default()
+    };
+    let server = Server::create(router, &config).unwrap();
+    let addr = std::net::SocketAddr::from_str("127.0.0.1:0").unwrap();
+    let addr = server.listen(addr).await.unwrap();
+
+    let ctx = Context::create(&config).unwrap().with_addr(addr);
+
+    let socket_types = [
+        SocketType::TCP,
+        SocketType::WS,
+        SocketType::HTTP,
+        #[cfg(feature = "rdma")]
+        SocketType::RDMA,
+    ];
+    for socket_type in socket_types {
+        println!("{socket_type:?}");
+
+        // Probe the transport once: environments without e.g. a usable RDMA
+        // device should skip instead of failing the whole benchmark.
+        let probe_client = Client {
+            socket_type: Some(socket_type),
+            ..Default::default()
+        };
+        if let Err(err) = probe_client.echo(&ctx, &"probe".to_string()).await {
+            println!("  skipped: {err}");
+            println!();
+            continue;
+        }
+
+        for payload_size in [16, 4096] {
+            bench_serial(&ctx, socket_type, payload_size).await;
+        }
+        for num_tasks in CONCURRENT_TASKS {
+            bench_concurrent(&ctx, socket_type, 16, num_tasks).await;
+        }
+        println!();
+    }
+
+    server.stop();
+    server.join().await;
+}
+
+fn main() {
+    println!("ruapc: end-to-end echo RPC benchmark (unified server, one port)");
+    println!();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(run());
+}

--- a/ruapc/src/task/mod.rs
+++ b/ruapc/src/task/mod.rs
@@ -1,5 +1,9 @@
 mod supervisor;
-pub use supervisor::{TaskSupervisor, TaskSupervisorGuard};
+pub use supervisor::TaskSupervisor;
+// Only the RDMA transport holds guards outside this module; without it the
+// re-export would trip `unused_imports` (`mod task` is crate-private).
+#[cfg(feature = "rdma")]
+pub use supervisor::TaskSupervisorGuard;
 
 pub(crate) mod waiter;
 pub(crate) use waiter::next_conn_id;


### PR DESCRIPTION
- ruapc-rdma: add version to the ruapc-bufpool dependency (path-only deps are stripped by cargo publish, breaking the release)
- release.yml: publish ruapc-bufpool first and fail loudly on any publish error instead of '|| echo skip'
- ruapc: remove rdma from default features (it needs libibverbs at build time, e.g. docs.rs doesn't have it); the crate's own tests and benches keep it enabled via a self dev-dependency; CI clippy now runs with --all-features; cfg-gate the TaskSupervisorGuard re-export that is only used by the rdma module
- add end-to-end echo benchmark (serial latency + closed-loop throughput at 64 and 1024 tasks per transport on a unified server, 1 GiB buffer pool to avoid allocation-wait artifacts): cargo bench -p ruapc --bench echo; document usage (incl. NUMA pinning) and reference results in docs/benchmark.md
- ruapc-macro: add trybuild UI tests (pass + compile-fail with pinned stderr snapshots)
- sync AGENTS.md/README with the actual workspace, CI, and feature state