### PR TITLE
chore(release): align workspace versions to 0.2.0-alpha.1 and write changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0-alpha.1] - 2026-07-23
+
+### Added
+- Remote Read/Write: server-side access to client memory with typed contracts.
+  `remote_read` / `remote_read_request` let the server read a client-provided
+  buffer; `ctx.remote_write(buf)` returns a `SentBuffer` witness and
+  `sent.reply(rsp)` builds a `Result<WithBuffer<T>>` return value recognized by
+  the type system through any alias. Transfers use data-copy over TCP or
+  zero-copy RDMA READ, with request-liveness (message ID) validation for
+  buffer lifetime safety (#42–#48, #61–#63, #76)
+- New `ruapc-bufpool` crate: buddy memory allocator with slab layer, lazy
+  merging, async waiters, subtree reservation, and transport-independent
+  device registration (#44, #51, #64, #65, #72)
+- RDMA multi-NIC path awareness: least-connections local NIC placement,
+  power-of-two-choices remote NIC selection, per-peer blacklist with
+  connect-phase failover, and a maintenance task that prunes dead stripes,
+  replenishes peers, and rate-limits rebalancing migrations. Explicit control
+  via `Context::with_rdma_path`, `rdma.device_filter` config, and
+  `State::rdma_path_report()` introspection (#77)
+- Production-readiness: per-method client/server metrics via the `metrics`
+  facade, deadline propagation (`Client.timeout` → `Context::deadline()`),
+  server load shedding (`max_inflight_requests`), handler panic containment,
+  client retries with round-robin multi-address failover (#78, #79)
+- RDMA Queue Pair config negotiation and device query handshake with
+  periodic port refresh (#67, #68, #70)
+- `ibv_devinfo` Rust binary in `ruapc-rdma` (behind the `bin` feature) (#66)
+- End-to-end echo benchmark (`cargo bench -p ruapc --bench echo`) with usage
+  and reference results in `docs/benchmark.md` (#80)
+- trybuild UI tests for the `#[service]` macro (#80)
+
+### Changed
+- **BREAKING**: the `rdma` feature is no longer enabled by default; opt in
+  with `features = ["rdma"]` (#80)
+- **BREAKING**: `ruapc-rdma` rewritten as low-level ibverbs FFI bindings with
+  type-safe device management; higher-level RDMA logic now lives in `ruapc`
+  (#55, #58–#60)
+- RDMA data path reworked for performance: dedicated poll-thread, fixed
+  dispatch worker pool, gather-list sends, self-delimiting framed wire format,
+  and flow-control hardening (#73, #75)
+- Buffer pool replaced with the buddy allocator from `ruapc-bufpool` (#64)
+- All workspace crates now share a single version (`workspace.package`);
+  `ruapc` pins `ruapc-macro` with an exact `=` requirement
+
+### Fixed
+- TCP/WS/HTTP connection lifecycle hardening: dead sockets evicted exactly
+  once, pending waiters failed eagerly on connection close (#78)
+- RDMA memory registration `rkey()` bug (#46)
+- crates.io publish chain: `ruapc-bufpool` is published first and internal
+  dependencies carry version requirements (#80)
+
 ## [0.1.3] - 2026-04-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["ruapc", "ruapc-bufpool", "ruapc-demo", "ruapc-macro", "ruapc-rdma"]
 resolver = "2"
 
 [workspace.package]
+version = "0.2.0-alpha.1"
 authors = ["SF-Zhou <sfzhou.scut@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/SF-Zhou/ruapc"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RDMA support is **not** enabled by default (it requires `libibverbs-dev` at buil
 
 ```toml
 [dependencies]
-ruapc = { version = "0.1", features = ["rdma"] }
+ruapc = { version = "0.2.0-alpha.1", features = ["rdma"] }
 ```
 
 Note: this crate requires a nightly toolchain (`#![feature(return_type_notation)]`).

--- a/ruapc-bufpool/Cargo.toml
+++ b/ruapc-bufpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-bufpool"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/ruapc-demo/Cargo.toml
+++ b/ruapc-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-demo"
-version = "0.1.0"
+version.workspace = true
 publish = false
 authors.workspace = true
 edition.workspace = true

--- a/ruapc-macro/Cargo.toml
+++ b/ruapc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-macro"
-version = "0.1.3"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc-rdma"
-version = "0.1.4"
+version.workspace = true
 description = "Low-level FFI bindings to libibverbs with type-safe device management for RDMA operations"
 authors.workspace = true
 edition.workspace = true
@@ -14,7 +14,7 @@ bin = ["dep:clap"]
 [dependencies]
 clap = { workspace = true, optional = true }
 libc.workspace = true
-ruapc-bufpool = { version = "0.1.0", path = "../ruapc-bufpool" }
+ruapc-bufpool = { version = "0.2.0-alpha.1", path = "../ruapc-bufpool" }
 schemars.workspace = true
 serde.workspace = true
 

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruapc"
-version = "0.1.3"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -13,9 +13,11 @@ rdma = ["ruapc-rdma"]
 default = []
 
 [dependencies]
-ruapc-macro ={ version = "0.1.3", path = "../ruapc-macro" }
-ruapc-bufpool = { version = "0.1.0", path = "../ruapc-bufpool" }
-ruapc-rdma = { version = "0.1.4", path = "../ruapc-rdma", optional = true }
+# The macro generates code against ruapc's internal glue API, so the two
+# crates must be paired exactly (same reason serde pins serde_derive).
+ruapc-macro = { version = "=0.2.0-alpha.1", path = "../ruapc-macro" }
+ruapc-bufpool = { version = "0.2.0-alpha.1", path = "../ruapc-bufpool" }
+ruapc-rdma = { version = "0.2.0-alpha.1", path = "../ruapc-rdma", optional = true }
 
 arc-swap.workspace = true
 bitflags.workspace = true


### PR DESCRIPTION
- single version via [workspace.package]; all crates inherit it
- ruapc pins ruapc-macro with an exact '=' requirement (macro-generated code targets ruapc's internal glue API, so the pair must match)
- internal dependency requirements bumped to 0.2.0-alpha.1
- CHANGELOG: record everything since 0.1.3 (#38-#80): remote read/write, ruapc-bufpool buddy allocator, RDMA multi-NIC path awareness and data path rework, production-readiness (metrics/deadlines/load shedding/ retries), rdma feature now opt-in
- README: feature snippet uses the explicit prerelease version