### PR TITLE
chore(release): prepare v0.2.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4] - 2026-08-20
+
 ### Changed
 - **BREAKING**: RDMA subnet matching is now client-only. `rdma.subnets` is a
   plain CIDR list and `rdma.subnet_policy` prefers or requires paths whose two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ruapc", "ruapc-bufpool", "ruapc-demo", "ruapc-macro", "ruapc-rdma"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 authors = ["SF-Zhou <sfzhou.scut@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/SF-Zhou/ruapc"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RDMA support is **not** enabled by default (it requires `libibverbs-dev` at buil
 
 ```toml
 [dependencies]
-ruapc = { version = "0.2.0-alpha.3", features = ["rdma"] }
+ruapc = { version = "0.2.0-alpha.4", features = ["rdma"] }
 ```
 
 ## Example

--- a/ruapc-rdma/Cargo.toml
+++ b/ruapc-rdma/Cargo.toml
@@ -18,7 +18,7 @@ bin = ["dep:clap"]
 clap = { workspace = true, optional = true }
 enumflags2 = { version = "0.7", features = ["serde"] }
 libc.workspace = true
-ruapc-bufpool = { version = "0.2.0-alpha.3", path = "../ruapc-bufpool" }
+ruapc-bufpool = { version = "0.2.0-alpha.4", path = "../ruapc-bufpool" }
 schemars.workspace = true
 serde.workspace = true
 strum = { version = "0.28", features = ["derive"] }

--- a/ruapc/Cargo.toml
+++ b/ruapc/Cargo.toml
@@ -15,9 +15,9 @@ default = []
 [dependencies]
 # The macro generates code against ruapc's internal glue API, so the two
 # crates must be paired exactly (same reason serde pins serde_derive).
-ruapc-macro = { version = "=0.2.0-alpha.3", path = "../ruapc-macro" }
-ruapc-bufpool = { version = "0.2.0-alpha.3", path = "../ruapc-bufpool" }
-ruapc-rdma = { version = "0.2.0-alpha.3", path = "../ruapc-rdma", optional = true }
+ruapc-macro = { version = "=0.2.0-alpha.4", path = "../ruapc-macro" }
+ruapc-bufpool = { version = "0.2.0-alpha.4", path = "../ruapc-bufpool" }
+ruapc-rdma = { version = "0.2.0-alpha.4", path = "../ruapc-rdma", optional = true }
 
 arc-swap.workspace = true
 bitflags.workspace = true


### PR DESCRIPTION
## Summary
- bump workspace and internal crate dependencies to 0.2.0-alpha.4
- archive the client-only RDMA subnet matching change in the changelog
- update the README dependency example

## Validation
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-features -- -D warnings