### PR TITLE
chore: inline serde defaults and a leaner remote read/write README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A high-performance Rust RPC library that supports multiple transport protocols (
 
 - **Multiple Transport Protocols**: TCP, WebSocket, HTTP/1.1 and HTTP/2 (h2c), RDMA (optional), and a unified protocol that supports all simultaneously
 - **Reverse RPC**: Server can call back into client services over established HTTP/2 or WebSocket connections
-- **Remote Read/Write**: Server-side access to client memory via registered buffer pool ([ruapc-bufpool](ruapc-bufpool/)). Multiple buffers form one *logical contiguous space* on each side: clients attach a read space (`with_read_buffers`) and/or a pinned write space (`with_write_buffers`); servers issue vectored `CopyOp` batches through `ctx.remote_read` / `ctx.remote_write` (fragmented into concurrent one-sided RDMA READs with scatter-gather lists, or reverse-RPC copies over TCP). `ctx.remote_write` returns a `SentBuffers` witness, then `sent.reply(rsp)` builds the `WithBuffers<T>` return value carrying every client buffer back — the transfer is observable (measurable latency, retryable errors) and buffer lifetime is anchored by client-side pinning, request-liveness (msgid) validation, and a software RDMA READ timeout (default 10s) that flushes stuck NICs without ever recycling in-flight memory
+- **Remote Read/Write**: Bulk data moves out-of-band through registered buffers ([ruapc-bufpool](ruapc-bufpool/)) instead of inline RPC payloads — one-sided RDMA READs on RDMA, transparent reverse-RPC copies on TCP/WS/HTTP. Clients attach buffers as logical contiguous spaces; servers transfer whole spaces or vectored `CopyOp` batches with offsets. The typed `Result<WithBuffers<T>, E>` contract and client-side buffer pinning make transfers impossible to forget and memory-safe even across timeouts
 - **Multiple Serialization Formats**: JSON (default) and MessagePack support
 - **OpenAPI Integration**: Automatic OpenAPI 3.0 specification generation with JSON Schema support
 - **Built-in Documentation**: RapiDoc integration for interactive API documentation
@@ -148,10 +148,49 @@ open http://0.0.0.0:8000/rapidoc
 
 ### Remote Read/Write
 
+Bulk data travels out-of-band through registered buffers, in both
+directions and over any transport. The client attaches buffers to a call;
+the server reads or writes them by offset:
+
+```rust
+use ruapc::*;
+
+#[ruapc::service]
+trait BlobService {
+    /// Reads the client's buffers, writes the result back into the
+    /// client's pre-pinned buffers, and replies with the byte count.
+    async fn transform(&self, ctx: &Context, req: &()) -> Result<WithBuffers<u64>>;
+}
+
+// ---- Server handler -----------------------------------------------------
+impl BlobService for BlobImpl {
+    async fn transform(&self, ctx: &Context, _req: &()) -> Result<WithBuffers<u64>> {
+        // Pull the client's read space (RDMA READ, or reverse-RPC on TCP).
+        let data = ctx.remote_read_all().await?;
+        let out = process(data, &ctx.state.buffer_pool);
+
+        // Write into the client's pinned buffers; vectored ops with
+        // explicit offsets are available via ctx.remote_write(&ops, bufs).
+        let total: u64 = out.iter().map(|b| b.len() as u64).sum();
+        let sent = ctx.remote_write_all(out).await?;
+        Ok(sent.reply(total)) // response is built *after* the transfer
+    }
+}
+
+// ---- Client --------------------------------------------------------------
+let src = [buf_a, buf_b];              // read space: borrowed for the call
+let dst = vec![out_buf];               // write space: pinned until it resolves
+let (total, buffers) = client
+    .with_read_buffers(&src)
+    .with_write_buffers(dst)
+    .transform(&ctx, &())
+    .await?
+    .into_parts();                     // every attached write buffer returns
+```
+
+Run the self-contained demo over any transport:
+
 ```bash
-# Self-contained demo: client uploads registered buffers (server pulls them
-# via remote_read_all) and downloads into pre-pinned buffers (typed
-# Result<WithBuffers<T>> contract). Works over any transport.
 cargo run --bin remote_memory -- --socket-type tcp
 cargo run --bin remote_memory --features rdma -- --socket-type rdma
 ```

--- a/ruapc/src/rdma/endpoint.rs
+++ b/ruapc/src/rdma/endpoint.rs
@@ -1,12 +1,14 @@
 use ruapc_rdma::{LinkLayer, ibv_gid, ibv_mtu};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_inline_default::serde_inline_default;
 
 use crate::RdmaQueuePairConfig;
 
 /// RDMA connection endpoint information.
 ///
 /// Contains the QP and address metadata needed to move a queue pair to RTR/RTS.
+#[serde_inline_default]
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy)]
 pub struct Endpoint {
     /// Queue pair number.
@@ -34,14 +36,10 @@ pub struct Endpoint {
     /// sides can program `max_rd_atomic` / `max_dest_rd_atomic` as the
     /// minimum of the two caps (they compute identical values, which the
     /// RC protocol requires). Higher values let batched `remote_read`
-    /// work requests proceed in parallel inside the NIC.
-    #[serde(default = "default_rd_atomic")]
+    /// work requests proceed in parallel inside the NIC. Peers that do
+    /// not advertise a cap default to the conservative 1.
+    #[serde_inline_default(1u8)]
     pub rd_atomic_cap: u8,
-}
-
-/// Conservative fallback used when a peer does not advertise a cap.
-pub(crate) fn default_rd_atomic() -> u8 {
-    1
 }
 
 /// Server-side RDMA device/port/GID selected by the client.

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -87,11 +87,14 @@ pub struct SocketPoolConfig {
 
 /// RDMA socket pool configuration.
 #[cfg(feature = "rdma")]
+#[serde_inline_default]
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct RdmaSocketPoolConfig {
     /// Requested Queue Pair capabilities for newly created RDMA connections.
+    #[serde(default)]
     pub qp: RdmaQueuePairConfig,
     /// Completion Queue length requested for each RDMA connection.
+    #[serde_inline_default(128u32)]
     pub cq_len: u32,
     /// Number of receive buffers to pre-post for each RDMA connection
     /// (negotiated to the minimum of both sides). The send window is half
@@ -105,32 +108,34 @@ pub struct RdmaSocketPoolConfig {
     /// beyond `recv_queue_len / 2` in-flight sends). Raise it for
     /// pipelines of large unaggregatable messages (up to `max_msg_size`
     /// each), where more in-flight WRs are needed to fill the wire.
+    #[serde_inline_default(8u32)]
     pub recv_queue_len: u32,
     /// P_Key table index used when moving the Queue Pair to INIT.
+    #[serde_inline_default(0u16)]
     pub pkey_index: u16,
     /// Selective signaling interval for data sends (local behavior, not
     /// negotiated). With interval `N > 1` only every Nth data send requests
     /// a completion; buffers of unsignaled sends are reclaimed when a later
     /// signaled completion arrives (RC SQs complete in order). `1` signals
     /// every send. Clamped to `max_send_wr / 2`.
-    #[serde(default = "default_send_signal_interval")]
+    #[serde_inline_default(8u32)]
     pub send_signal_interval: u32,
     /// Capacity (entries) of the per-device shared completion queue used by
     /// the dedicated poll thread. Bounds the number of concurrent
     /// connections per device: the sum of every connection's queue depths
     /// must fit.
-    #[serde(default = "default_device_cq_len")]
+    #[serde_inline_default(65536u32)]
     pub device_cq_len: u32,
     /// Busy-poll window of the per-device poll thread, in microseconds:
     /// after the last completion the thread keeps polling for this long
     /// before arming the CQ interrupt and sleeping. `0` disables spinning
     /// (pure event-driven mode).
-    #[serde(default = "default_poll_spin_us")]
+    #[serde_inline_default(50u64)]
     pub poll_spin_us: u64,
     /// Maximum serialized message size for RDMA sends; also the size of
     /// each pre-posted receive buffer (negotiated to the minimum of both
     /// sides). Larger payloads must use the remote read/write paths.
-    #[serde(default = "default_max_msg_size")]
+    #[serde_inline_default(256 * 1024u32)]
     pub max_msg_size: u32,
     /// Whether to aggregate sends: under backlog, multiple small
     /// window-blocked sends are packed into a single RDMA send, which
@@ -138,13 +143,13 @@ pub struct RdmaSocketPoolConfig {
     /// on the peer. Send-side toggle only; every RDMA send is a sequence
     /// of length-prefixed frames, so receivers walk the same parse loop
     /// either way.
-    #[serde(default = "default_msg_aggregation")]
+    #[serde_inline_default(true)]
     pub msg_aggregation: bool,
     /// Number of (shared CQ + poll thread) shards per RDMA device.
     /// Connections are assigned round-robin, spreading completion
     /// processing across cores. Each shard burns up to one core while
     /// spinning.
-    #[serde(default = "default_poll_threads_per_device")]
+    #[serde_inline_default(1u32)]
     pub poll_threads_per_device: u32,
     /// Number of long-lived dispatch worker tasks shared by all RDMA poll
     /// threads of this pool, each owning one SPSC queue. Received buffers
@@ -154,13 +159,13 @@ pub struct RdmaSocketPoolConfig {
     /// each to the router (requests) or waiter (responses). When every
     /// worker is saturated the poll thread falls back to spawning a
     /// one-shot task per batch, so it never blocks.
-    #[serde(default = "default_dispatch_workers")]
+    #[serde_inline_default(32u32)]
     pub dispatch_workers: u32,
     /// Number of RDMA connections (QPs) to establish per peer. Requests
     /// are striped round-robin across them; combined with poll thread
     /// shards this scales single-peer throughput across cores. RPC
     /// messages carry no cross-message ordering guarantees.
-    #[serde(default = "default_connections_per_peer")]
+    #[serde_inline_default(1u32)]
     pub connections_per_peer: u32,
     /// If non-empty, only RDMA devices whose name is listed are used.
     /// Useful when a host has NICs without connectivity to the target
@@ -177,16 +182,16 @@ pub struct RdmaSocketPoolConfig {
     /// and migrates at most one connection per tick towards less loaded
     /// NIC pairs (make-before-break). The interval is jittered by ±50%
     /// per process. `0` disables maintenance entirely.
-    #[serde(default = "default_maintenance_interval_ms")]
+    #[serde_inline_default(5000u64)]
     pub maintenance_interval_ms: u64,
     /// Minimum connection-count improvement required before a connection
     /// is migrated to another NIC pair; provides hysteresis on top of the
     /// self-excluding score model. Values below 1 are treated as 1.
-    #[serde(default = "default_rebalance_threshold")]
+    #[serde_inline_default(2u32)]
     pub rebalance_threshold: u32,
     /// Grace period (milliseconds) a migrated-away connection stays alive
     /// after leaving the rotation, so its in-flight responses can arrive.
-    #[serde(default = "default_drain_timeout_ms")]
+    #[serde_inline_default(10_000u64)]
     pub drain_timeout_ms: u64,
     /// Software timeout (milliseconds) for RDMA READ completions,
     /// enforced by the poll thread's periodic sweep (no per-operation
@@ -194,7 +199,7 @@ pub struct RdmaSocketPoolConfig {
     /// connection to the error state, so the NIC flushes the outstanding
     /// work requests and their buffers are reclaimed safely. `0`
     /// disables the timeout. Default is 10s.
-    #[serde(default = "default_read_timeout_ms")]
+    #[serde_inline_default(10_000u64)]
     pub read_timeout_ms: u64,
     /// Maximum in-flight RDMA READ work requests per *local NIC*
     /// (device), shared by every connection on it — the primary
@@ -207,99 +212,16 @@ pub struct RdmaSocketPoolConfig {
     /// `qp.max_send_wr / 2` (not configurable): the send queue is shared
     /// with regular sends, and a device-wide budget landing on a single
     /// QP must not overflow it.
-    #[serde(default = "default_max_inflight_read_wrs")]
+    #[serde_inline_default(32u32)]
     pub max_inflight_read_wrs: u32,
-}
-
-#[cfg(feature = "rdma")]
-fn default_send_signal_interval() -> u32 {
-    8
-}
-
-#[cfg(feature = "rdma")]
-fn default_device_cq_len() -> u32 {
-    65536
-}
-
-#[cfg(feature = "rdma")]
-fn default_poll_spin_us() -> u64 {
-    50
-}
-
-#[cfg(feature = "rdma")]
-fn default_max_msg_size() -> u32 {
-    256 * 1024
-}
-
-#[cfg(feature = "rdma")]
-fn default_msg_aggregation() -> bool {
-    true
-}
-
-#[cfg(feature = "rdma")]
-fn default_poll_threads_per_device() -> u32 {
-    1
-}
-
-#[cfg(feature = "rdma")]
-fn default_dispatch_workers() -> u32 {
-    32
-}
-
-#[cfg(feature = "rdma")]
-fn default_connections_per_peer() -> u32 {
-    1
-}
-
-#[cfg(feature = "rdma")]
-fn default_maintenance_interval_ms() -> u64 {
-    5000
-}
-
-#[cfg(feature = "rdma")]
-fn default_rebalance_threshold() -> u32 {
-    2
-}
-
-#[cfg(feature = "rdma")]
-fn default_drain_timeout_ms() -> u64 {
-    10_000
-}
-
-#[cfg(feature = "rdma")]
-fn default_read_timeout_ms() -> u64 {
-    10_000
-}
-
-#[cfg(feature = "rdma")]
-fn default_max_inflight_read_wrs() -> u32 {
-    32
 }
 
 #[cfg(feature = "rdma")]
 impl Default for RdmaSocketPoolConfig {
     fn default() -> Self {
-        Self {
-            qp: RdmaQueuePairConfig::default(),
-            cq_len: 128,
-            recv_queue_len: 8,
-            pkey_index: 0,
-            send_signal_interval: default_send_signal_interval(),
-            device_cq_len: default_device_cq_len(),
-            poll_spin_us: default_poll_spin_us(),
-            max_msg_size: default_max_msg_size(),
-            msg_aggregation: default_msg_aggregation(),
-            poll_threads_per_device: default_poll_threads_per_device(),
-            dispatch_workers: default_dispatch_workers(),
-            connections_per_peer: default_connections_per_peer(),
-            device_filter: Vec::new(),
-            remote_device_filter: Vec::new(),
-            maintenance_interval_ms: default_maintenance_interval_ms(),
-            rebalance_threshold: default_rebalance_threshold(),
-            drain_timeout_ms: default_drain_timeout_ms(),
-            read_timeout_ms: default_read_timeout_ms(),
-            max_inflight_read_wrs: default_max_inflight_read_wrs(),
-        }
+        // Every field carries an inline serde default, so the canonical
+        // default is "deserialize an empty object" — one source of truth.
+        serde_json::from_value(serde_json::Value::Object(serde_json::Map::default())).unwrap()
     }
 }
 
@@ -604,6 +526,27 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let recovered: SocketPoolConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(recovered, config);
+    }
+
+    /// Every RDMA config field carries an inline serde default, so a
+    /// partial `rdma` object deserializes with the remaining fields at
+    /// their documented defaults (also the source of `Default`).
+    #[cfg(feature = "rdma")]
+    #[test]
+    fn test_rdma_config_partial_object_fills_defaults() {
+        let config: SocketPoolConfig =
+            serde_json::from_str(r#"{"socket_type":"RDMA","rdma":{"recv_queue_len":16}}"#).unwrap();
+        assert_eq!(config.rdma.recv_queue_len, 16);
+        assert_eq!(config.rdma.qp, RdmaQueuePairConfig::default());
+        assert_eq!(config.rdma.cq_len, 128);
+        assert_eq!(config.rdma.pkey_index, 0);
+        assert_eq!(config.rdma.max_msg_size, 256 * 1024);
+        assert_eq!(config.rdma.dispatch_workers, 32);
+        assert_eq!(config.rdma.read_timeout_ms, 10_000);
+        assert_eq!(config.rdma.max_inflight_read_wrs, 32);
+        // `Default` is exactly the all-defaults deserialization.
+        let default: RdmaSocketPoolConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(default, RdmaSocketPoolConfig::default());
     }
 
     #[test]


### PR DESCRIPTION
- Replace every #[serde(default = "fn")] with #[serde_inline_default] (RdmaSocketPoolConfig, Endpoint.rd_atomic_cap), dropping the boilerplate default fns. All RDMA config fields now carry inline defaults, so a partial `rdma` object deserializes cleanly and `Default` is simply the all-defaults deserialization (one source of truth, regression-tested).
- Condense the README remote read/write feature bullet to the essentials and add a code walkthrough: attaching read/write buffer spaces on the client, remote_read_all / remote_write_all + SentBuffers::reply on the server, and the WithBuffers return path.