### PR TITLE
fix(rdma): route all verbs calls through a C shim honoring header macro/inline layers

### DIFF
--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -28,6 +28,7 @@ serde_json.workspace = true
 
 [build-dependencies]
 bindgen = "0.72"
+cc = "1"
 pkg-config = "0.3"
 syn = { version = "2.0", features = ["full", "parsing"] }
 prettyplease = "0.2"

--- a/ruapc-rdma/build.rs
+++ b/ruapc-rdma/build.rs
@@ -2,9 +2,12 @@
 //!
 //! This script:
 //! 1. Probes for libibverbs using pkg-config
-//! 2. Generates FFI bindings using bindgen
-//! 3. Applies custom type replacements (FwVer, Guid, WRID)
-//! 4. Derives serialization traits for select types
+//! 2. Compiles the C shim (src/shim.c) wrapping all verbs entry points, so
+//!    static inline functions and function-like macros in verbs.h (which
+//!    bindgen cannot handle) are always honored
+//! 3. Generates FFI bindings using bindgen
+//! 4. Applies custom type replacements (FwVer, Guid, WRID)
+//! 5. Derives serialization traits for select types
 
 use std::collections::HashSet;
 use std::env;
@@ -134,10 +137,23 @@ fn main() {
     let mut include_paths = lib.include_paths.into_iter().collect::<HashSet<_>>();
     include_paths.insert(PathBuf::from("/usr/include"));
 
+    // Compile the C shim wrapping all verbs entry points (see src/shim.h for
+    // details). Compiling it against the locally installed header guarantees
+    // the wrappers match the exact semantics of this platform's rdma-core
+    // version, including any macro / static inline compat layers.
+    println!("cargo:rerun-if-changed=src/shim.c");
+    println!("cargo:rerun-if-changed=src/shim.h");
+    let mut shim = cc::Build::new();
+    shim.file("src/shim.c");
+    for path in &include_paths {
+        shim.include(path);
+    }
+    shim.compile("ruapc_rdma_shim");
+
     // Configure bindgen to generate RDMA verb bindings
     let builder = bindgen::Builder::default()
         .clang_args(include_paths.iter().map(|p| format!("-I{p:?}")))
-        .header_contents("header.h", "#include <infiniband/verbs.h>")
+        .header("src/shim.h") // includes <infiniband/verbs.h>
         // Enable common derives for generated types
         .derive_copy(true)
         .derive_debug(true)
@@ -176,31 +192,10 @@ fn main() {
         .allowlist_type("ibv_device_cap_flags")
         .allowlist_type("ibv_port_cap_flags")
         .allowlist_type("ibv_port_cap_flags2")
-        .allowlist_function("ibv_ack_cq_events")
-        .allowlist_function("ibv_alloc_pd")
-        .allowlist_function("ibv_close_device")
-        .allowlist_function("ibv_create_comp_channel")
-        .allowlist_function("ibv_create_cq")
-        .allowlist_function("ibv_create_qp")
-        .allowlist_function("ibv_dealloc_pd")
-        .allowlist_function("ibv_dereg_mr")
-        .allowlist_function("ibv_destroy_comp_channel")
-        .allowlist_function("ibv_destroy_cq")
-        .allowlist_function("ibv_destroy_qp")
-        .allowlist_function("ibv_free_device_list")
-        .allowlist_function("ibv_get_cq_event")
-        .allowlist_function("ibv_get_device_guid")
-        .allowlist_function("ibv_get_device_list")
-        .allowlist_function("ibv_modify_qp")
-        .allowlist_function("ibv_req_notify_cq")
-        .allowlist_function("ibv_poll_cq")
-        .allowlist_function("ibv_post_recv")
-        .allowlist_function("ibv_post_send")
-        .allowlist_function("ibv_query_device")
-        .allowlist_function("ibv_query_gid")
-        .allowlist_function("ibv_query_port")
-        .allowlist_function("ibv_open_device")
-        .allowlist_function("ibv_reg_mr")
+        // All verbs entry points go through the C shim (src/shim.h); Rust
+        // never binds ibv_* symbols directly. This guarantees macro/inline
+        // layers in verbs.h are honored, on any rdma-core version.
+        .allowlist_function("ruapc_ibv_.*")
         .bitfield_enum("ibv_access_flags")
         .bitfield_enum("ibv_send_flags")
         .bitfield_enum("ibv_wc_flags")

--- a/ruapc-rdma/src/shim.c
+++ b/ruapc-rdma/src/shim.c
@@ -1,0 +1,157 @@
+/* See shim.h for why these wrappers exist. */
+#include "shim.h"
+
+/* Device management */
+
+struct ibv_device **ruapc_ibv_get_device_list(int *num_devices)
+{
+	return ibv_get_device_list(num_devices);
+}
+
+void ruapc_ibv_free_device_list(struct ibv_device **list)
+{
+	ibv_free_device_list(list);
+}
+
+__be64 ruapc_ibv_get_device_guid(struct ibv_device *device)
+{
+	return ibv_get_device_guid(device);
+}
+
+struct ibv_context *ruapc_ibv_open_device(struct ibv_device *device)
+{
+	return ibv_open_device(device);
+}
+
+int ruapc_ibv_close_device(struct ibv_context *context)
+{
+	return ibv_close_device(context);
+}
+
+/* Queries */
+
+int ruapc_ibv_query_device(struct ibv_context *context,
+                           struct ibv_device_attr *device_attr)
+{
+	return ibv_query_device(context, device_attr);
+}
+
+int ruapc_ibv_query_port(struct ibv_context *context, uint8_t port_num,
+                         struct ibv_port_attr *port_attr)
+{
+	return ibv_query_port(context, port_num, port_attr);
+}
+
+int ruapc_ibv_query_gid(struct ibv_context *context, uint8_t port_num,
+                        int index, union ibv_gid *gid)
+{
+	return ibv_query_gid(context, port_num, index, gid);
+}
+
+/* Protection domain */
+
+struct ibv_pd *ruapc_ibv_alloc_pd(struct ibv_context *context)
+{
+	return ibv_alloc_pd(context);
+}
+
+int ruapc_ibv_dealloc_pd(struct ibv_pd *pd)
+{
+	return ibv_dealloc_pd(pd);
+}
+
+/* Memory region */
+
+struct ibv_mr *ruapc_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                int access)
+{
+	/* `access` is not a compile-time constant here, so on modern
+	 * rdma-core the ibv_reg_mr macro conservatively routes through
+	 * ibv_reg_mr_iova2, which accepts optional access flags. */
+	return ibv_reg_mr(pd, addr, length, access);
+}
+
+int ruapc_ibv_dereg_mr(struct ibv_mr *mr)
+{
+	return ibv_dereg_mr(mr);
+}
+
+/* Completion channel */
+
+struct ibv_comp_channel *ruapc_ibv_create_comp_channel(
+	struct ibv_context *context)
+{
+	return ibv_create_comp_channel(context);
+}
+
+int ruapc_ibv_destroy_comp_channel(struct ibv_comp_channel *channel)
+{
+	return ibv_destroy_comp_channel(channel);
+}
+
+int ruapc_ibv_get_cq_event(struct ibv_comp_channel *channel,
+                           struct ibv_cq **cq, void **cq_context)
+{
+	return ibv_get_cq_event(channel, cq, cq_context);
+}
+
+/* Completion queue */
+
+struct ibv_cq *ruapc_ibv_create_cq(struct ibv_context *context, int cqe,
+                                   void *cq_context,
+                                   struct ibv_comp_channel *channel,
+                                   int comp_vector)
+{
+	return ibv_create_cq(context, cqe, cq_context, channel, comp_vector);
+}
+
+int ruapc_ibv_destroy_cq(struct ibv_cq *cq)
+{
+	return ibv_destroy_cq(cq);
+}
+
+int ruapc_ibv_req_notify_cq(struct ibv_cq *cq, int solicited_only)
+{
+	return ibv_req_notify_cq(cq, solicited_only);
+}
+
+void ruapc_ibv_ack_cq_events(struct ibv_cq *cq, unsigned int nevents)
+{
+	ibv_ack_cq_events(cq, nevents);
+}
+
+int ruapc_ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc)
+{
+	return ibv_poll_cq(cq, num_entries, wc);
+}
+
+/* Queue pair */
+
+struct ibv_qp *ruapc_ibv_create_qp(struct ibv_pd *pd,
+                                   struct ibv_qp_init_attr *qp_init_attr)
+{
+	return ibv_create_qp(pd, qp_init_attr);
+}
+
+int ruapc_ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+                        int attr_mask)
+{
+	return ibv_modify_qp(qp, attr, attr_mask);
+}
+
+int ruapc_ibv_destroy_qp(struct ibv_qp *qp)
+{
+	return ibv_destroy_qp(qp);
+}
+
+int ruapc_ibv_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr,
+                        struct ibv_send_wr **bad_wr)
+{
+	return ibv_post_send(qp, wr, bad_wr);
+}
+
+int ruapc_ibv_post_recv(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+                        struct ibv_recv_wr **bad_wr)
+{
+	return ibv_post_recv(qp, wr, bad_wr);
+}

--- a/ruapc-rdma/src/shim.h
+++ b/ruapc-rdma/src/shim.h
@@ -1,0 +1,108 @@
+/* C shim wrapping every libibverbs entry point used by this crate.
+ *
+ * Why wrap everything, not just the problematic ones?
+ *
+ * rdma-core's standard ABI-evolution technique is to keep the old exported
+ * symbol for already-compiled binaries and redirect newly compiled code to
+ * new semantics via a function-like macro or static inline wrapper in
+ * <infiniband/verbs.h> (ibv_query_port and ibv_reg_mr both started life as
+ * plain functions and were later macro-wrapped this way). bindgen binds
+ * exported symbols directly, so it silently keeps the frozen legacy
+ * semantics forever -- no compile error, just subtly wrong behavior (e.g.
+ * the legacy ibv_query_port only fills the compat-sized prefix of
+ * ibv_port_attr, leaving newer fields uninitialized).
+ *
+ * Routing every call through this C translation unit guarantees "freshly
+ * compiled against the installed header" semantics for each entry point,
+ * on any platform and any rdma-core version, present or future. The C
+ * compiler also type-checks each wrapper body against the real header
+ * prototypes. The cost is one direct call per invocation, which is not
+ * measurable even on the hottest path (empty ibv_poll_cq on mlx5:
+ * 9.79 ns/op both with and without the shim).
+ *
+ * Rust code must never bind an ibv_* symbol directly; add a wrapper here
+ * instead.
+ */
+#ifndef RUAPC_RDMA_SHIM_H
+#define RUAPC_RDMA_SHIM_H
+
+#include <infiniband/verbs.h>
+
+/* Device management */
+
+struct ibv_device **ruapc_ibv_get_device_list(int *num_devices);
+
+void ruapc_ibv_free_device_list(struct ibv_device **list);
+
+__be64 ruapc_ibv_get_device_guid(struct ibv_device *device);
+
+struct ibv_context *ruapc_ibv_open_device(struct ibv_device *device);
+
+int ruapc_ibv_close_device(struct ibv_context *context);
+
+/* Queries */
+
+int ruapc_ibv_query_device(struct ibv_context *context,
+                           struct ibv_device_attr *device_attr);
+
+int ruapc_ibv_query_port(struct ibv_context *context, uint8_t port_num,
+                         struct ibv_port_attr *port_attr);
+
+int ruapc_ibv_query_gid(struct ibv_context *context, uint8_t port_num,
+                        int index, union ibv_gid *gid);
+
+/* Protection domain */
+
+struct ibv_pd *ruapc_ibv_alloc_pd(struct ibv_context *context);
+
+int ruapc_ibv_dealloc_pd(struct ibv_pd *pd);
+
+/* Memory region */
+
+struct ibv_mr *ruapc_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                int access);
+
+int ruapc_ibv_dereg_mr(struct ibv_mr *mr);
+
+/* Completion channel */
+
+struct ibv_comp_channel *ruapc_ibv_create_comp_channel(
+	struct ibv_context *context);
+
+int ruapc_ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
+
+int ruapc_ibv_get_cq_event(struct ibv_comp_channel *channel,
+                           struct ibv_cq **cq, void **cq_context);
+
+/* Completion queue */
+
+struct ibv_cq *ruapc_ibv_create_cq(struct ibv_context *context, int cqe,
+                                   void *cq_context,
+                                   struct ibv_comp_channel *channel,
+                                   int comp_vector);
+
+int ruapc_ibv_destroy_cq(struct ibv_cq *cq);
+
+int ruapc_ibv_req_notify_cq(struct ibv_cq *cq, int solicited_only);
+
+void ruapc_ibv_ack_cq_events(struct ibv_cq *cq, unsigned int nevents);
+
+int ruapc_ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc);
+
+/* Queue pair */
+
+struct ibv_qp *ruapc_ibv_create_qp(struct ibv_pd *pd,
+                                   struct ibv_qp_init_attr *qp_init_attr);
+
+int ruapc_ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+                        int attr_mask);
+
+int ruapc_ibv_destroy_qp(struct ibv_qp *qp);
+
+int ruapc_ibv_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr,
+                        struct ibv_send_wr **bad_wr);
+
+int ruapc_ibv_post_recv(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+                        struct ibv_recv_wr **bad_wr);
+
+#endif /* RUAPC_RDMA_SHIM_H */

--- a/ruapc-rdma/src/verbs/comp_channel.rs
+++ b/ruapc-rdma/src/verbs/comp_channel.rs
@@ -18,7 +18,7 @@ pub struct CompChannel {
 impl CompChannel {
     /// Creates a new completion channel on the given context.
     pub fn create(context: &Arc<Context>) -> Result<Arc<Self>> {
-        let ptr = unsafe { crate::ibv_create_comp_channel(context.as_ptr()) };
+        let ptr = unsafe { crate::ruapc_ibv_create_comp_channel(context.as_ptr()) };
         if ptr.is_null() {
             return Err(ErrorKind::IBCreateCompChannelFail.with_errno());
         }
@@ -63,7 +63,7 @@ impl CompChannel {
     pub fn get_event(&self) -> Result<*mut crate::ibv_cq> {
         let mut cq_ptr: *mut crate::ibv_cq = ptr::null_mut();
         let mut cq_context: *mut std::ffi::c_void = ptr::null_mut();
-        let ret = unsafe { crate::ibv_get_cq_event(self.ptr, &mut cq_ptr, &mut cq_context) };
+        let ret = unsafe { crate::ruapc_ibv_get_cq_event(self.ptr, &mut cq_ptr, &mut cq_context) };
         if ret != 0 {
             return Err(ErrorKind::IBGetCompQueueEventFail.with_errno());
         }
@@ -73,7 +73,7 @@ impl CompChannel {
 
 impl Drop for CompChannel {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_destroy_comp_channel(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_destroy_comp_channel(self.ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/completion_queue.rs
+++ b/ruapc-rdma/src/verbs/completion_queue.rs
@@ -33,7 +33,7 @@ impl CompletionQueue {
     ) -> Result<Arc<Self>> {
         let channel_ptr = channel.map(|c| c.as_ptr()).unwrap_or(ptr::null_mut());
         let ptr = unsafe {
-            crate::ibv_create_cq(
+            crate::ruapc_ibv_create_cq(
                 context.as_ptr(),
                 cq_size,
                 ptr::null_mut(), // cq_context
@@ -58,12 +58,7 @@ impl CompletionQueue {
 
     /// Requests notification for the next completion event.
     pub fn req_notify(&self, solicited_only: bool) -> Result<()> {
-        let ret = unsafe {
-            (*(*self.ptr).context).ops.req_notify_cq.unwrap_unchecked()(
-                self.ptr,
-                solicited_only as c_int,
-            )
-        };
+        let ret = unsafe { crate::ruapc_ibv_req_notify_cq(self.ptr, solicited_only as c_int) };
         if ret != 0 {
             return Err(ErrorKind::IBReqNotifyCompQueueFail.with_errno());
         }
@@ -74,13 +69,7 @@ impl CompletionQueue {
     ///
     /// Returns the number of completions written to the `wc` slice.
     pub fn poll(&self, wc: &mut [ibv_wc]) -> Result<usize> {
-        let ret = unsafe {
-            (*(*self.ptr).context).ops.poll_cq.unwrap_unchecked()(
-                self.ptr,
-                wc.len() as c_int,
-                wc.as_mut_ptr(),
-            )
-        };
+        let ret = unsafe { crate::ruapc_ibv_poll_cq(self.ptr, wc.len() as c_int, wc.as_mut_ptr()) };
         if ret < 0 {
             return Err(ErrorKind::IBPollCompQueueFail.with_errno());
         }
@@ -89,13 +78,13 @@ impl CompletionQueue {
 
     /// Acknowledges CQ events received via [`CompChannel::get_event`].
     pub fn ack_events(&self, nevents: u32) {
-        unsafe { crate::ibv_ack_cq_events(self.ptr, nevents) };
+        unsafe { crate::ruapc_ibv_ack_cq_events(self.ptr, nevents) };
     }
 }
 
 impl Drop for CompletionQueue {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_destroy_cq(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_destroy_cq(self.ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/context.rs
+++ b/ruapc-rdma/src/verbs/context.rs
@@ -27,7 +27,7 @@ impl Context {
     /// `device` must be a valid pointer obtained from `ibv_get_device_list`.
     /// The device list may be freed after this call returns successfully.
     pub(crate) fn open(device: *mut crate::ibv_device) -> Result<Arc<Self>> {
-        let ptr = unsafe { crate::ibv_open_device(device) };
+        let ptr = unsafe { crate::ruapc_ibv_open_device(device) };
         if ptr.is_null() {
             return Err(ErrorKind::IBOpenDeviceFail.with_errno());
         }
@@ -42,7 +42,7 @@ impl Context {
     /// Queries device attributes.
     pub fn query_device(&self) -> Result<crate::ibv_device_attr> {
         let mut attr = crate::ibv_device_attr::default();
-        let ret = unsafe { crate::ibv_query_device(self.ptr, &mut attr) };
+        let ret = unsafe { crate::ruapc_ibv_query_device(self.ptr, &mut attr) };
         if ret != 0 {
             return Err(ErrorKind::IBQueryDeviceFail.with_errno());
         }
@@ -52,7 +52,7 @@ impl Context {
     /// Queries port attributes.
     pub fn query_port(&self, port_num: u8) -> Result<crate::ibv_port_attr> {
         let mut attr = std::mem::MaybeUninit::<crate::ibv_port_attr>::uninit();
-        let ret = unsafe { crate::ibv_query_port(self.ptr, port_num, attr.as_mut_ptr() as _) };
+        let ret = unsafe { crate::ruapc_ibv_query_port(self.ptr, port_num, attr.as_mut_ptr()) };
         if ret != 0 {
             return Err(ErrorKind::IBQueryPortFail.with_errno());
         }
@@ -62,8 +62,9 @@ impl Context {
     /// Queries a GID for the specified port and index.
     pub fn query_gid(&self, port_num: u8, gid_index: u8) -> Result<crate::ibv_gid> {
         let mut gid = crate::ibv_gid::default();
-        let ret =
-            unsafe { crate::ibv_query_gid(self.ptr, port_num as _, gid_index as _, &mut gid) };
+        let ret = unsafe {
+            crate::ruapc_ibv_query_gid(self.ptr, port_num as _, gid_index as _, &mut gid)
+        };
         if ret == 0 && !gid.is_null() {
             Ok(gid)
         } else {
@@ -101,7 +102,7 @@ impl Context {
 
 impl Drop for Context {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_close_device(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_close_device(self.ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/device.rs
+++ b/ruapc-rdma/src/verbs/device.rs
@@ -33,7 +33,7 @@ impl Device {
                 .to_string_lossy()
                 .to_string()
         };
-        let guid = Guid::from_be(unsafe { crate::ibv_get_device_guid(ptr) });
+        let guid = Guid::from_be(unsafe { crate::ruapc_ibv_get_device_guid(ptr) });
         let transport_type = unsafe { (*ptr).transport_type };
         let ibdev_path = unsafe {
             Path::new(std::ffi::OsStr::from_bytes(

--- a/ruapc-rdma/src/verbs/device_list.rs
+++ b/ruapc-rdma/src/verbs/device_list.rs
@@ -16,7 +16,7 @@ pub struct DeviceList {
 impl DeviceList {
     pub fn available() -> Result<Self> {
         let mut num_devices: libc::c_int = 0;
-        let ptr = unsafe { crate::ibv_get_device_list(&mut num_devices) };
+        let ptr = unsafe { crate::ruapc_ibv_get_device_list(&mut num_devices) };
         if ptr.is_null() {
             return Err(ErrorKind::IBGetDeviceListFail.with_errno());
         }
@@ -38,7 +38,7 @@ impl DeviceList {
 
 impl Drop for DeviceList {
     fn drop(&mut self) {
-        unsafe { crate::ibv_free_device_list(self.raw_ptr) };
+        unsafe { crate::ruapc_ibv_free_device_list(self.raw_ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/memory_region.rs
+++ b/ruapc-rdma/src/verbs/memory_region.rs
@@ -29,7 +29,7 @@ impl MemoryRegion {
         access: c_int,
     ) -> Result<Self> {
         let ptr = unsafe {
-            crate::ibv_reg_mr(pd.as_ptr(), memory.as_mut_ptr() as _, memory.size(), access)
+            crate::ruapc_ibv_reg_mr(pd.as_ptr(), memory.as_mut_ptr() as _, memory.size(), access)
         };
         if ptr.is_null() {
             return Err(ErrorKind::IBRegMemoryRegionFail.with_errno());
@@ -69,7 +69,7 @@ impl MemoryRegion {
 
 impl Drop for MemoryRegion {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_dereg_mr(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_dereg_mr(self.ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/protection_domain.rs
+++ b/ruapc-rdma/src/verbs/protection_domain.rs
@@ -19,7 +19,7 @@ pub struct ProtectionDomain {
 impl ProtectionDomain {
     /// Allocates a new protection domain on the given context.
     pub fn alloc(context: &Arc<Context>) -> Result<Arc<Self>> {
-        let ptr = unsafe { crate::ibv_alloc_pd(context.as_ptr()) };
+        let ptr = unsafe { crate::ruapc_ibv_alloc_pd(context.as_ptr()) };
         if ptr.is_null() {
             return Err(ErrorKind::IBAllocPDFail.with_errno());
         }
@@ -37,7 +37,7 @@ impl ProtectionDomain {
 
 impl Drop for ProtectionDomain {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_dealloc_pd(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_dealloc_pd(self.ptr) };
     }
 }
 

--- a/ruapc-rdma/src/verbs/queue_pair.rs
+++ b/ruapc-rdma/src/verbs/queue_pair.rs
@@ -98,7 +98,7 @@ impl QueuePair {
     ) -> Result<Self> {
         init_attr.send_cq = send_cq.as_ptr();
         init_attr.recv_cq = recv_cq.as_ptr();
-        let ptr = unsafe { crate::ibv_create_qp(pd.as_ptr(), init_attr) };
+        let ptr = unsafe { crate::ruapc_ibv_create_qp(pd.as_ptr(), init_attr) };
         if ptr.is_null() {
             return Err(ErrorKind::IBCreateQueuePairFail.with_errno());
         }
@@ -483,7 +483,7 @@ impl QueuePair {
     }
 
     pub fn modify(&self, attr: &mut crate::ibv_qp_attr, attr_mask: c_int) -> Result<()> {
-        let ret = unsafe { crate::ibv_modify_qp(self.ptr, attr, attr_mask) };
+        let ret = unsafe { crate::ruapc_ibv_modify_qp(self.ptr, attr, attr_mask) };
         if ret != 0 {
             return Err(ErrorKind::IBModifyQueuePairFail.with_errno());
         }
@@ -628,9 +628,7 @@ impl QueuePair {
         wr: *mut crate::ibv_send_wr,
     ) -> std::result::Result<(), (*mut crate::ibv_send_wr, Error)> {
         let mut bad_wr: *mut crate::ibv_send_wr = ptr::null_mut();
-        let ret = unsafe {
-            (*(*self.ptr).context).ops.post_send.unwrap_unchecked()(self.ptr, wr, &mut bad_wr)
-        };
+        let ret = unsafe { crate::ruapc_ibv_post_send(self.ptr, wr, &mut bad_wr) };
         if ret != 0 {
             return Err((bad_wr, ErrorKind::IBPostSendFail.with_errno()));
         }
@@ -642,9 +640,7 @@ impl QueuePair {
         wr: *mut crate::ibv_recv_wr,
     ) -> std::result::Result<(), (*mut crate::ibv_recv_wr, Error)> {
         let mut bad_wr: *mut crate::ibv_recv_wr = ptr::null_mut();
-        let ret = unsafe {
-            (*(*self.ptr).context).ops.post_recv.unwrap_unchecked()(self.ptr, wr, &mut bad_wr)
-        };
+        let ret = unsafe { crate::ruapc_ibv_post_recv(self.ptr, wr, &mut bad_wr) };
         if ret != 0 {
             return Err((bad_wr, ErrorKind::IBPostRecvFail.with_errno()));
         }
@@ -654,7 +650,7 @@ impl QueuePair {
 
 impl Drop for QueuePair {
     fn drop(&mut self) {
-        let _ = unsafe { crate::ibv_destroy_qp(self.ptr) };
+        let _ = unsafe { crate::ruapc_ibv_destroy_qp(self.ptr) };
     }
 }
 impl std::fmt::Debug for QueuePair {


### PR DESCRIPTION
bindgen cannot bind static inline functions or function-like macros from <infiniband/verbs.h>. Previously we worked around this in two fragile ways:

- post_send/post_recv/poll_cq/req_notify_cq were reimplemented in Rust by dispatching through the ibv_context ops table, duplicating header-private inline logic that may differ across rdma-core versions and platforms.
- ibv_query_port and ibv_reg_mr silently bound the legacy exported compat symbols, bypassing the header's macro layer. For query_port this was a real bug: the legacy symbol only fills the compat-sized struct prefix, leaving new ibv_port_attr fields (flags, port_cap_flags2) as uninitialized memory behind MaybeUninit::assume_init. For reg_mr it ruled out optional access flags (IBV_ACCESS_OPTIONAL_RANGE / ODP).

Both patterns share one root cause: rdma-core's standard ABI-evolution technique keeps the old exported symbol for already-compiled binaries and redirects newly compiled code to new semantics via a macro or inline wrapper (query_port and reg_mr both started as plain functions). Any ibv_* symbol bound directly is thus a latent hazard: a future release can macro-wrap it and we would silently keep frozen legacy semantics.

Add src/shim.{h,c}, compiled by cc against the locally installed header, wrapping all 25 verbs entry points used by this crate, and drop every direct ibv_* function binding from the bindgen allowlist. The invariant: Rust never binds ibv_* symbols directly; every call gets "freshly compiled against the installed header" semantics on any platform and any rdma-core version. The C compiler type-checks each wrapper body against the real header prototypes.

Overhead is one direct call per invocation, unmeasurable in practice: an empty poll_cq microbenchmark on mlx5 shows 9.79 ns/op both via the shim and via the direct ops-table call (<0.1% delta, within noise).