### PR TITLE
feat(rdma): client-chosen GRH traffic class for RDMA connections

### DIFF
--- a/ruapc-demo/src/bin/client.rs
+++ b/ruapc-demo/src/bin/client.rs
@@ -86,6 +86,11 @@ pub struct Args {
     /// aggregation under load; raise for large-message pipelines.
     #[arg(long, default_value = "8")]
     pub recv_queue_len: u32,
+
+    /// RDMA: GRH traffic class (RoCE DSCP/ECN byte) for the connections
+    /// this client creates; the server applies the same value on its side.
+    #[arg(long, default_value = "0")]
+    pub traffic_class: u8,
 }
 
 fn socket_pool_config(args: &Args) -> SocketPoolConfig {
@@ -103,6 +108,7 @@ fn socket_pool_config(args: &Args) -> SocketPoolConfig {
         config.rdma.poll_spin_us = args.poll_spin_us;
         config.rdma.dispatch_workers = args.dispatch_workers;
         config.rdma.recv_queue_len = args.recv_queue_len;
+        config.rdma.traffic_class = args.traffic_class;
     }
     config
 }

--- a/ruapc-rdma/src/verbs/queue_pair.rs
+++ b/ruapc-rdma/src/verbs/queue_pair.rs
@@ -561,6 +561,7 @@ impl QueuePair {
         path_mtu: ibv_mtu,
         rq_psn: u32,
         max_dest_rd_atomic: u8,
+        traffic_class: u8,
     ) -> Result<()> {
         let mut ah_attr = crate::ibv_ah_attr {
             sl: 0,
@@ -581,7 +582,7 @@ impl QueuePair {
                     flow_label: 0,
                     sgid_index: local_gid_index,
                     hop_limit: 0xff,
-                    traffic_class: 0,
+                    traffic_class,
                 };
                 ah_attr.is_global = 1;
             }
@@ -656,6 +657,7 @@ impl QueuePair {
         remote_psn: u32,
         max_rd_atomic: u8,
         max_dest_rd_atomic: u8,
+        traffic_class: u8,
     ) -> Result<()> {
         self.init(local_port_num, pkey_index)?;
         self.ready_to_recv(
@@ -668,6 +670,7 @@ impl QueuePair {
             path_mtu,
             remote_psn,
             max_dest_rd_atomic,
+            traffic_class,
         )?;
         self.ready_to_send(local_psn, max_rd_atomic)
     }

--- a/ruapc/src/rdma/endpoint.rs
+++ b/ruapc/src/rdma/endpoint.rs
@@ -66,6 +66,12 @@ pub struct RdmaConnectionConfig {
     /// receive buffers are sized accordingly. Negotiated as the minimum of
     /// both sides.
     pub max_msg_size: u32,
+    /// GRH traffic class (RoCE: DSCP/ECN byte) programmed into both sides'
+    /// address handles. Chosen by the connecting client; the server applies
+    /// the client's value verbatim. Peers that do not send it use 0.
+    /// Ignored on InfiniBand link layers (no GRH).
+    #[serde(default)]
+    pub traffic_class: u8,
 }
 
 /// RDMA connection request sent after the client has selected a server port.

--- a/ruapc/src/rdma/rdma_service.rs
+++ b/ruapc/src/rdma/rdma_service.rs
@@ -93,6 +93,9 @@ impl RdmaInfo {
                             cq_len: config.cq_len.min(info.device_attr.max_cqe as u32),
                             recv_queue_len: config.recv_queue_len,
                             max_msg_size: config.max_msg_size.max(16 * 1024),
+                            // Advisory only: connecting clients dictate the
+                            // traffic class of the connections they create.
+                            traffic_class: config.traffic_class,
                         },
                         ports: info
                             .ports
@@ -195,6 +198,7 @@ mod tests {
                 cq_len: 128,
                 recv_queue_len: 64,
                 max_msg_size: 1024 * 1024,
+                traffic_class: 0,
             },
         };
         let result = ().connect(&ctx, &request).await;

--- a/ruapc/src/rdma/rdma_socket_pool.rs
+++ b/ruapc/src/rdma/rdma_socket_pool.rs
@@ -197,6 +197,7 @@ impl SocketPoolTrait for RdmaSocketPool {
             &local_endpoint,
             &request.endpoint,
             self.config.pkey_index,
+            connection_config.traffic_class,
         )?;
 
         let info = device.info();
@@ -801,6 +802,7 @@ impl RdmaSocketPool {
             &local_endpoint,
             &remote_endpoint,
             self.config.pkey_index,
+            connection_config.traffic_class,
         ) {
             // QP setup failures are typically path problems (no route
             // between the selected NIC pair): penalize the pair so
@@ -1149,6 +1151,9 @@ impl RdmaSocketPool {
             cq_len: local.cq_len.min(remote.cq_len),
             recv_queue_len: local.recv_queue_len.min(remote.recv_queue_len),
             max_msg_size: local.max_msg_size.min(remote.max_msg_size),
+            // The connecting side dictates the traffic class; the remote
+            // advertisement is irrelevant here.
+            traffic_class: self.config.traffic_class,
         }
     }
 
@@ -1171,6 +1176,9 @@ impl RdmaSocketPool {
             cq_len: requested.cq_len.min(local.cq_len),
             recv_queue_len: requested.recv_queue_len.min(local.recv_queue_len),
             max_msg_size: requested.max_msg_size.min(local.max_msg_size),
+            // Client-chosen: applied verbatim so both directions of the
+            // connection share one traffic class.
+            traffic_class: requested.traffic_class,
         }
     }
 
@@ -1204,6 +1212,7 @@ impl RdmaSocketPool {
             // Enforce a small floor so a tiny misconfiguration cannot break
             // the RPC control plane.
             max_msg_size: self.config.max_msg_size.max(16 * 1024),
+            traffic_class: self.config.traffic_class,
         }
     }
 
@@ -1297,6 +1306,7 @@ impl RdmaSocketPool {
         local: &Endpoint,
         remote: &Endpoint,
         pkey_index: u16,
+        traffic_class: u8,
     ) -> Result<()> {
         if local.link_layer != remote.link_layer {
             return Err(Error::new(
@@ -1329,6 +1339,7 @@ impl RdmaSocketPool {
             remote.psn,
             rd_atomic,
             rd_atomic,
+            traffic_class,
         )
         .map_err(|e| Error::new(ErrorKind::RdmaSendFailed, e.to_string()))
     }
@@ -1807,6 +1818,7 @@ mod path_selection_tests {
             cq_len: 128,
             recv_queue_len: 8,
             max_msg_size: 64 * 1024,
+            traffic_class: 0,
         }
     }
 
@@ -1886,6 +1898,54 @@ mod path_selection_tests {
             .select_candidate(&addr(), &candidates, Some(&missing), &info, &[])
             .unwrap_err();
         assert_eq!(err.kind, ErrorKind::InvalidArgument);
+    }
+
+    /// The connecting client dictates the traffic class (its own config,
+    /// not min'd with the remote advertisement); the accepting server
+    /// applies the client's requested value verbatim.
+    #[tokio::test]
+    async fn test_traffic_class_client_decides_server_obeys() {
+        let devices = crate::rdma::test_utils::make_rdma_devices();
+        let buffer_pool = ruapc_bufpool::BufferPoolBuilder::new(devices.clone()).build();
+        let config = RdmaSocketPoolConfig {
+            traffic_class: 96,
+            ..Default::default()
+        };
+        let pool = RdmaSocketPool::new(devices, buffer_pool, config).unwrap();
+        let rdma_devices = pool.devices.rdma_devices();
+        let device = &rdma_devices[0];
+
+        // Client path: local config wins over the remote advertisement.
+        let mut advertised = connection_limits();
+        advertised.traffic_class = 7;
+        let negotiated = pool.negotiate_connection_config(device, &advertised);
+        assert_eq!(negotiated.traffic_class, 96);
+
+        // Server path: the requested (client-chosen) value passes through.
+        let mut requested = connection_limits();
+        requested.traffic_class = 42;
+        let clamped = pool.clamp_connection_config(device, requested);
+        assert_eq!(clamped.traffic_class, 42);
+    }
+
+    /// Old peers omit `traffic_class` from the handshake payload; it must
+    /// deserialize to 0.
+    #[test]
+    fn test_connection_config_traffic_class_serde_default() {
+        let encoded = rmp_serde::to_vec_named(&serde_json::json!({
+            "qp": {
+                "max_send_wr": 64,
+                "max_recv_wr": 64,
+                "max_send_sge": 16,
+                "max_recv_sge": 1,
+            },
+            "cq_len": 128,
+            "recv_queue_len": 8,
+            "max_msg_size": 65536,
+        }))
+        .unwrap();
+        let config: RdmaConnectionConfig = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(config.traffic_class, 0);
     }
 
     #[tokio::test]

--- a/ruapc/src/sockets/socket_pool.rs
+++ b/ruapc/src/sockets/socket_pool.rs
@@ -214,6 +214,15 @@ pub struct RdmaSocketPoolConfig {
     /// QP must not overflow it.
     #[serde_inline_default(32u32)]
     pub max_inflight_read_wrs: u32,
+    /// GRH traffic class (RoCE: the DSCP/ECN byte of outgoing RDMA
+    /// packets) for connections *initiated by this pool*. The client
+    /// decides: the value travels in the connect request and the server
+    /// programs the same value into its own address handle, so both
+    /// directions of a connection share one traffic class. Inbound
+    /// connections ignore the local setting. No effect on InfiniBand
+    /// link layers (no GRH). Default is 0.
+    #[serde_inline_default(0u8)]
+    pub traffic_class: u8,
 }
 
 #[cfg(feature = "rdma")]
@@ -544,6 +553,7 @@ mod tests {
         assert_eq!(config.rdma.dispatch_workers, 32);
         assert_eq!(config.rdma.read_timeout_ms, 10_000);
         assert_eq!(config.rdma.max_inflight_read_wrs, 32);
+        assert_eq!(config.rdma.traffic_class, 0);
         // `Default` is exactly the all-defaults deserialization.
         let default: RdmaSocketPoolConfig = serde_json::from_str("{}").unwrap();
         assert_eq!(default, RdmaSocketPoolConfig::default());
@@ -686,6 +696,7 @@ mod tests {
                 cq_len: 128,
                 recv_queue_len: 64,
                 max_msg_size: 1024 * 1024,
+                traffic_class: 0,
             },
         };
         assert!(pool.rdma_accept(&request, &state).is_err());

--- a/ruapc/src/sockets/unified/unified_socket_pool.rs
+++ b/ruapc/src/sockets/unified/unified_socket_pool.rs
@@ -221,6 +221,7 @@ mod tests {
                 cq_len: 128,
                 recv_queue_len: 64,
                 max_msg_size: 1024 * 1024,
+                traffic_class: 0,
             },
         };
         assert!(pool.rdma_accept(&request, &state).is_err());


### PR DESCRIPTION
Add rdma.traffic_class to RdmaSocketPoolConfig (default 0). The connecting client dictates the value: it travels in the connect request's RdmaConnectionConfig (#[serde(default)] for compatible evolution) and the accepting server applies it verbatim, so both directions of a connection program the same DSCP/ECN byte into their address handles. Only the RoCE (Ethernet) branch consumes it; IB link layers carry no GRH. The demo client gains --traffic-class.